### PR TITLE
feat(mcp): add host_path and mount_path parameters with unit tests

### DIFF
--- a/sdks/mcp/sandbox/python/src/opensandbox_mcp/server.py
+++ b/sdks/mcp/sandbox/python/src/opensandbox_mcp/server.py
@@ -214,8 +214,10 @@ def register_tools(
                 progress=0.3, total=1.0, message="Creating sandbox"
             )
 
-        # Dynamically compile the volumes configuration using native SDK models
         volumes = None
+        if (host_path is not None) != (mount_path is not None):
+            raise ValueError("Both 'host_path' and 'mount_path' must be provided together to enable persistence.")
+
         if host_path and mount_path:
             from opensandbox.models.sandboxes import Host, Volume
 
@@ -223,7 +225,7 @@ def register_tools(
                 Volume(
                     name="mcp-persistent-storage",
                     host=Host(path=host_path),
-                    mountPath=mount_path,
+                    mount_path=mount_path,
                 )
             ]
 

--- a/sdks/mcp/sandbox/python/src/opensandbox_mcp/server.py
+++ b/sdks/mcp/sandbox/python/src/opensandbox_mcp/server.py
@@ -67,19 +67,23 @@ class ServerState:
 class StatusResponse(BaseModel):
     status: str = Field(description="Operation status string.")
 
+
 class DirectoryEntryInput(BaseModel):
     path: str = Field(description="Directory path.")
     mode: int = Field(default=755, description="Unix permissions for the directory.")
     owner: str | None = Field(default=None, description="Owner username.")
     group: str | None = Field(default=None, description="Group name.")
 
+
 class SandboxInfoResponse(BaseModel):
     sandbox_id: str = Field(description="Sandbox identifier.")
     info: SandboxInfo = Field(description="Sandbox info payload.")
 
+
 class SandboxHealthResponse(BaseModel):
     sandbox_id: str = Field(description="Sandbox identifier.")
     healthy: bool = Field(description="Sandbox health status.")
+
 
 class FileReadResponse(BaseModel):
     path: str = Field(description="File path.")
@@ -142,6 +146,8 @@ def register_tools(
         network_policy: NetworkPolicy | None = None,
         extensions: dict[str, str] | None = None,
         entrypoint: list[str] | None = None,
+        host_path: str | None = None,
+        mount_path: str | None = None,
     ) -> SandboxInfoResponse:
         """Create a sandbox and store it in the MCP server session.
 
@@ -167,6 +173,8 @@ def register_tools(
                 )
             extensions: Opaque extension parameters passed through to the server.
             entrypoint: Entrypoint command list.
+            host_path: Optional host path to mount (must be whitelisted on the manager).
+            mount_path: Optional internal container target path (e.g., "/workspace").
 
         Returns:
             A dict with:
@@ -182,14 +190,20 @@ def register_tools(
                 image="python:3.11",
                 env={"PYTHONPATH": "/app"},
                 resource={"cpu": "1", "memory": "2Gi"},
+                host_path="/var/lib/sandboxes/workspaces",
+                mount_path="/workspace",
             )
         """
         if ctx:
-            await ctx.report_progress(progress=0.1, total=1.0, message="Validating input")
+            await ctx.report_progress(
+                progress=0.1, total=1.0, message="Validating input"
+            )
         image_auth = None
         if auth_username or auth_password:
             if not auth_username or not auth_password:
-                raise ValueError("auth_username and auth_password must be provided together")
+                raise ValueError(
+                    "auth_username and auth_password must be provided together"
+                )
             image_auth = SandboxImageAuth(
                 username=auth_username,
                 password=auth_password,
@@ -199,6 +213,20 @@ def register_tools(
             await ctx.report_progress(
                 progress=0.3, total=1.0, message="Creating sandbox"
             )
+
+        # Dynamically compile the volumes configuration using native SDK models
+        volumes = None
+        if host_path and mount_path:
+            from opensandbox.models.sandboxes import Host, Volume
+
+            volumes = [
+                Volume(
+                    name="mcp-persistent-storage",
+                    host=Host(path=host_path),
+                    mountPath=mount_path,
+                )
+            ]
+
         sandbox = await Sandbox.create(
             image_spec,
             timeout=timedelta(seconds=timeout_seconds),
@@ -214,6 +242,7 @@ def register_tools(
             ),
             skip_health_check=skip_health_check,
             connection_config=state.connection_config,
+            volumes=volumes,
         )
         await state.add(sandbox)
         if ctx:
@@ -308,9 +337,7 @@ def register_tools(
         sandbox = await state.get(sandbox_id)
         if sandbox is not None:
             return await sandbox.get_info()
-        manager = await SandboxManager.create(
-            connection_config=state.connection_config
-        )
+        manager = await SandboxManager.create(connection_config=state.connection_config)
         try:
             info = await manager.get_sandbox_info(sandbox_id)
         finally:
@@ -333,11 +360,11 @@ def register_tools(
             Paginated sandbox list.
         """
         if ctx:
-            await ctx.report_progress(progress=0.1, total=1.0, message="Listing sandboxes")
+            await ctx.report_progress(
+                progress=0.1, total=1.0, message="Listing sandboxes"
+            )
         filter = filter or SandboxFilter()
-        manager = await SandboxManager.create(
-            connection_config=state.connection_config
-        )
+        manager = await SandboxManager.create(connection_config=state.connection_config)
         try:
             result = await manager.list_sandbox_infos(filter)
         finally:

--- a/sdks/mcp/sandbox/python/tests/test_server.py
+++ b/sdks/mcp/sandbox/python/tests/test_server.py
@@ -1,0 +1,66 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from opensandbox_mcp.server import create_server 
+
+@pytest.mark.asyncio
+@patch("opensandbox_mcp.server.Sandbox")
+async def test_sandbox_create_with_volumes(mock_sandbox):
+    mock_instance = MagicMock()
+    mock_instance.id = "sbx_mock_test_123"
+    mock_instance.get_info = AsyncMock()
+    mock_sandbox.create = AsyncMock(return_value=mock_instance)
+    
+    mcp_app = create_server()
+    tool_name = "sandbox_create"
+    target_func = None
+    
+    if hasattr(mcp_app, "_tool_manager"):
+        tool_obj = mcp_app._tool_manager.get_tool(tool_name)
+        if tool_obj:
+            target_func = getattr(tool_obj, "fn", None)
+        
+    if not target_func:
+        raise ValueError(f"Could not locate '{tool_name}' inner function within the FastMCP tool manager.")
+
+    with patch("opensandbox_mcp.server.SandboxInfoResponse") as mock_info_response:
+        mock_response_instance = MagicMock()
+        mock_response_instance.sandbox_id = "sbx_mock_test_123"
+        mock_info_response.return_value = mock_response_instance
+
+        result = await target_func(
+            image="ghcr.io/agent-infra/sandbox:latest",
+            host_path="/var/lib/sandboxes/workspaces",
+            mount_path="/workspace"
+        )
+    
+    mock_sandbox.create.assert_called_once()
+    executed_kwargs = mock_sandbox.create.call_args[1]
+    
+    assert "volumes" in executed_kwargs
+    assert executed_kwargs["volumes"] is not None
+    assert len(executed_kwargs["volumes"]) == 1
+    
+    volume_spec = executed_kwargs["volumes"][0]
+    assert volume_spec.name == "mcp-persistent-storage"
+    assert volume_spec.host.path == "/var/lib/sandboxes/workspaces"
+    assert volume_spec.mount_path == "/workspace"
+    assert result.sandbox_id == "sbx_mock_test_123"
+
+@pytest.mark.asyncio
+@patch("opensandbox_mcp.server.Sandbox")
+async def test_sandbox_create_partial_volumes_raises_error(mock_sandbox):
+    mcp_app = create_server()
+    tool_name = "sandbox_create"
+    target_func = None
+    
+    if hasattr(mcp_app, "_tool_manager"):
+        tool_obj = mcp_app._tool_manager.get_tool(tool_name)
+        if tool_obj:
+            target_func = getattr(tool_obj, "fn", None)
+
+    with pytest.raises(ValueError, match="Both 'host_path' and 'mount_path' must be provided together"):
+        await target_func(
+            image="ghcr.io/agent-infra/sandbox:latest",
+            host_path="/var/lib/sandboxes/workspaces",
+            mount_path=None  # Triggers the exclusive-OR partial specification error
+        )


### PR DESCRIPTION
# Summary
- What is changing and why?
This PR exposes the core platform's native volume-mounting layer through the Python MCP server configuration schema. Currently, the `sandbox_create` MCP tool omits the underlying Python SDK's volume mapping options. This locks downstream MCP-capable AI clients (such as LibreChat, Claude Code, and Cursor) out of host-bound filesystem persistence workflows.

This change appends keyword-only optional attributes (`host_path: str | None = None` and `mount_path: str | None = None`) onto the `sandbox_create` tool signature, cleanly maps them to native OpenSandbox `Volume` models, and forwards them to the orchestration layer.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

### Details:
1. **Unit Testing:** Introduced the first unit verification suite for the MCP module (`tests/test_server.py`). The test initializes the FastMCP application via the `create_server` factory, extracts the target function from the tool manager, and asserts that input parameters are successfully structured into native `Volume` specs with accurate snake_case attributes. Passed cleanly locally using `uv run pytest tests/`.
2. **E2E Verification:** Manually verified via a LibreChat instance using a bridge network proxy (`socat`). Confirmed the new schema updates are broadcasted accurately, allowing an LLM agent to provision a container, mount an ext4 host path (`/var/lib/sandboxes/workspaces`), write an integrity file, completely destroy the sandbox instance, and verify data persistence upon mounting the same path to an independent subsequent sandbox.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

### Details:
The added parameters are fully optional keyword arguments defaulting to `None`. All existing orchestration blocks, environment mappings, metadata payloads, and progress streams remain 100% backward compatible and unaffected.

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed) — *Updated function signatures and tool schema definitions*
- [x] Added/updated tests (if needed)
- [x] Security impact considered — *Volume mounting isolation boundaries match upstream engine policies*
- [x] Backward compatibility considered