### PR TITLE
fix(k8s): use call_api for patch_pvc — _headers and _content_type both unsupported

### DIFF
--- a/server/opensandbox_server/services/k8s/client.py
+++ b/server/opensandbox_server/services/k8s/client.py
@@ -367,14 +367,24 @@ class K8sClient:
         default (first entry in the generated content-type list) which would
         reject our merge-shaped body. Force strategic-merge so list fields
         like ``ownerReferences`` merge by key.
+
+        Uses ``api_client.call_api`` instead of the generated method because
+        the deployed kubernetes-client (pre-OpenAPI-generator) does not
+        support ``_headers`` or ``_content_type`` kwargs on the generated
+        ``patch_namespaced_persistent_volume_claim``.  ``call_api`` accepts
+        ``header_params`` in all versions.
         """
         if self._write_limiter:
             self._write_limiter.acquire()
-        return self.get_core_v1_api().patch_namespaced_persistent_volume_claim(
-            name=name,
-            namespace=namespace,
+        api = self.get_core_v1_api()
+        return api.api_client.call_api(
+            "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}",
+            "PATCH",
+            path_params={"name": name, "namespace": namespace},
+            header_params={"Content-Type": "application/strategic-merge-patch+json"},
             body=body,
-            _content_type="application/strategic-merge-patch+json",
+            auth_settings=["BearerToken"],
+            _return_http_data_only=True,
         )
 
     # ------------------------------------------------------------------

--- a/server/tests/k8s/test_k8s_client.py
+++ b/server/tests/k8s/test_k8s_client.py
@@ -398,11 +398,14 @@ class TestK8sClient:
         c = self._make_client(k8s_runtime_config)
         body = {"metadata": {"ownerReferences": [{"name": "x"}]}}
         c.patch_pvc("ns", "pvc-a", body)
-        c._core_v1_api.patch_namespaced_persistent_volume_claim.assert_called_once_with(
-            name="pvc-a",
-            namespace="ns",
+        c._core_v1_api.api_client.call_api.assert_called_once_with(
+            "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}",
+            "PATCH",
+            path_params={"name": "pvc-a", "namespace": "ns"},
+            header_params={"Content-Type": "application/strategic-merge-patch+json"},
             body=body,
-            _content_type="application/strategic-merge-patch+json",
+            auth_settings=["BearerToken"],
+            _return_http_data_only=True,
         )
 
     def test_create_secret_delegates_to_api(self, k8s_runtime_config):


### PR DESCRIPTION
## 问题

`_attach_pvc_owner_references` 在给自动创建的 PVC 附加 `ownerReferences` 时失败，导致 K8s GC 无法级联删除 PVC。

## 修复历程

1. **_content_type** -> 生产环境 kubernetes-client（旧版）不支持该参数
2. **_headers** -> 同样不支持，旧版 OpenAPI 生成器不生成任何下划线参数
3. **ApiClient.call_api() + header_params + auth_settings** -> 最终方案

`call_api` 是 kubernetes-client 最底层的方法，`header_params` 在所有版本中均受支持。需同时指定 `auth_settings=['BearerToken']`，否则请求以 `system:anonymous` 身份发送导致 403 Forbidden。

Fixes #1199

## 测试

```
tests/k8s/test_k8s_client.py ........... 43 passed
```