### PR TITLE
fix(ingress): support WebSocket over HTTP/2 (replace gorilla/websocket)

### DIFF
--- a/components/ingress/go.mod
+++ b/components/ingress/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alibaba/OpenSandbox/sandbox-k8s v0.0.0
 	github.com/alibaba/opensandbox/internal v0.0.0
 	github.com/alicebob/miniredis/v2 v2.37.0
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/coder/websocket v1.8.15
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.34.3

--- a/components/ingress/go.sum
+++ b/components/ingress/go.sum
@@ -8,6 +8,8 @@ github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -46,8 +48,6 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/components/ingress/main.go
+++ b/components/ingress/main.go
@@ -92,7 +92,15 @@ func main() {
 	http.Handle("/", reverseProxy)
 	http.HandleFunc("/status.ok", proxy.Healthz)
 
-	if err := http.ListenAndServe(fmt.Sprintf(":%v", flag.Port), nil); err != nil {
+	protos := new(http.Protocols)
+	protos.SetHTTP1(true)
+	protos.SetUnencryptedHTTP2(true)
+	srv := &http.Server{
+		Addr:      fmt.Sprintf(":%v", flag.Port),
+		Protocols: protos,
+	}
+
+	if err := srv.ListenAndServe(); err != nil {
 		log.Panicf("Error starting http server: %v", err)
 	}
 

--- a/components/ingress/pkg/proxy/proxy.go
+++ b/components/ingress/pkg/proxy/proxy.go
@@ -128,16 +128,31 @@ func (p *Proxy) serve(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Proxy) isWebSocketRequest(r *http.Request) bool {
+	// HTTP/2 Extended CONNECT (RFC 8441)
+	if r.Method == http.MethodConnect && r.ProtoMajor >= 2 &&
+		strings.EqualFold(r.Header.Get(":protocol"), "websocket") {
+		return true
+	}
+	// HTTP/1.1 Upgrade
 	if r.Method != http.MethodGet {
 		return false
 	}
-	if r.Header.Get("Upgrade") != "websocket" {
-		return false
+	return headerContainsToken(r.Header, "Connection", "Upgrade") &&
+		headerContainsToken(r.Header, "Upgrade", "websocket")
+}
+
+// headerContainsToken checks whether a comma-separated HTTP header contains
+// the given token (case-insensitive). This handles L7 proxies that send
+// multi-value headers like "Connection: keep-alive, Upgrade".
+func headerContainsToken(h http.Header, key, token string) bool {
+	for _, v := range h[http.CanonicalHeaderKey(key)] {
+		for _, s := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(s), token) {
+				return true
+			}
+		}
 	}
-	if r.Header.Get("Connection") != "Upgrade" {
-		return false
-	}
-	return true
+	return false
 }
 
 func (p *Proxy) resolveRealHost(host *sandboxHost) (string, error, int) {

--- a/components/ingress/pkg/proxy/proxy_test.go
+++ b/components/ingress/pkg/proxy/proxy_test.go
@@ -54,6 +54,31 @@ func TestIsWebSocketRequest(t *testing.T) {
 	req.Header.Set("Upgrade", "websocket")
 	req.Header.Set("Connection", "Upgrade")
 	assert.False(t, proxy.isWebSocketRequest(req))
+
+	// Connection header with multiple tokens (L7 proxy scenario)
+	req = httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "keep-alive, Upgrade")
+	assert.True(t, proxy.isWebSocketRequest(req))
+
+	// Case-insensitive headers
+	req = httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Upgrade", "WebSocket")
+	req.Header.Set("Connection", "upgrade")
+	assert.True(t, proxy.isWebSocketRequest(req))
+
+	// HTTP/2 Extended CONNECT (RFC 8441)
+	req = httptest.NewRequest(http.MethodConnect, "/ws", nil)
+	req.ProtoMajor = 2
+	req.ProtoMinor = 0
+	req.Header.Set(":protocol", "websocket")
+	assert.True(t, proxy.isWebSocketRequest(req))
+
+	// HTTP/2 CONNECT without :protocol is not WebSocket
+	req = httptest.NewRequest(http.MethodConnect, "/ws", nil)
+	req.ProtoMajor = 2
+	req.ProtoMinor = 0
+	assert.False(t, proxy.isWebSocketRequest(req))
 }
 
 func TestParseHostRoute(t *testing.T) {

--- a/components/ingress/pkg/proxy/websocket.go
+++ b/components/ingress/pkg/proxy/websocket.go
@@ -157,7 +157,7 @@ func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backen
 		}
 		return
 	}
-	defer connBackend.CloseNow()
+	defer connBackend.CloseNow() //nolint:errcheck
 
 	// Accept the client-side WebSocket upgrade.
 	connPub, err := websocket.Accept(rw, r, &websocket.AcceptOptions{
@@ -168,7 +168,7 @@ func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backen
 		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: couldn't upgrade websocket connection")
 		return
 	}
-	defer connPub.CloseNow()
+	defer connPub.CloseNow() //nolint:errcheck
 
 	// Bidirectional relay.
 	errClient := make(chan error, 1)
@@ -196,9 +196,12 @@ func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backen
 func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, backendURL *url.URL, requestHeader http.Header) {
 	ctx := r.Context()
 
-	connBackend, _, err := websocket.Dial(ctx, backendURL.String(), &websocket.DialOptions{
+	connBackend, resp, err := websocket.Dial(ctx, backendURL.String(), &websocket.DialOptions{
 		HTTPHeader: requestHeader,
 	})
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: couldn't dial to remote backend (h2 tunnel)")
 		http.Error(rw, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
@@ -222,9 +225,9 @@ func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		io.Copy(backendNetConn, r.Body)
+		_, _ = io.Copy(backendNetConn, r.Body)
 	}()
-	io.Copy(rw, backendNetConn)
+	_, _ = io.Copy(rw, backendNetConn)
 	<-done
 }
 

--- a/components/ingress/pkg/proxy/websocket.go
+++ b/components/ingress/pkg/proxy/websocket.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -242,11 +241,7 @@ func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backen
 func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, backendURL *url.URL, requestHeader http.Header, clientSubprotocols []string) {
 	backendAddr := backendURL.Host
 	if !strings.Contains(backendAddr, ":") {
-		if backendURL.Scheme == "wss" || backendURL.Scheme == "https" {
-			backendAddr += ":443"
-		} else {
-			backendAddr += ":80"
-		}
+		backendAddr += ":80"
 	}
 
 	backendConn, err := net.DialTimeout("tcp", backendAddr, backendHandshakeTimeout)
@@ -256,24 +251,6 @@ func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, 
 		return
 	}
 	defer backendConn.Close()
-
-	// Wrap with TLS for wss/https backends.
-	if backendURL.Scheme == "wss" || backendURL.Scheme == "https" {
-		host, _, _ := net.SplitHostPort(backendAddr)
-		tlsConn := tls.Client(backendConn, &tls.Config{ServerName: host})
-		if err := tlsConn.SetDeadline(time.Now().Add(backendHandshakeTimeout)); err != nil {
-			Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: TLS set deadline failed (h2 tunnel)")
-			http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
-			return
-		}
-		if err := tlsConn.Handshake(); err != nil {
-			Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: TLS handshake failed (h2 tunnel)")
-			http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
-			return
-		}
-		_ = tlsConn.SetDeadline(time.Time{})
-		backendConn = tlsConn
-	}
 
 	// Perform the WebSocket handshake over the raw connection.
 	if err := rawWebSocketHandshake(backendConn, backendURL, requestHeader, clientSubprotocols); err != nil {

--- a/components/ingress/pkg/proxy/websocket.go
+++ b/components/ingress/pkg/proxy/websocket.go
@@ -15,6 +15,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/base64"
@@ -267,12 +268,16 @@ func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, 
 	}
 
 	// Both sides now carry raw WebSocket frame bytes — copy bidirectionally.
+	// Wrap rw in a flushing writer so small frames reach the h2 client promptly.
+	flusher, _ := rw.(http.Flusher)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		_, _ = io.Copy(backendConn, r.Body)
+		// Client disconnected — close backend to unblock the read side.
+		backendConn.Close()
 	}()
-	_, _ = io.Copy(rw, backendConn)
+	copyFlush(rw, backendConn, flusher)
 	<-done
 }
 
@@ -298,6 +303,10 @@ func rawWebSocketHandshake(conn net.Conn, target *url.URL, extraHeaders http.Hea
 	buf.WriteString("Sec-WebSocket-Version: 13\r\n")
 	buf.WriteString("Sec-WebSocket-Key: " + secKey + "\r\n")
 	for k, vs := range extraHeaders {
+		// Host is already written above; skip to avoid duplicate.
+		if k == "Host" {
+			continue
+		}
 		for _, v := range vs {
 			buf.WriteString(k + ": " + v + "\r\n")
 		}
@@ -311,15 +320,29 @@ func rawWebSocketHandshake(conn net.Conn, target *url.URL, extraHeaders http.Hea
 		return fmt.Errorf("write handshake: %w", err)
 	}
 
-	// Read the response line — we only need to confirm "101".
-	var respBuf [1024]byte
-	n, err := conn.Read(respBuf[:])
-	if err != nil {
-		return fmt.Errorf("read handshake response: %w", err)
+	// Read the full HTTP response up to the end-of-headers marker (\r\n\r\n).
+	var resp []byte
+	single := make([]byte, 1)
+	for {
+		if _, err := conn.Read(single); err != nil {
+			return fmt.Errorf("read handshake response: %w", err)
+		}
+		resp = append(resp, single[0])
+		if len(resp) >= 4 && string(resp[len(resp)-4:]) == "\r\n\r\n" {
+			break
+		}
+		if len(resp) > 4096 {
+			return fmt.Errorf("handshake response too large")
+		}
 	}
-	respLine := string(respBuf[:n])
-	if !strings.Contains(respLine, "101") {
-		return fmt.Errorf("unexpected handshake response: %s", strings.SplitN(respLine, "\r\n", 2)[0])
+
+	end := bytes.IndexByte(resp, '\r')
+	if end < 0 {
+		end = len(resp)
+	}
+	statusLine := string(resp[:end])
+	if !strings.Contains(statusLine, "101") {
+		return fmt.Errorf("unexpected handshake response: %s", statusLine)
 	}
 
 	// Clear deadline for the tunnel phase.
@@ -370,6 +393,24 @@ func copyHeader(dst, src http.Header) {
 	for k, vv := range src {
 		for _, v := range vv {
 			dst.Add(k, v)
+		}
+	}
+}
+
+// copyFlush copies from src to dst, flushing after each read chunk so that
+// small WebSocket frames reach the h2 client without waiting for more data.
+func copyFlush(dst io.Writer, src io.Reader, flusher http.Flusher) {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := src.Read(buf)
+		if n > 0 {
+			_, _ = dst.Write(buf[:n])
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if err != nil {
+			break
 		}
 	}
 }

--- a/components/ingress/pkg/proxy/websocket.go
+++ b/components/ingress/pkg/proxy/websocket.go
@@ -15,7 +15,8 @@
 package proxy
 
 import (
-	"fmt"
+	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -23,23 +24,7 @@ import (
 	"strings"
 
 	slogger "github.com/alibaba/opensandbox/internal/logger"
-	"github.com/gorilla/websocket"
-)
-
-var (
-	// defaultWebSocketDialer is a dialer with all fields set to the default zero values.
-	defaultWebSocketDialer = websocket.DefaultDialer
-
-	// defaultUpgrader specifies the parameters for upgrading an HTTP
-	// connection to a WebSocket connection.
-	defaultUpgrader = &websocket.Upgrader{
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
-		// Allow any Origin: ingress sits behind trusted gateways where Host/Origin
-		// often diverge (e.g. browser UI vs internal target). gorilla's default
-		// same-origin check rejects those upgrades.
-		CheckOrigin: func(_ *http.Request) bool { return true },
-	}
+	"github.com/coder/websocket"
 )
 
 // WebSocketProxy is an HTTP Handler that takes an incoming WebSocket
@@ -54,14 +39,6 @@ type WebSocketProxy struct {
 	// the incoming WebSocket connection. Request is the initial incoming and
 	// unmodified request.
 	backend func(*http.Request) *url.URL
-
-	//  dialer contains options for connecting to the backend WebSocket server.
-	//  If nil, DefaultDialer is used.
-	dialer *websocket.Dialer
-
-	// upgrader specifies the parameters for upgrading a incoming HTTP
-	// connection to a WebSocket connection. If nil, DefaultUpgrader is used.
-	upgrader *websocket.Upgrader
 }
 
 // ProxyHandler returns a new http.Handler interface that reverse proxies the
@@ -93,11 +70,6 @@ func (w *WebSocketProxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if backendURL == nil {
 		http.Error(rw, "WebSocketProxy: backend URL is nil", http.StatusInternalServerError)
 		return
-	}
-
-	dialer := w.dialer
-	if w.dialer == nil {
-		dialer = defaultWebSocketDialer
 	}
 
 	// Forward all incoming headers to the backend except hop-by-hop headers
@@ -157,74 +129,53 @@ func (w *WebSocketProxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		w.director(r, requestHeader)
 	}
 
-	// Connect to the backend URL, also pass the headers we get from the requst
-	// together with the Forwarded headers we prepared above.
-	connBackend, resp, err := dialer.Dial(backendURL.String(), requestHeader)
+	// HTTP/2 Extended CONNECT (RFC 8441) — raw bidirectional tunnel.
+	if r.ProtoMajor >= 2 && r.Method == http.MethodConnect {
+		w.serveH2Tunnel(rw, r, backendURL, requestHeader)
+		return
+	}
+
+	w.serveH1(rw, r, backendURL, requestHeader)
+}
+
+// serveH1 handles the traditional HTTP/1.1 WebSocket upgrade path.
+func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backendURL *url.URL, requestHeader http.Header) {
+	ctx := r.Context()
+
+	// Dial the backend first so we can relay errors before upgrading the client.
+	connBackend, resp, err := websocket.Dial(ctx, backendURL.String(), &websocket.DialOptions{
+		HTTPHeader: requestHeader,
+	})
 	if err != nil {
 		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: couldn't dial to remote backend")
 		if resp != nil {
-			// If the WebSocket handshake fails, ErrBadHandshake is returned
-			// along with a non-nil *http.Response so that callers can handle
-			// redirects, authentication, etcetera.
-			if err := copyResponse(rw, resp); err != nil {
-				Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: couldn't write response after failed remote backend handshake")
+			if copyErr := copyResponse(rw, resp); copyErr != nil {
+				Logger.With(slogger.Field{Key: "error", Value: copyErr}).Errorf("WebSocketProxy: couldn't write response after failed remote backend handshake")
 			}
 		} else {
 			http.Error(rw, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
 		}
 		return
 	}
-	defer connBackend.Close()
+	defer connBackend.CloseNow()
 
-	upgrader := w.upgrader
-	if w.upgrader == nil {
-		upgrader = defaultUpgrader
-	}
-
-	// Only pass those headers to the upgrader.
-	upgradeHeader := http.Header{}
-	if hdr := resp.Header.Get(SecWebSocketProtocol); hdr != "" {
-		upgradeHeader.Set(SecWebSocketProtocol, hdr)
-	}
-	if hdr := resp.Header.Get(SetCookie); hdr != "" {
-		upgradeHeader.Set(SetCookie, hdr)
-	}
-
-	// Now upgrade the existing incoming request to a WebSocket connection.
-	// Also pass the header that we gathered from the Dial handshake.
-	connPub, err := upgrader.Upgrade(rw, r, upgradeHeader)
+	// Accept the client-side WebSocket upgrade.
+	connPub, err := websocket.Accept(rw, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true,
+		Subprotocols:       subprotocolsFromResponse(resp),
+	})
 	if err != nil {
 		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: couldn't upgrade websocket connection")
 		return
 	}
-	defer connPub.Close()
+	defer connPub.CloseNow()
 
+	// Bidirectional relay.
 	errClient := make(chan error, 1)
 	errBackend := make(chan error, 1)
-	replicateWebsocketConn := func(dst, src *websocket.Conn, errc chan error) {
-		for {
-			msgType, msg, err := src.ReadMessage()
-			if err != nil {
-				m := websocket.FormatCloseMessage(websocket.CloseNormalClosure, fmt.Sprintf("%v", err))
-				if e, ok := err.(*websocket.CloseError); ok { //nolint:errorlint
-					if e.Code != websocket.CloseNoStatusReceived {
-						m = websocket.FormatCloseMessage(e.Code, e.Text)
-					}
-				}
-				errc <- err
-				_ = dst.WriteMessage(websocket.CloseMessage, m)
-				break
-			}
-			err = dst.WriteMessage(msgType, msg)
-			if err != nil {
-				errc <- err
-				break
-			}
-		}
-	}
 
-	go replicateWebsocketConn(connPub, connBackend, errClient)
-	go replicateWebsocketConn(connBackend, connPub, errBackend)
+	go replicateConn(ctx, connPub, connBackend, errClient)
+	go replicateConn(ctx, connBackend, connPub, errBackend)
 
 	var message string
 	select {
@@ -232,11 +183,75 @@ func (w *WebSocketProxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		message = "WebSocketProxy: Error when copying from backend to client: %v"
 	case err = <-errBackend:
 		message = "WebSocketProxy: Error when copying from client to backend: %v"
-
 	}
-	if e, ok := err.(*websocket.CloseError); !ok || e.Code == websocket.CloseAbnormalClosure { //nolint:errorlint
+
+	var closeErr websocket.CloseError
+	if !errors.As(err, &closeErr) || closeErr.Code == websocket.StatusAbnormalClosure {
 		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf(message, err)
 	}
+}
+
+// serveH2Tunnel handles HTTP/2 Extended CONNECT (RFC 8441) by creating
+// a raw bidirectional tunnel between the h2 stream and a backend h1 WebSocket.
+func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, backendURL *url.URL, requestHeader http.Header) {
+	ctx := r.Context()
+
+	connBackend, _, err := websocket.Dial(ctx, backendURL.String(), &websocket.DialOptions{
+		HTTPHeader: requestHeader,
+	})
+	if err != nil {
+		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: couldn't dial to remote backend (h2 tunnel)")
+		http.Error(rw, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
+		return
+	}
+	backendNetConn := websocket.NetConn(ctx, connBackend, websocket.MessageBinary)
+	defer backendNetConn.Close()
+
+	rc := http.NewResponseController(rw)
+	if err := rc.EnableFullDuplex(); err != nil {
+		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: EnableFullDuplex failed")
+		http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	rw.WriteHeader(http.StatusOK)
+	if err := rc.Flush(); err != nil {
+		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: flush failed")
+		return
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		io.Copy(backendNetConn, r.Body)
+	}()
+	io.Copy(rw, backendNetConn)
+	<-done
+}
+
+func replicateConn(ctx context.Context, dst, src *websocket.Conn, errc chan error) {
+	for {
+		msgType, msg, err := src.Read(ctx)
+		if err != nil {
+			errc <- err
+			dst.Close(websocket.StatusNormalClosure, "")
+			break
+		}
+		err = dst.Write(ctx, msgType, msg)
+		if err != nil {
+			errc <- err
+			break
+		}
+	}
+}
+
+func subprotocolsFromResponse(resp *http.Response) []string {
+	if resp == nil {
+		return nil
+	}
+	if proto := resp.Header.Get(SecWebSocketProtocol); proto != "" {
+		return []string{proto}
+	}
+	return nil
 }
 
 func copyResponse(rw http.ResponseWriter, resp *http.Response) error {

--- a/components/ingress/pkg/proxy/websocket.go
+++ b/components/ingress/pkg/proxy/websocket.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -25,6 +26,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,6 +35,13 @@ import (
 )
 
 const backendHandshakeTimeout = 45 * time.Second
+
+type handshakeError struct {
+	statusCode int
+	statusLine string
+}
+
+func (e *handshakeError) Error() string { return e.statusLine }
 
 // WebSocketProxy is an HTTP Handler that takes an incoming WebSocket
 // connection and proxies it to another server.
@@ -154,7 +163,7 @@ func (w *WebSocketProxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	// HTTP/2 Extended CONNECT (RFC 8441) — raw bidirectional tunnel.
 	if r.ProtoMajor >= 2 && r.Method == http.MethodConnect {
-		w.serveH2Tunnel(rw, r, backendURL, requestHeader)
+		w.serveH2Tunnel(rw, r, backendURL, requestHeader, clientSubprotocols)
 		return
 	}
 
@@ -230,7 +239,7 @@ func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backen
 // the backend over raw HTTP/1.1 and tunneling bytes between the h2 stream
 // and the backend TCP connection. Both sides carry WebSocket frame bytes,
 // so no re-framing is needed.
-func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, backendURL *url.URL, requestHeader http.Header) {
+func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, backendURL *url.URL, requestHeader http.Header, clientSubprotocols []string) {
 	backendAddr := backendURL.Host
 	if !strings.Contains(backendAddr, ":") {
 		if backendURL.Scheme == "wss" || backendURL.Scheme == "https" {
@@ -248,10 +257,33 @@ func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, 
 	}
 	defer backendConn.Close()
 
+	// Wrap with TLS for wss/https backends.
+	if backendURL.Scheme == "wss" || backendURL.Scheme == "https" {
+		host, _, _ := net.SplitHostPort(backendAddr)
+		tlsConn := tls.Client(backendConn, &tls.Config{ServerName: host})
+		if err := tlsConn.SetDeadline(time.Now().Add(backendHandshakeTimeout)); err != nil {
+			Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: TLS set deadline failed (h2 tunnel)")
+			http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+			return
+		}
+		if err := tlsConn.Handshake(); err != nil {
+			Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: TLS handshake failed (h2 tunnel)")
+			http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+			return
+		}
+		_ = tlsConn.SetDeadline(time.Time{})
+		backendConn = tlsConn
+	}
+
 	// Perform the WebSocket handshake over the raw connection.
-	if err := rawWebSocketHandshake(backendConn, backendURL, requestHeader); err != nil {
-		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: backend WebSocket handshake failed (h2 tunnel)")
-		http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+	if err := rawWebSocketHandshake(backendConn, backendURL, requestHeader, clientSubprotocols); err != nil {
+		var hsErr *handshakeError
+		if errors.As(err, &hsErr) {
+			http.Error(rw, hsErr.statusLine, hsErr.statusCode)
+		} else {
+			Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: backend WebSocket handshake failed (h2 tunnel)")
+			http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+		}
 		return
 	}
 
@@ -274,16 +306,16 @@ func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, 
 	go func() {
 		defer close(done)
 		_, _ = io.Copy(backendConn, r.Body)
-		// Client disconnected — close backend to unblock the read side.
 		backendConn.Close()
 	}()
 	copyFlush(rw, backendConn, flusher)
+	r.Body.Close()
 	<-done
 }
 
 // rawWebSocketHandshake sends an HTTP/1.1 WebSocket upgrade request on conn
 // and verifies the 101 response. After success, conn carries raw WS frames.
-func rawWebSocketHandshake(conn net.Conn, target *url.URL, extraHeaders http.Header) error {
+func rawWebSocketHandshake(conn net.Conn, target *url.URL, extraHeaders http.Header, subprotocols []string) error {
 	key := make([]byte, 16)
 	if _, err := rand.Read(key); err != nil {
 		return fmt.Errorf("generate Sec-WebSocket-Key: %w", err)
@@ -302,8 +334,10 @@ func rawWebSocketHandshake(conn net.Conn, target *url.URL, extraHeaders http.Hea
 	buf.WriteString("Connection: Upgrade\r\n")
 	buf.WriteString("Sec-WebSocket-Version: 13\r\n")
 	buf.WriteString("Sec-WebSocket-Key: " + secKey + "\r\n")
+	if len(subprotocols) > 0 {
+		buf.WriteString("Sec-WebSocket-Protocol: " + strings.Join(subprotocols, ", ") + "\r\n")
+	}
 	for k, vs := range extraHeaders {
-		// Host is already written above; skip to avoid duplicate.
 		if k == "Host" {
 			continue
 		}
@@ -342,11 +376,22 @@ func rawWebSocketHandshake(conn net.Conn, target *url.URL, extraHeaders http.Hea
 	}
 	statusLine := string(resp[:end])
 	if !strings.Contains(statusLine, "101") {
-		return fmt.Errorf("unexpected handshake response: %s", statusLine)
+		code := parseHTTPStatusCode(statusLine)
+		return &handshakeError{statusCode: code, statusLine: statusLine}
 	}
 
 	// Clear deadline for the tunnel phase.
 	return conn.SetDeadline(time.Time{})
+}
+
+func parseHTTPStatusCode(statusLine string) int {
+	parts := strings.SplitN(statusLine, " ", 3)
+	if len(parts) >= 2 {
+		if code, err := strconv.Atoi(parts[1]); err == nil {
+			return code
+		}
+	}
+	return http.StatusBadGateway
 }
 
 func replicateConn(ctx context.Context, dst, src *websocket.Conn, errc chan error) {

--- a/components/ingress/pkg/proxy/websocket.go
+++ b/components/ingress/pkg/proxy/websocket.go
@@ -179,6 +179,7 @@ func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backen
 	connBackend, resp, err := websocket.Dial(dialCtx, backendURL.String(), &websocket.DialOptions{
 		HTTPHeader:   requestHeader,
 		Subprotocols: clientSubprotocols,
+		Host:         requestHeader.Get("Host"),
 	})
 	if err != nil {
 		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: couldn't dial to remote backend")
@@ -253,7 +254,8 @@ func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, 
 	defer backendConn.Close()
 
 	// Perform the WebSocket handshake over the raw connection.
-	if err := rawWebSocketHandshake(backendConn, backendURL, requestHeader, clientSubprotocols); err != nil {
+	respHeaders, err := rawWebSocketHandshake(backendConn, backendURL, requestHeader, clientSubprotocols)
+	if err != nil {
 		var hsErr *handshakeError
 		if errors.As(err, &hsErr) {
 			http.Error(rw, hsErr.statusLine, hsErr.statusCode)
@@ -270,6 +272,11 @@ func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, 
 		http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+
+	// Forward Set-Cookie from backend handshake before writing the h2 200.
+	for _, c := range respHeaders.Values("Set-Cookie") {
+		rw.Header().Add("Set-Cookie", c)
+	}
 	rw.WriteHeader(http.StatusOK)
 	if err := rc.Flush(); err != nil {
 		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: flush failed")
@@ -277,13 +284,17 @@ func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, 
 	}
 
 	// Both sides now carry raw WebSocket frame bytes — copy bidirectionally.
-	// Wrap rw in a flushing writer so small frames reach the h2 client promptly.
 	flusher, _ := rw.(http.Flusher)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		_, _ = io.Copy(backendConn, r.Body)
-		backendConn.Close()
+		// Half-close the write side so backend can finish sending.
+		if tc, ok := backendConn.(interface{ CloseWrite() error }); ok {
+			tc.CloseWrite()
+		} else {
+			backendConn.Close()
+		}
 	}()
 	copyFlush(rw, backendConn, flusher)
 	r.Body.Close()
@@ -291,11 +302,11 @@ func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, 
 }
 
 // rawWebSocketHandshake sends an HTTP/1.1 WebSocket upgrade request on conn
-// and verifies the 101 response. After success, conn carries raw WS frames.
-func rawWebSocketHandshake(conn net.Conn, target *url.URL, extraHeaders http.Header, subprotocols []string) error {
+// and verifies the 101 response. Returns parsed response headers on success.
+func rawWebSocketHandshake(conn net.Conn, target *url.URL, extraHeaders http.Header, subprotocols []string) (http.Header, error) {
 	key := make([]byte, 16)
 	if _, err := rand.Read(key); err != nil {
-		return fmt.Errorf("generate Sec-WebSocket-Key: %w", err)
+		return nil, fmt.Errorf("generate Sec-WebSocket-Key: %w", err)
 	}
 	secKey := base64.StdEncoding.EncodeToString(key)
 
@@ -325,25 +336,26 @@ func rawWebSocketHandshake(conn net.Conn, target *url.URL, extraHeaders http.Hea
 	buf.WriteString("\r\n")
 
 	if err := conn.SetDeadline(time.Now().Add(backendHandshakeTimeout)); err != nil {
-		return err
+		return nil, err
 	}
 	if _, err := io.WriteString(conn, buf.String()); err != nil {
-		return fmt.Errorf("write handshake: %w", err)
+		return nil, fmt.Errorf("write handshake: %w", err)
 	}
 
 	// Read the full HTTP response up to the end-of-headers marker (\r\n\r\n).
+	const maxHandshakeResponseSize = 16384
 	var resp []byte
 	single := make([]byte, 1)
 	for {
 		if _, err := conn.Read(single); err != nil {
-			return fmt.Errorf("read handshake response: %w", err)
+			return nil, fmt.Errorf("read handshake response: %w", err)
 		}
 		resp = append(resp, single[0])
 		if len(resp) >= 4 && string(resp[len(resp)-4:]) == "\r\n\r\n" {
 			break
 		}
-		if len(resp) > 4096 {
-			return fmt.Errorf("handshake response too large")
+		if len(resp) > maxHandshakeResponseSize {
+			return nil, fmt.Errorf("handshake response too large")
 		}
 	}
 
@@ -354,11 +366,36 @@ func rawWebSocketHandshake(conn net.Conn, target *url.URL, extraHeaders http.Hea
 	statusLine := string(resp[:end])
 	if !strings.Contains(statusLine, "101") {
 		code := parseHTTPStatusCode(statusLine)
-		return &handshakeError{statusCode: code, statusLine: statusLine}
+		return nil, &handshakeError{statusCode: code, statusLine: statusLine}
 	}
 
-	// Clear deadline for the tunnel phase.
-	return conn.SetDeadline(time.Time{})
+	// Parse response headers.
+	respHeaders := http.Header{}
+	headerLines := strings.Split(string(resp), "\r\n")
+	for i := 1; i < len(headerLines); i++ {
+		line := headerLines[i]
+		if line == "" {
+			break
+		}
+		colonIdx := strings.IndexByte(line, ':')
+		if colonIdx < 0 {
+			continue
+		}
+		respHeaders.Add(
+			strings.TrimSpace(line[:colonIdx]),
+			strings.TrimSpace(line[colonIdx+1:]),
+		)
+	}
+
+	if !strings.EqualFold(respHeaders.Get("Upgrade"), "websocket") ||
+		!headerContainsToken(respHeaders, "Connection", "Upgrade") {
+		return nil, fmt.Errorf("invalid WebSocket handshake: missing Upgrade/Connection headers")
+	}
+
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		return nil, err
+	}
+	return respHeaders, nil
 }
 
 func parseHTTPStatusCode(statusLine string) int {

--- a/components/ingress/pkg/proxy/websocket.go
+++ b/components/ingress/pkg/proxy/websocket.go
@@ -291,7 +291,7 @@ func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, 
 		_, _ = io.Copy(backendConn, r.Body)
 		// Half-close the write side so backend can finish sending.
 		if tc, ok := backendConn.(interface{ CloseWrite() error }); ok {
-			tc.CloseWrite()
+			_ = tc.CloseWrite()
 		} else {
 			backendConn.Close()
 		}

--- a/components/ingress/pkg/proxy/websocket.go
+++ b/components/ingress/pkg/proxy/websocket.go
@@ -16,16 +16,22 @@ package proxy
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	slogger "github.com/alibaba/opensandbox/internal/logger"
 	"github.com/coder/websocket"
 )
+
+const backendHandshakeTimeout = 45 * time.Second
 
 // WebSocketProxy is an HTTP Handler that takes an incoming WebSocket
 // connection and proxies it to another server.
@@ -83,15 +89,31 @@ func (w *WebSocketProxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+
+	// Collect client-requested subprotocols before filtering headers.
+	var clientSubprotocols []string
+	for _, v := range r.Header[SecWebSocketProtocol] {
+		for _, sp := range strings.Split(v, ",") {
+			if sp = strings.TrimSpace(sp); sp != "" {
+				clientSubprotocols = append(clientSubprotocols, sp)
+			}
+		}
+	}
+
 	requestHeader := http.Header{}
 	for key, values := range r.Header {
 		switch key {
 		case HopByHopConnection, HopByHopKeepAlive, HopByHopProxyAuth, HopByHopProxyAuthz,
 			HopByHopTE, HopByHopTrailer, HopByHopTransferEncoding, HopByHopUpgrade,
-			HopByHopProxyConnection, SecWebSocketKey, SecWebSocketVersion, SecWebSocketExtensions:
+			HopByHopProxyConnection,
+			SecWebSocketKey, SecWebSocketVersion, SecWebSocketExtensions, SecWebSocketProtocol:
 			continue
 		}
 		if connTokens[key] {
+			continue
+		}
+		// Strip h2 pseudo-headers — invalid in h1 backend requests.
+		if strings.HasPrefix(key, ":") {
 			continue
 		}
 		for _, v := range values {
@@ -135,16 +157,19 @@ func (w *WebSocketProxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.serveH1(rw, r, backendURL, requestHeader)
+	w.serveH1(rw, r, backendURL, requestHeader, clientSubprotocols)
 }
 
 // serveH1 handles the traditional HTTP/1.1 WebSocket upgrade path.
-func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backendURL *url.URL, requestHeader http.Header) {
+func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backendURL *url.URL, requestHeader http.Header, clientSubprotocols []string) {
 	ctx := r.Context()
+	dialCtx, dialCancel := context.WithTimeout(ctx, backendHandshakeTimeout)
+	defer dialCancel()
 
 	// Dial the backend first so we can relay errors before upgrading the client.
-	connBackend, resp, err := websocket.Dial(ctx, backendURL.String(), &websocket.DialOptions{
-		HTTPHeader: requestHeader,
+	connBackend, resp, err := websocket.Dial(dialCtx, backendURL.String(), &websocket.DialOptions{
+		HTTPHeader:   requestHeader,
+		Subprotocols: clientSubprotocols,
 	})
 	if err != nil {
 		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: couldn't dial to remote backend")
@@ -158,6 +183,14 @@ func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backen
 		return
 	}
 	defer connBackend.CloseNow() //nolint:errcheck
+	connBackend.SetReadLimit(-1)
+
+	// Copy Set-Cookie from the backend handshake response before upgrading.
+	if resp != nil {
+		for _, c := range resp.Header.Values(SetCookie) {
+			rw.Header().Add(SetCookie, c)
+		}
+	}
 
 	// Accept the client-side WebSocket upgrade.
 	connPub, err := websocket.Accept(rw, r, &websocket.AcceptOptions{
@@ -169,6 +202,7 @@ func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backen
 		return
 	}
 	defer connPub.CloseNow() //nolint:errcheck
+	connPub.SetReadLimit(-1)
 
 	// Bidirectional relay.
 	errClient := make(chan error, 1)
@@ -191,24 +225,34 @@ func (w *WebSocketProxy) serveH1(rw http.ResponseWriter, r *http.Request, backen
 	}
 }
 
-// serveH2Tunnel handles HTTP/2 Extended CONNECT (RFC 8441) by creating
-// a raw bidirectional tunnel between the h2 stream and a backend h1 WebSocket.
+// serveH2Tunnel handles HTTP/2 Extended CONNECT (RFC 8441) by dialing
+// the backend over raw HTTP/1.1 and tunneling bytes between the h2 stream
+// and the backend TCP connection. Both sides carry WebSocket frame bytes,
+// so no re-framing is needed.
 func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, backendURL *url.URL, requestHeader http.Header) {
-	ctx := r.Context()
-
-	connBackend, resp, err := websocket.Dial(ctx, backendURL.String(), &websocket.DialOptions{
-		HTTPHeader: requestHeader,
-	})
-	if resp != nil && resp.Body != nil {
-		defer resp.Body.Close()
+	backendAddr := backendURL.Host
+	if !strings.Contains(backendAddr, ":") {
+		if backendURL.Scheme == "wss" || backendURL.Scheme == "https" {
+			backendAddr += ":443"
+		} else {
+			backendAddr += ":80"
+		}
 	}
+
+	backendConn, err := net.DialTimeout("tcp", backendAddr, backendHandshakeTimeout)
 	if err != nil {
-		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: couldn't dial to remote backend (h2 tunnel)")
+		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: couldn't connect to remote backend (h2 tunnel)")
 		http.Error(rw, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
 		return
 	}
-	backendNetConn := websocket.NetConn(ctx, connBackend, websocket.MessageBinary)
-	defer backendNetConn.Close()
+	defer backendConn.Close()
+
+	// Perform the WebSocket handshake over the raw connection.
+	if err := rawWebSocketHandshake(backendConn, backendURL, requestHeader); err != nil {
+		Logger.With(slogger.Field{Key: "error", Value: err}).Errorf("WebSocketProxy: backend WebSocket handshake failed (h2 tunnel)")
+		http.Error(rw, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+		return
+	}
 
 	rc := http.NewResponseController(rw)
 	if err := rc.EnableFullDuplex(); err != nil {
@@ -222,21 +266,77 @@ func (w *WebSocketProxy) serveH2Tunnel(rw http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	// Both sides now carry raw WebSocket frame bytes — copy bidirectionally.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_, _ = io.Copy(backendNetConn, r.Body)
+		_, _ = io.Copy(backendConn, r.Body)
 	}()
-	_, _ = io.Copy(rw, backendNetConn)
+	_, _ = io.Copy(rw, backendConn)
 	<-done
+}
+
+// rawWebSocketHandshake sends an HTTP/1.1 WebSocket upgrade request on conn
+// and verifies the 101 response. After success, conn carries raw WS frames.
+func rawWebSocketHandshake(conn net.Conn, target *url.URL, extraHeaders http.Header) error {
+	key := make([]byte, 16)
+	if _, err := rand.Read(key); err != nil {
+		return fmt.Errorf("generate Sec-WebSocket-Key: %w", err)
+	}
+	secKey := base64.StdEncoding.EncodeToString(key)
+
+	path := target.RequestURI()
+	if path == "" {
+		path = "/"
+	}
+
+	var buf strings.Builder
+	buf.WriteString("GET " + path + " HTTP/1.1\r\n")
+	buf.WriteString("Host: " + target.Host + "\r\n")
+	buf.WriteString("Upgrade: websocket\r\n")
+	buf.WriteString("Connection: Upgrade\r\n")
+	buf.WriteString("Sec-WebSocket-Version: 13\r\n")
+	buf.WriteString("Sec-WebSocket-Key: " + secKey + "\r\n")
+	for k, vs := range extraHeaders {
+		for _, v := range vs {
+			buf.WriteString(k + ": " + v + "\r\n")
+		}
+	}
+	buf.WriteString("\r\n")
+
+	if err := conn.SetDeadline(time.Now().Add(backendHandshakeTimeout)); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(conn, buf.String()); err != nil {
+		return fmt.Errorf("write handshake: %w", err)
+	}
+
+	// Read the response line — we only need to confirm "101".
+	var respBuf [1024]byte
+	n, err := conn.Read(respBuf[:])
+	if err != nil {
+		return fmt.Errorf("read handshake response: %w", err)
+	}
+	respLine := string(respBuf[:n])
+	if !strings.Contains(respLine, "101") {
+		return fmt.Errorf("unexpected handshake response: %s", strings.SplitN(respLine, "\r\n", 2)[0])
+	}
+
+	// Clear deadline for the tunnel phase.
+	return conn.SetDeadline(time.Time{})
 }
 
 func replicateConn(ctx context.Context, dst, src *websocket.Conn, errc chan error) {
 	for {
 		msgType, msg, err := src.Read(ctx)
 		if err != nil {
+			var closeErr websocket.CloseError
+			if errors.As(err, &closeErr) {
+				dst.Close(closeErr.Code, closeErr.Reason)
+			} else {
+				dst.Close(websocket.StatusNormalClosure, "")
+			}
 			errc <- err
-			dst.Close(websocket.StatusNormalClosure, "")
 			break
 		}
 		err = dst.Write(ctx, msgType, msg)

--- a/components/ingress/pkg/proxy/websocket_test.go
+++ b/components/ingress/pkg/proxy/websocket_test.go
@@ -17,7 +17,6 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -25,7 +24,7 @@ import (
 	"time"
 
 	slogger "github.com/alibaba/opensandbox/internal/logger"
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,26 +74,27 @@ func webSocketProxyWithHeaderMode(t *testing.T) {
 			// Don't upgrade if original host header isn't preserved
 			assert.True(t, strings.HasPrefix(r.Host, "127.0.0.1"))
 
-			conn, err := defaultUpgrader.Upgrade(w, r, nil)
+			conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+				InsecureSkipVerify: true,
+			})
 			if err != nil {
-				log.Println(err)
+				t.Log(err)
+				return
+			}
+			defer conn.CloseNow()
+
+			msgType, p, err := conn.Read(ctx)
+			if err != nil {
 				return
 			}
 
-			messageType, p, err := conn.ReadMessage()
-			if err != nil {
-				return
-			}
-
-			if err = conn.WriteMessage(messageType, p); err != nil {
+			if err = conn.Write(ctx, msgType, p); err != nil {
 				return
 			}
 		})
 
-		err := http.ListenAndServe(":"+strconv.Itoa(backendPort), mux2)
-		if err != nil {
-			t.Error("ListenAndServe: ", err)
-			return
+		if listenErr := http.ListenAndServe(":"+strconv.Itoa(backendPort), mux2); listenErr != nil {
+			t.Error("ListenAndServe: ", listenErr)
 		}
 	}()
 
@@ -104,24 +104,27 @@ func webSocketProxyWithHeaderMode(t *testing.T) {
 	// message to the backend websocket server.
 	h := http.Header{}
 	h.Set(SandboxIngress, "test-sandbox-"+strconv.Itoa(backendPort))
-	conn, _, err := websocket.DefaultDialer.Dial(proxyURL+"/ws", h)
+	conn, _, err := websocket.Dial(ctx, proxyURL+"/ws", &websocket.DialOptions{
+		HTTPHeader: h,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer conn.CloseNow()
 
 	// write a message and send it to the backend server
 	msg := "hello kite"
-	err = conn.WriteMessage(websocket.TextMessage, []byte(msg))
+	err = conn.Write(ctx, websocket.MessageText, []byte(msg))
 	if err != nil {
 		t.Error(err)
 	}
 
-	messageType, p, err := conn.ReadMessage()
+	messageType, p, err := conn.Read(ctx)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if messageType != websocket.TextMessage {
+	if messageType != websocket.MessageText {
 		t.Error("incoming message type is not Text")
 	}
 
@@ -167,26 +170,27 @@ func webSocketProxyWithURIMode(t *testing.T) {
 			// Don't upgrade if original host header isn't preserved
 			assert.True(t, strings.HasPrefix(r.Host, "127.0.0.1"))
 
-			conn, err := defaultUpgrader.Upgrade(w, r, nil)
+			conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+				InsecureSkipVerify: true,
+			})
 			if err != nil {
-				log.Println(err)
+				t.Log(err)
+				return
+			}
+			defer conn.CloseNow()
+
+			msgType, p, err := conn.Read(ctx)
+			if err != nil {
 				return
 			}
 
-			messageType, p, err := conn.ReadMessage()
-			if err != nil {
-				return
-			}
-
-			if err = conn.WriteMessage(messageType, p); err != nil {
+			if err = conn.Write(ctx, msgType, p); err != nil {
 				return
 			}
 		})
 
-		err := http.ListenAndServe(":"+strconv.Itoa(backendPort), mux2)
-		if err != nil {
-			t.Error("ListenAndServe: ", err)
-			return
+		if listenErr := http.ListenAndServe(":"+strconv.Itoa(backendPort), mux2); listenErr != nil {
+			t.Error("ListenAndServe: ", listenErr)
 		}
 	}()
 
@@ -196,24 +200,27 @@ func webSocketProxyWithURIMode(t *testing.T) {
 	// message to the backend websocket server.
 	h := http.Header{}
 	h.Set(SandboxIngress, "test-sandbox-"+strconv.Itoa(backendPort))
-	conn, _, err := websocket.DefaultDialer.Dial(proxyURL+fmt.Sprintf("/test-sandbox/%v", backendPort)+"/ws", h)
+	conn, _, err := websocket.Dial(ctx, proxyURL+fmt.Sprintf("/test-sandbox/%v", backendPort)+"/ws", &websocket.DialOptions{
+		HTTPHeader: h,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer conn.CloseNow()
 
 	// write a message and send it to the backend server
 	msg := "hello kite"
-	err = conn.WriteMessage(websocket.TextMessage, []byte(msg))
+	err = conn.Write(ctx, websocket.MessageText, []byte(msg))
 	if err != nil {
 		t.Error(err)
 	}
 
-	messageType, p, err := conn.ReadMessage()
+	messageType, p, err := conn.Read(ctx)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if messageType != websocket.TextMessage {
+	if messageType != websocket.MessageText {
 		t.Error("incoming message type is not Text")
 	}
 

--- a/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
@@ -70,6 +70,9 @@ spec:
         - name: main
           image: {{ include "opensandbox-server.ingressGatewayImage" . }}
           imagePullPolicy: IfNotPresent
+          env:
+            - name: GODEBUG
+              value: "http2xconnect=1"
           args:
             - "--namespace={{ .Values.server.gateway.dataplaneNamespace }}"
             - "--port={{ .Values.server.gateway.port }}"


### PR DESCRIPTION
## Summary

- Replace archived `gorilla/websocket` with actively-maintained `github.com/coder/websocket` v1.8.15
- Fix `isWebSocketRequest` to use case-insensitive token matching — handles L7 proxies sending `Connection: keep-alive, Upgrade`
- Add HTTP/2 Extended CONNECT (RFC 8441) detection and raw bidirectional tunnel (`serveH2Tunnel`)
- Enable h2c (unencrypted HTTP/2) by default on the ingress server via `http.Protocols`
- Set `GODEBUG=http2xconnect=1` in Helm ingress-gateway deployment template

Closes #1105

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/proxy/... -run TestIsWebSocketRequest` — token matching, case-insensitive, Extended CONNECT detection
- [x] `go test ./pkg/proxy/... -run Test_WebSocketProxy` — header mode + URI mode echo round-trip
- [ ] Deploy with HAProxy fronting ingress (h2 ALPN enabled), verify code-server WebSocket connects
- [ ] Deploy with `GODEBUG=http2xconnect=1`, verify direct h2 Extended CONNECT WebSocket tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)