### PR TITLE
feat: add resource_requests for Burstable QoS support（When creating a sandbox, support creating according to the strategy of low request and high limit）

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
@@ -148,6 +148,7 @@ class SandboxModelConverter:
         network_policy: NetworkPolicy | None,
         extensions: dict[str, str],
         volumes: list[Volume] | None,
+        resource_requests: dict[str, str] | None = None,
     ) -> CreateSandboxRequest:
         """Convert domain parameters to API CreateSandboxRequest."""
         from opensandbox.api.lifecycle.models.create_sandbox_request import (
@@ -243,6 +244,11 @@ class SandboxModelConverter:
                 SandboxModelConverter.to_api_volume(v) for v in volumes
             ]
 
+        # Convert resource requests dict to API model
+        api_resource_requests = UNSET
+        if resource_requests is not None:
+            api_resource_requests = ResourceLimits.from_dict(resource_requests)
+
         request = CreateSandboxRequest(
             image=SandboxModelConverter.to_api_image_spec(spec),
             entrypoint=entrypoint,
@@ -253,6 +259,7 @@ class SandboxModelConverter:
             network_policy=api_network_policy,
             extensions=api_extensions,
             volumes=api_volumes,
+            resource_requests=api_resource_requests,
         )
         if timeout is not None:
             request.timeout = int(timeout.total_seconds())

--- a/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
@@ -121,6 +121,7 @@ class SandboxesAdapter(Sandboxes):
         extensions: dict[str, str],
         volumes: list[Volume] | None,
         platform: PlatformSpec | None = None,
+        resource_requests: dict[str, str] | None = None,
     ) -> SandboxCreateResponse:
         """Create a new sandbox instance with the specified configuration."""
         logger.info(f"Creating sandbox with image: {spec.image}")
@@ -139,6 +140,7 @@ class SandboxesAdapter(Sandboxes):
                 network_policy=network_policy,
                 extensions=extensions,
                 volumes=volumes,
+                resource_requests=resource_requests,
             )
 
             client = await self._get_client()

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_request.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_request.py
@@ -57,6 +57,10 @@ class CreateSandboxRequest:
 
                 New resource types can be added without API changes.
                  Example: {'cpu': '500m', 'memory': '512Mi', 'gpu': '1'}.
+            resource_requests (ResourceLimits | Unset): Optional resource requests for the sandbox instance
+                (guaranteed resources).
+                If omitted, defaults to resourceLimits (Guaranteed QoS).
+                When specified, enables Burstable QoS with requests < limits.
             entrypoint (list[str]): The command to execute as the sandbox's entry process (required).
 
                 Explicitly specifies the user's expected main process, allowing the sandbox management
@@ -126,6 +130,7 @@ class CreateSandboxRequest:
     network_policy: NetworkPolicy | Unset = UNSET
     volumes: list[Volume] | Unset = UNSET
     extensions: CreateSandboxRequestExtensions | Unset = UNSET
+    resource_requests: ResourceLimits | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -168,6 +173,10 @@ class CreateSandboxRequest:
         if not isinstance(self.extensions, Unset):
             extensions = self.extensions.to_dict()
 
+        resource_requests: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.resource_requests, Unset):
+            resource_requests = self.resource_requests.to_dict()
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -191,6 +200,8 @@ class CreateSandboxRequest:
             field_dict["volumes"] = volumes
         if extensions is not UNSET:
             field_dict["extensions"] = extensions
+        if resource_requests is not UNSET:
+            field_dict["resourceRequests"] = resource_requests
 
         return field_dict
 
@@ -265,6 +276,13 @@ class CreateSandboxRequest:
         else:
             extensions = CreateSandboxRequestExtensions.from_dict(_extensions)
 
+        _resource_requests = d.pop("resourceRequests", UNSET)
+        resource_requests: ResourceLimits | Unset
+        if isinstance(_resource_requests, Unset):
+            resource_requests = UNSET
+        else:
+            resource_requests = ResourceLimits.from_dict(_resource_requests)
+
         create_sandbox_request = cls(
             image=image,
             resource_limits=resource_limits,
@@ -276,6 +294,7 @@ class CreateSandboxRequest:
             network_policy=network_policy,
             volumes=volumes,
             extensions=extensions,
+            resource_requests=resource_requests,
         )
 
         create_sandbox_request.additional_properties = d

--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -400,6 +400,7 @@ class Sandbox:
         env: dict[str, str] | None = None,
         metadata: dict[str, str] | None = None,
         resource: dict[str, str] | None = None,
+        resource_requests: dict[str, str] | None = None,
         platform: PlatformSpec | None = None,
         network_policy: NetworkPolicy | None = None,
         extensions: dict[str, str] | None = None,
@@ -420,6 +421,9 @@ class Sandbox:
             env: Environment variables for the sandbox
             metadata: Custom metadata for the sandbox
             resource: Resource limits (CPU, memory, etc.)
+            resource_requests: Optional resource requests (guaranteed resources).
+                If omitted, defaults to resource (Guaranteed QoS).
+                When specified, enables Burstable QoS with requests < limits.
             network_policy: Optional outbound network policy (egress).
             extensions: Opaque extension parameters passed through to the server as-is.
                 Prefer namespaced keys (e.g. ``storage.id``).
@@ -471,11 +475,14 @@ class Sandbox:
                 volumes,
             )
             if platform is None:
-                response = await sandbox_service.create_sandbox(*create_args)
+                response = await sandbox_service.create_sandbox(
+                    *create_args, resource_requests=resource_requests
+                )
             else:
                 response = await sandbox_service.create_sandbox(
                     *create_args,
                     platform=platform,
+                    resource_requests=resource_requests,
                 )
             sandbox_id = response.id
 

--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -474,16 +474,14 @@ class Sandbox:
                 extensions,
                 volumes,
             )
-            if platform is None:
-                response = await sandbox_service.create_sandbox(
-                    *create_args, resource_requests=resource_requests
-                )
-            else:
-                response = await sandbox_service.create_sandbox(
-                    *create_args,
-                    platform=platform,
-                    resource_requests=resource_requests,
-                )
+            create_kwargs: dict = {}
+            if platform is not None:
+                create_kwargs["platform"] = platform
+            if resource_requests is not None:
+                create_kwargs["resource_requests"] = resource_requests
+            response = await sandbox_service.create_sandbox(
+                *create_args, **create_kwargs
+            )
             sandbox_id = response.id
 
             execd_endpoint = await sandbox_service.get_sandbox_endpoint(

--- a/sdks/sandbox/python/src/opensandbox/services/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/services/sandbox.py
@@ -56,6 +56,7 @@ class Sandboxes(Protocol):
         extensions: dict[str, str],
         volumes: list[Volume] | None,
         platform: PlatformSpec | None = None,
+        resource_requests: dict[str, str] | None = None,
     ) -> SandboxCreateResponse:
         """
         Create a new sandbox with the specified configuration.
@@ -71,6 +72,8 @@ class Sandboxes(Protocol):
             extensions: Opaque extension parameters passed through to the server as-is.
                 Prefer namespaced keys (e.g. ``storage.id``).
             volumes: Optional list of volume mounts for persistent storage.
+            resource_requests: Optional resource requests (guaranteed resources).
+                If omitted, defaults to resource limits (Guaranteed QoS).
 
         Returns:
             Sandbox create response

--- a/sdks/sandbox/python/tests/test_sandbox_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_business_logic.py
@@ -307,6 +307,7 @@ async def test_create_keeps_service_create_signature_backward_compatible(
             network_policy,
             _extensions,
             _volumes,
+            **kwargs,
         ):
             assert isinstance(network_policy, NetworkPolicy)
             return _CreateResponse()

--- a/sdks/sandbox/python/tests/test_sandbox_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_business_logic.py
@@ -307,7 +307,6 @@ async def test_create_keeps_service_create_signature_backward_compatible(
             network_policy,
             _extensions,
             _volumes,
-            **kwargs,
         ):
             assert isinstance(network_policy, NetworkPolicy)
             return _CreateResponse()

--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -353,6 +353,15 @@ class CreateSandboxRequest(BaseModel):
         alias="resourceLimits",
         description="Runtime resource constraints for the sandbox instance",
     )
+    resource_requests: Optional[ResourceLimits] = Field(
+        None,
+        alias="resourceRequests",
+        description=(
+            "Optional resource requests (guaranteed resources). "
+            "Defaults to resourceLimits if omitted (Guaranteed QoS). "
+            "When specified, enables Burstable QoS with requests < limits."
+        ),
+    )
     env: Optional[Dict[str, Optional[str]]] = Field(
         None,
         description="Environment variables to inject into the sandbox runtime",

--- a/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
@@ -141,6 +141,7 @@ class AgentSandboxProvider(WorkloadProvider):
         annotations: Optional[Dict[str, str]] = None,
         egress_auth_token: Optional[str] = None,
         egress_mode: str = EGRESS_MODE_DNS,
+        resource_requests: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Create an agent-sandbox Sandbox CRD workload."""
         if self.runtime_class:
@@ -160,6 +161,7 @@ class AgentSandboxProvider(WorkloadProvider):
             egress_image=egress_image,
             egress_auth_token=egress_auth_token,
             egress_mode=egress_mode,
+            resource_requests=resource_requests,
         )
 
         # Add user-specified volumes if provided
@@ -248,6 +250,7 @@ class AgentSandboxProvider(WorkloadProvider):
         egress_image: Optional[str] = None,
         egress_auth_token: Optional[str] = None,
         egress_mode: str = EGRESS_MODE_DNS,
+        resource_requests: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Build pod spec dict for the Sandbox CRD."""
         disable_ipv6_for_egress = network_policy is not None and egress_image is not None
@@ -261,6 +264,7 @@ class AgentSandboxProvider(WorkloadProvider):
             resource_limits=resource_limits,
             include_execd_volume=True,
             has_network_policy=network_policy is not None,
+            resource_requests=resource_requests,
         )
         
         containers = [self._container_to_dict(main_container)]
@@ -340,15 +344,17 @@ class AgentSandboxProvider(WorkloadProvider):
         resource_limits: Dict[str, str],
         include_execd_volume: bool,
         has_network_policy: bool = False,
+        resource_requests: Optional[Dict[str, str]] = None,
     ) -> V1Container:
         env_vars = [V1EnvVar(name=k, value=v) for k, v in env.items()]
         env_vars.append(V1EnvVar(name="EXECD", value="/opt/opensandbox/bin/execd"))
 
         resources = None
         if resource_limits:
+            requests = resource_requests if resource_requests else resource_limits
             resources = V1ResourceRequirements(
                 limits=resource_limits,
-                requests=resource_limits,
+                requests=requests,
             )
 
         wrapped_command = ["/opt/opensandbox/bin/bootstrap.sh"] + entrypoint

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -120,6 +120,7 @@ class BatchSandboxProvider(WorkloadProvider):
         annotations: Optional[Dict[str, str]] = None,
         egress_auth_token: Optional[str] = None,
         egress_mode: str = EGRESS_MODE_DNS,
+        resource_requests: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """
         Create a BatchSandbox workload.
@@ -203,6 +204,7 @@ class BatchSandboxProvider(WorkloadProvider):
             env=env,
             resource_limits=resource_limits,
             has_network_policy=network_policy is not None,
+            resource_requests=resource_requests,
         )
         
         # Build containers list
@@ -594,20 +596,22 @@ class BatchSandboxProvider(WorkloadProvider):
         env: Dict[str, str],
         resource_limits: Dict[str, str],
         has_network_policy: bool = False,
+        resource_requests: Optional[Dict[str, str]] = None,
     ) -> V1Container:
         """
         Build main container spec with execd support.
-        
+
         The container will use bootstrap script to start execd in background,
         then execute user's command.
-        
+
         Args:
             image_spec: Container image specification
             entrypoint: Container entrypoint command
             env: Environment variables
             resource_limits: Resource limits
             has_network_policy: Whether network policy is enabled for this sandbox
-            
+            resource_requests: Optional resource requests. If None, defaults to resource_limits.
+
         Returns:
             V1Container: Main container spec
         """
@@ -615,13 +619,14 @@ class BatchSandboxProvider(WorkloadProvider):
         env_vars = [V1EnvVar(name=k, value=v) for k, v in env.items()]
         # Add EXECD environment variable to specify execd binary path
         env_vars.append(V1EnvVar(name="EXECD", value="/opt/opensandbox/bin/execd"))
-        
+
         # Build resource requirements
         resources = None
         if resource_limits:
+            requests = resource_requests if resource_requests else resource_limits
             resources = V1ResourceRequirements(
                 limits=resource_limits,
-                requests=resource_limits,  # Set requests = limits for guaranteed QoS
+                requests=requests,
             )
         
         # Wrap entrypoint with bootstrap script to start execd

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -337,6 +337,11 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         resource_limits = {}
         if request.resource_limits and request.resource_limits.root:
             resource_limits = request.resource_limits.root
+
+        # Extract resource requests (optional, defaults to limits for Guaranteed QoS)
+        resource_requests = None
+        if request.resource_requests and request.resource_requests.root:
+            resource_requests = request.resource_requests.root
         
         try:
             egress_mode = (
@@ -379,6 +384,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 egress_mode=egress_mode,
                 volumes=request.volumes,
                 platform=request.platform,
+                resource_requests=resource_requests,
             )
             
             logger.info(

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -366,6 +366,9 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             )
             
             # Create workload
+            create_kwargs: dict = {}
+            if resource_requests is not None:
+                create_kwargs["resource_requests"] = resource_requests
             workload_info = self.workload_provider.create_workload(
                 sandbox_id=sandbox_id,
                 namespace=self.namespace,
@@ -384,7 +387,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 egress_mode=egress_mode,
                 volumes=request.volumes,
                 platform=request.platform,
-                resource_requests=resource_requests,
+                **create_kwargs,
             )
             
             logger.info(

--- a/server/opensandbox_server/services/k8s/workload_provider.py
+++ b/server/opensandbox_server/services/k8s/workload_provider.py
@@ -52,6 +52,7 @@ class WorkloadProvider(ABC):
         annotations: Optional[Dict[str, str]] = None,
         egress_auth_token: Optional[str] = None,
         egress_mode: str = EGRESS_MODE_DNS,
+        resource_requests: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """
         Create a new workload resource.
@@ -73,6 +74,8 @@ class WorkloadProvider(ABC):
             egress_image: Optional egress sidecar image. Required when network_policy is provided.
             egress_mode: Sidecar ``OPENSANDBOX_EGRESS_MODE`` (from app ``[egress].mode`` when using network policy).
             volumes: Optional list of volume mounts for the sandbox.
+            resource_requests: Optional resource requests (guaranteed resources).
+                If None, defaults to resource_limits (Guaranteed QoS).
 
         Returns:
             Dict containing workload metadata (name, uid, etc.)

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -766,6 +766,13 @@ components:
             Runtime resource constraints for the sandbox instance.
             SDK clients should provide sensible defaults (e.g., cpu: "500m", memory: "512Mi").
 
+        resourceRequests:
+          $ref: '#/components/schemas/ResourceLimits'
+          description: |
+            Optional resource requests for the sandbox instance (guaranteed resources).
+            If omitted, defaults to resourceLimits (Guaranteed QoS).
+            When specified, enables Burstable QoS with requests < limits.
+
         env:
           type: object
           additionalProperties:


### PR DESCRIPTION

# Summary
  feat: add resource_requests for Burstable QoS support
  When creating a sandbox, support creating according to the strategy of low request and high limit

# Testing
- [ ] Not run (explain why)
- [ √] Unit tests
- [ ] Integration tests
- [√ ] e2e / manual verification

# Breaking Changes
- [ ] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
