### PR TITLE
feat(snapshots): expose imageUri end-to-end (spec, server, all SDKs)

### DIFF
--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/SandboxesAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/SandboxesAdapter.cs
@@ -418,7 +418,10 @@ internal sealed class SandboxesAdapter : ISandboxes
                     ? ParseIsoDate("lastTransitionAt", lastTransitionAt)
                     : null
             },
-            CreatedAt = ParseIsoDate("createdAt", element.GetProperty("createdAt"))
+            CreatedAt = ParseIsoDate("createdAt", element.GetProperty("createdAt")),
+            ImageUri = element.TryGetProperty("imageUri", out var imageUri) && imageUri.ValueKind != JsonValueKind.Null
+                ? imageUri.GetString()
+                : null
         };
     }
 

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
@@ -974,6 +974,13 @@ public class SnapshotInfo
 
     [JsonPropertyName("createdAt")]
     public required DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Portable OCI image reference for a Ready snapshot, usable to restore a sandbox (e.g. across
+    /// clusters). Populated once the snapshot is Ready; null otherwise.
+    /// </summary>
+    [JsonPropertyName("imageUri")]
+    public string? ImageUri { get; set; }
 }
 
 /// <summary>

--- a/sdks/sandbox/go/types.go
+++ b/sdks/sandbox/go/types.go
@@ -202,6 +202,9 @@ type SnapshotInfo struct {
 	Name      string         `json:"name,omitempty"`
 	Status    SnapshotStatus `json:"status"`
 	CreatedAt time.Time      `json:"createdAt"`
+	// ImageURI is the portable OCI image reference for a Ready snapshot, usable to restore a
+	// sandbox (e.g. across clusters). Populated once the snapshot is Ready; empty otherwise.
+	ImageURI string `json:"imageUri,omitempty"`
 }
 
 type CreateSnapshotRequest struct {

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -818,6 +818,8 @@ export interface components {
              * @description Snapshot creation timestamp
              */
             createdAt: string;
+            /** @description Portable OCI image reference produced for a Ready snapshot, usable to restore a sandbox (e.g. across clusters). Present once the snapshot reaches the Ready state; omitted otherwise. */
+            imageUri?: string;
         };
         /**
          * @description Snapshot lifecycle state.

--- a/sdks/sandbox/javascript/src/models/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/models/sandboxes.ts
@@ -509,6 +509,11 @@ export interface SnapshotInfo extends Record<string, unknown> {
   name?: string;
   status: SnapshotStatus;
   createdAt: Date;
+  /**
+   * Portable OCI image reference for a Ready snapshot, usable to restore a sandbox (e.g. across
+   * clusters). Populated once the snapshot is Ready; absent otherwise.
+   */
+  imageUri?: string;
 }
 
 export interface CreateSnapshotRequest extends Record<string, unknown> {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
@@ -794,7 +794,29 @@ class SnapshotInfo(
     val name: String? = null,
     val status: SnapshotStatus,
     val createdAt: OffsetDateTime,
-)
+    /**
+     * Portable OCI image reference for a Ready snapshot, usable to restore a sandbox (e.g. across
+     * clusters). Populated once the snapshot reaches [SnapshotState.READY]; null otherwise.
+     */
+    val imageUri: String? = null,
+) {
+    /**
+     * Binary-compatibility constructor preserving the pre-`imageUri` JVM signatures for
+     * already-compiled callers; delegates [imageUri] to null.
+     *
+     * The default on [name] is deliberate: it makes the compiler emit the old
+     * `(String, String, String?, SnapshotStatus, OffsetDateTime, int, DefaultConstructorMarker)`
+     * synthetic `$default` constructor, so Kotlin call sites compiled against the previous
+     * `SnapshotInfo` that omitted `name` keep resolving instead of hitting `NoSuchMethodError`.
+     */
+    constructor(
+        id: String,
+        sandboxId: String,
+        name: String? = null,
+        status: SnapshotStatus,
+        createdAt: OffsetDateTime,
+    ) : this(id, sandboxId, name, status, createdAt, null)
+}
 
 class SnapshotFilter private constructor(
     val sandboxId: String?,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
@@ -410,6 +410,7 @@ internal object SandboxModelConverter {
                     lastTransitionAt = this.status.lastTransitionAt,
                 ),
             createdAt = this.createdAt,
+            imageUri = this.imageUri,
         )
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
@@ -369,7 +369,8 @@ class SandboxesAdapterTest {
                     "message": null,
                     "lastTransitionAt": "2023-01-01T10:00:00Z"
                 },
-                "createdAt": "2023-01-01T10:00:00Z"
+                "createdAt": "2023-01-01T10:00:00Z",
+                "imageUri": "registry.example.com/snapshots/snap-123:latest"
             }
             """.trimIndent()
         mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(200))
@@ -378,6 +379,7 @@ class SandboxesAdapterTest {
 
         assertEquals(snapshotId, result.id)
         assertEquals("sandbox-123", result.sandboxId)
+        assertEquals("registry.example.com/snapshots/snap-123:latest", result.imageUri)
 
         val request = mockWebServer.takeRequest()
         assertEquals("GET", request.method)

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
@@ -537,6 +537,10 @@ class SandboxModelConverter:
         if isinstance(name, Unset):
             name = None
 
+        image_uri = api_snapshot.image_uri
+        if isinstance(image_uri, Unset):
+            image_uri = None
+
         return SnapshotInfo(
             id=api_snapshot.id,
             sandbox_id=api_snapshot.sandbox_id,
@@ -548,6 +552,7 @@ class SandboxModelConverter:
                 last_transition_at=last_transition_at,
             ),
             created_at=api_snapshot.created_at,
+            image_uri=image_uri,
         )
 
     @staticmethod

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/snapshot.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/snapshot.py
@@ -42,6 +42,8 @@ class Snapshot:
         status (SnapshotStatus): Detailed snapshot status information with lifecycle state and transition details.
         created_at (datetime.datetime): Snapshot creation timestamp
         name (str | Unset): Optional human-readable snapshot name
+        image_uri (str | Unset): Portable OCI image reference produced for a Ready snapshot, usable to restore a sandbox
+            (e.g. across clusters). Present once the snapshot reaches the Ready state; omitted otherwise.
     """
 
     id: str
@@ -49,6 +51,7 @@ class Snapshot:
     status: SnapshotStatus
     created_at: datetime.datetime
     name: str | Unset = UNSET
+    image_uri: str | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         id = self.id
@@ -60,6 +63,8 @@ class Snapshot:
         created_at = self.created_at.isoformat()
 
         name = self.name
+
+        image_uri = self.image_uri
 
         field_dict: dict[str, Any] = {}
 
@@ -73,6 +78,8 @@ class Snapshot:
         )
         if name is not UNSET:
             field_dict["name"] = name
+        if image_uri is not UNSET:
+            field_dict["imageUri"] = image_uri
 
         return field_dict
 
@@ -91,12 +98,15 @@ class Snapshot:
 
         name = d.pop("name", UNSET)
 
+        image_uri = d.pop("imageUri", UNSET)
+
         snapshot = cls(
             id=id,
             sandbox_id=sandbox_id,
             status=status,
             created_at=created_at,
             name=name,
+            image_uri=image_uri,
         )
 
         return snapshot

--- a/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
+++ b/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
@@ -618,6 +618,14 @@ class SnapshotInfo(BaseModel):
     name: str | None = Field(default=None, description="Optional snapshot name")
     status: SnapshotStatus = Field(description="Current status of the snapshot")
     created_at: datetime = Field(description="Creation timestamp", alias="created_at")
+    image_uri: str | None = Field(
+        default=None,
+        alias="image_uri",
+        description=(
+            "Portable OCI image reference for a Ready snapshot, usable to restore a sandbox "
+            "(e.g. across clusters). Populated once the snapshot is Ready; None otherwise."
+        ),
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -672,6 +672,14 @@ class Snapshot(BaseModel):
         alias="createdAt",
         description="Snapshot creation timestamp",
     )
+    image_uri: Optional[str] = Field(
+        None,
+        alias="imageUri",
+        description=(
+            "Portable OCI image reference produced for a Ready snapshot, usable to restore a "
+            "sandbox (e.g. across clusters). Present once the snapshot is Ready; omitted otherwise."
+        ),
+    )
 
     class Config:
         populate_by_name = True

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -549,6 +549,13 @@ class PersistedSnapshotService(SnapshotService):
                 lastTransitionAt=record.status.last_transition_at,
             ),
             createdAt=record.created_at,
+            # The restore image is part of the contract only once the snapshot is Ready; never
+            # surface it for Creating/Deleting/Failed states (e.g. after deletion is requested).
+            imageUri=(
+                record.restore_config.image
+                if record.status.state == SnapshotState.READY
+                else None
+            ),
         )
 
 

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -124,6 +124,16 @@ def _snapshot_record(
     )
 
 
+def test_snapshot_response_exposes_image_uri_only_when_ready() -> None:
+    image = "opensandbox-snapshots:snap-1"
+    ready = _snapshot_record("snap-ready", SnapshotState.READY, image=image)
+    deleting = _snapshot_record("snap-deleting", SnapshotState.DELETING, image=image)
+
+    assert PersistedSnapshotService._to_snapshot_response(ready).image_uri == image
+    # Once deletion is requested (or any non-Ready state), the restore image must not leak.
+    assert PersistedSnapshotService._to_snapshot_response(deleting).image_uri is None
+
+
 def test_snapshot_service_persists_create_and_get(tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     runtime = StubSnapshotRuntime()
@@ -220,6 +230,10 @@ def test_snapshot_service_marks_snapshot_ready_from_worker(tmp_path) -> None:
     assert stored is not None
     assert stored.status.state == SnapshotState.READY
     assert stored.restore_config.image == "opensandbox-snapshots:snap-ready"
+
+    # The Ready snapshot response exposes the portable restore image via imageUri.
+    response = service.get_snapshot(created.id)
+    assert response.image_uri == "opensandbox-snapshots:snap-ready"
 
 
 def test_snapshot_service_marks_snapshot_failed_from_worker(tmp_path) -> None:

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -915,6 +915,12 @@ components:
           format: date-time
           description: Snapshot creation timestamp
 
+        imageUri:
+          type: string
+          description: >-
+            Portable OCI image reference produced for a Ready snapshot, usable to restore a sandbox
+            (e.g. across clusters). Present once the snapshot reaches the Ready state; omitted otherwise.
+
       required:
         - id
         - sandboxId


### PR DESCRIPTION
# Summary

Closes #1271.

In our organization we integrate with OpenSandbox through the official SDKs rather than calling the REST API directly — the typed client is our integration contract. When a field is missing from the SDK we are forced to drop down to raw HTTP, which adds complexity and couples our code to the wire protocol, hurting maintainability.

A `Ready` snapshot already produces a portable OCI restore image internally, but it is never surfaced on the public snapshot contract, so callers cannot restore a sandbox from that image (e.g. to move a sandbox across clusters) through the SDK without bypassing it. This exposes it end-to-end as `imageUri`, across the spec, the server, and **all SDKs**.

> Per the Codex review on the earlier revision (which flagged that only the server + Kotlin were updated, leaving the other SDK snapshot models inconsistent), this now regenerates/updates **every** SDK. Commits are split by concern — one for spec + server, then one per SDK.

**Spec**

- Add the optional `imageUri` to the `Snapshot` schema in `specs/sandbox-lifecycle.yml`.

**Server**

- Add `image_uri`/`imageUri` to the `Snapshot` response model and populate it from the record's restore image in `_to_snapshot_response`, only once the snapshot is `Ready`.

**Generated clients** (regenerated from the spec, not hand-edited)

- **python**: regenerated the lifecycle `Snapshot` model with `scripts/generate_api.py` (openapi-python-client); mapped onto the domain `SnapshotInfo` in the converter.
- **javascript**: regenerated `api/lifecycle.ts` with `pnpm gen:api` (openapi-typescript); added `imageUri` to the domain snapshot model.
- **kotlin**: the lifecycle client regenerates from the spec at build time (`sandbox-api` OpenAPI generator); added `imageUri` to the domain `SnapshotInfo` and mapped it in `SandboxModelConverter`.

**Hand-written clients** (no spec codegen — field added by hand)

- **go**: the lifecycle types are hand-written, so the field was added directly to `types.go` (`ImageURI string` with `json:"imageUri,omitempty"`).
- **csharp**: the snapshot model is hand-written, so `Models/Sandboxes.cs` gets `string? ImageUri` and `Adapters/SandboxesAdapter.cs` parses `imageUri` from the response JSON.

`imageUri` is optional and only populated once the snapshot is `Ready` (null/omitted otherwise), so the change is additive and backward compatible.

## Commits

1. `feat(snapshots): expose snapshot imageUri in spec and server`
2. `feat(python): expose snapshot imageUri in the Python SDK`
3. `feat(javascript): expose snapshot imageUri in the JavaScript SDK`
4. `feat(kotlin): expose snapshot imageUri in the Kotlin SDK`
5. `feat(go): expose snapshot imageUri in the Go SDK`
6. `feat(csharp): expose snapshot imageUri in the C# SDK`

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

- **server**: `uv run pytest tests/test_snapshot_service.py` — asserts the response exposes `imageUri` only when `Ready`. Green.
- **kotlin**: `./gradlew spotlessCheck :sandbox:test` — `SandboxesAdapterTest.getSnapshot` parses `imageUri`; the lifecycle client regenerated from the spec exposes the field. Green.
- **csharp**: `dotnet build` + `dotnet test` — 132 passed.
- **javascript**: `pnpm run typecheck` green; `api/lifecycle.ts` regenerated from the spec.
- **python**: `ruff check` clean; lifecycle `Snapshot` regenerated via `scripts/generate_api.py`.
- **go**: hand-written field; the SDK has no codegen step.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

Additive optional field; null/omitted unless the snapshot is `Ready`.

# Checklist

- [x] Linked Issue or clearly described motivation — #1271
- [x] Added/updated tests (if needed)
- [x] Security impact considered — exposes the OCI restore image reference the caller needs to restore; gated on `Ready`, no new privileged data
- [x] Backward compatibility considered — additive optional field
