### PR TITLE
feat(execd): add bounded command inventory

### DIFF
--- a/.github/workflows/execd-test.yml
+++ b/.github/workflows/execd-test.yml
@@ -114,8 +114,18 @@ jobs:
           chmod +x tests/smoke.sh
           ./tests/smoke.sh
 
-          sleep 5
-          python3 tests/smoke_api.py
+      - name: Run command inventory cap retention smoke
+        working-directory: components/execd
+        run: EXECD_COMMAND_RECOVERY_TTL=1h EXECD_COMMAND_RECOVERY_MAX_TERMINAL=2 ./tests/smoke.sh --inventory-cap
+
+      - name: Run command inventory expiry retention smoke
+        working-directory: components/execd
+        run: EXECD_COMMAND_RECOVERY_TTL=2s EXECD_COMMAND_RECOVERY_MAX_TERMINAL=1000 ./tests/smoke.sh --inventory-expiry
+
+      - name: Run Windows command inventory lifecycle tests
+        if: matrix.os == 'windows-latest'
+        working-directory: components/execd
+        run: go test ./pkg/runtime -run '^(TestCommandInventoryWindows|TestCommandInventorySafePoint|TestCommandInventoryStartFailure)$' -count=1
       - name: SIGTERM forward test
         if: matrix.os == 'ubuntu-latest'
         working-directory: components/execd
@@ -215,10 +225,27 @@ jobs:
         working-directory: components/execd
         run: sudo -E env "PATH=$PATH" go test -tags="linux,bwrap" -v -count=1 -timeout=5m ./pkg/runtime/bwrap_test/
 
+  inventory-race:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.9'
+
+      - name: Run command inventory race tests
+        working-directory: components/execd
+        run: go test -race ./pkg/runtime/... -run 'TestCommandInventory'
+
   required:
     name: Execd CI
     if: always()
-    needs: [changes, test, smoke, bwrap-smoke]
+    needs: [changes, test, smoke, bwrap-smoke, inventory-race]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
@@ -228,13 +255,14 @@ jobs:
           TEST_RESULT: ${{ needs.test.result }}
           SMOKE_RESULT: ${{ needs.smoke.result }}
           BWRAP_SMOKE_RESULT: ${{ needs.bwrap-smoke.result }}
+          INVENTORY_RACE_RESULT: ${{ needs.inventory-race.result }}
         run: |
           if [[ "$CHANGES_RESULT" != "success" ]]; then
             echo "Change detection failed: $CHANGES_RESULT"
             exit 1
           fi
           if [[ "$RELEVANT" == "true" ]]; then
-            [[ "$TEST_RESULT" == "success" && "$SMOKE_RESULT" == "success" && "$BWRAP_SMOKE_RESULT" == "success" ]]
+            [[ "$TEST_RESULT" == "success" && "$SMOKE_RESULT" == "success" && "$BWRAP_SMOKE_RESULT" == "success" && "$INVENTORY_RACE_RESULT" == "success" ]]
           else
-            [[ "$RELEVANT" == "false" && "$TEST_RESULT" == "skipped" && "$SMOKE_RESULT" == "skipped" && "$BWRAP_SMOKE_RESULT" == "skipped" ]]
+            [[ "$RELEVANT" == "false" && "$TEST_RESULT" == "skipped" && "$SMOKE_RESULT" == "skipped" && "$BWRAP_SMOKE_RESULT" == "skipped" && "$INVENTORY_RACE_RESULT" == "skipped" ]]
           fi

--- a/components/execd/go.mod
+++ b/components/execd/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.2
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/stretchr/testify v1.11.1
+	github.com/tidwall/btree v1.8.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.uber.org/automaxprocs v1.6.0

--- a/components/execd/go.sum
+++ b/components/execd/go.sum
@@ -108,6 +108,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
+github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/components/execd/pkg/flag/flags.go
+++ b/components/execd/pkg/flag/flags.go
@@ -42,4 +42,10 @@ var (
 	// IsolationConfigPath points to the TOML isolation config file.
 	// Empty means use built-in defaults.
 	IsolationConfigPath string
+
+	// CommandRecoveryTTL controls retention of completed command summaries.
+	CommandRecoveryTTL time.Duration
+
+	// CommandRecoveryMaxTerminal caps retained completed command summaries.
+	CommandRecoveryMaxTerminal int
 )

--- a/components/execd/pkg/flag/parser.go
+++ b/components/execd/pkg/flag/parser.go
@@ -16,8 +16,10 @@ package flag
 
 import (
 	"flag"
+	"fmt"
 	stdlog "log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -31,6 +33,11 @@ const (
 	gracefulShutdownTimeoutEnv = "EXECD_API_GRACE_SHUTDOWN"
 	jupyterIdlePollIntervalEnv = "EXECD_JUPYTER_IDLE_POLL_INTERVAL"
 	isolationConfigEnv         = "EXECD_ISOLATION_CONFIG"
+	commandRecoveryTTLEnv      = "EXECD_COMMAND_RECOVERY_TTL"
+	commandRecoveryMaxEnv      = "EXECD_COMMAND_RECOVERY_MAX_TERMINAL"
+	defaultCommandRecoveryTTL  = time.Hour
+	defaultCommandRecoveryMax  = 1000
+	maxCommandRecoveryTerminal = 10000
 )
 
 // InitFlags registers CLI flags and env overrides.
@@ -42,6 +49,8 @@ func InitFlags() {
 	ApiGracefulShutdownTimeout = time.Second * 1
 	JupyterIdlePollInterval = 100 * time.Millisecond
 	IsolationConfigPath = ""
+	CommandRecoveryTTL = defaultCommandRecoveryTTL
+	CommandRecoveryMaxTerminal = defaultCommandRecoveryMax
 
 	// First, set default values from environment variables
 	if jupyterFromEnv := os.Getenv(jupyterHostEnv); jupyterFromEnv != "" {
@@ -86,8 +95,15 @@ func InitFlags() {
 		}
 	}
 
+	CommandRecoveryTTL = commandRecoveryTTLFromEnv()
+	CommandRecoveryMaxTerminal = commandRecoveryMaxFromEnv()
+
 	flag.DurationVar(&ApiGracefulShutdownTimeout, "graceful-shutdown-timeout", ApiGracefulShutdownTimeout, "API graceful shutdown timeout duration (default: 1s)")
 	flag.DurationVar(&JupyterIdlePollInterval, "jupyter-idle-poll-interval", JupyterIdlePollInterval, "Polling interval after Jupyter idle status before closing stream (default: 100ms)")
+	commandRecoveryTTLFlag := commandRecoveryTTLValue{value: &CommandRecoveryTTL}
+	commandRecoveryMaxFlag := commandRecoveryMaxValue{value: &CommandRecoveryMaxTerminal}
+	flag.Var(&commandRecoveryTTLFlag, "command-recovery-ttl", "Retention duration for completed command summaries (default: 1h)")
+	flag.Var(&commandRecoveryMaxFlag, "command-recovery-max-terminal", "Maximum retained completed command summaries (default: 1000)")
 
 	// Isolation config
 	if v := os.Getenv(isolationConfigEnv); v != "" {
@@ -97,6 +113,12 @@ func InitFlags() {
 
 	// Parse flags - these will override environment variables if provided
 	flag.Parse()
+	if commandRecoveryTTLFlag.err != nil {
+		stdlog.Panicf("Invalid --command-recovery-ttl: %v", commandRecoveryTTLFlag.err)
+	}
+	if commandRecoveryMaxFlag.err != nil {
+		stdlog.Panicf("Invalid --command-recovery-max-terminal: %v", commandRecoveryMaxFlag.err)
+	}
 	if JupyterIdlePollInterval <= 0 {
 		stdlog.Printf("Invalid --jupyter-idle-poll-interval=%s; fallback to default %s", JupyterIdlePollInterval, 100*time.Millisecond)
 		JupyterIdlePollInterval = 100 * time.Millisecond
@@ -105,4 +127,87 @@ func InitFlags() {
 	// Log final values
 	log.Info("Jupyter server host is: %s", JupyterServerHost)
 	log.Info("Jupyter server token is: %s", log.MaskToken(JupyterServerToken))
+}
+
+func commandRecoveryTTLFromEnv() time.Duration {
+	value, present := os.LookupEnv(commandRecoveryTTLEnv)
+	if !present {
+		return CommandRecoveryTTL
+	}
+	if value == "" {
+		stdlog.Panicf("Invalid %s: value must not be empty", commandRecoveryTTLEnv)
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil || duration < 0 {
+		stdlog.Panicf("Invalid %s=%q: must be a non-negative duration", commandRecoveryTTLEnv, value)
+	}
+	return duration
+}
+
+func commandRecoveryMaxFromEnv() int {
+	value, present := os.LookupEnv(commandRecoveryMaxEnv)
+	if !present {
+		return CommandRecoveryMaxTerminal
+	}
+	if value == "" {
+		stdlog.Panicf("Invalid %s: value must not be empty", commandRecoveryMaxEnv)
+	}
+	max, err := parseCommandRecoveryMax(value)
+	if err != nil {
+		stdlog.Panicf("Invalid %s=%q: %v", commandRecoveryMaxEnv, value, err)
+	}
+	return max
+}
+
+type commandRecoveryTTLValue struct {
+	value *time.Duration
+	err   error
+}
+
+func (v *commandRecoveryTTLValue) String() string {
+	return v.value.String()
+}
+
+func (v *commandRecoveryTTLValue) Set(value string) error {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		v.err = err
+		return nil
+	}
+	if duration < 0 {
+		v.err = fmt.Errorf("must be a non-negative duration")
+		return nil
+	}
+	*v.value = duration
+	return nil
+}
+
+type commandRecoveryMaxValue struct {
+	value *int
+	err   error
+}
+
+func (v *commandRecoveryMaxValue) String() string {
+	return strconv.Itoa(*v.value)
+}
+
+func (v *commandRecoveryMaxValue) Set(value string) error {
+	max, err := parseCommandRecoveryMax(value)
+	if err != nil {
+		v.err = err
+		return nil
+	}
+	*v.value = max
+	return nil
+}
+
+func parseCommandRecoveryMax(value string) (int, error) {
+	max, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, err
+	}
+	if max < 0 || max > maxCommandRecoveryTerminal {
+		return 0, fmt.Errorf("must be between 0 and %d", maxCommandRecoveryTerminal)
+	}
+	return max, nil
 }

--- a/components/execd/pkg/flag/parser_test.go
+++ b/components/execd/pkg/flag/parser_test.go
@@ -71,3 +71,116 @@ func TestInitFlagsCliOverridesEnvAccessToken(t *testing.T) {
 
 	require.Equal(t, "cli-token", ServerAccessToken)
 }
+
+func TestCommandRecoveryDefaults(t *testing.T) {
+	withCommandRecoveryFlagState(t, nil, nil, func() {
+		InitFlags()
+
+		require.Equal(t, time.Hour, CommandRecoveryTTL)
+		require.Equal(t, 1000, CommandRecoveryMaxTerminal)
+	})
+}
+
+func TestCommandRecoveryEnvDefaultsAndCLIOverrides(t *testing.T) {
+	withCommandRecoveryFlagState(t, map[string]string{
+		"EXECD_COMMAND_RECOVERY_TTL":          "30m",
+		"EXECD_COMMAND_RECOVERY_MAX_TERMINAL": "42",
+	}, nil, func() {
+		InitFlags()
+
+		require.Equal(t, 30*time.Minute, CommandRecoveryTTL)
+		require.Equal(t, 42, CommandRecoveryMaxTerminal)
+	})
+
+	withCommandRecoveryFlagState(t, map[string]string{
+		"EXECD_COMMAND_RECOVERY_TTL":          "30m",
+		"EXECD_COMMAND_RECOVERY_MAX_TERMINAL": "42",
+	}, []string{"--command-recovery-ttl=0", "--command-recovery-max-terminal=0"}, func() {
+		InitFlags()
+
+		require.Zero(t, CommandRecoveryTTL)
+		require.Zero(t, CommandRecoveryMaxTerminal)
+	})
+}
+
+func TestCommandRecoveryAcceptsZeroEnvironmentAndMaximumCap(t *testing.T) {
+	withCommandRecoveryFlagState(t, map[string]string{
+		"EXECD_COMMAND_RECOVERY_TTL":          "0",
+		"EXECD_COMMAND_RECOVERY_MAX_TERMINAL": "10000",
+	}, nil, func() {
+		InitFlags()
+
+		require.Zero(t, CommandRecoveryTTL)
+		require.Equal(t, 10000, CommandRecoveryMaxTerminal)
+	})
+}
+
+func TestCommandRecoveryRejectsInvalidEnvironment(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		env  map[string]string
+	}{
+		{name: "empty TTL", env: map[string]string{"EXECD_COMMAND_RECOVERY_TTL": ""}},
+		{name: "malformed TTL", env: map[string]string{"EXECD_COMMAND_RECOVERY_TTL": "tomorrow"}},
+		{name: "negative TTL", env: map[string]string{"EXECD_COMMAND_RECOVERY_TTL": "-1s"}},
+		{name: "empty cap", env: map[string]string{"EXECD_COMMAND_RECOVERY_MAX_TERMINAL": ""}},
+		{name: "malformed cap", env: map[string]string{"EXECD_COMMAND_RECOVERY_MAX_TERMINAL": "many"}},
+		{name: "negative cap", env: map[string]string{"EXECD_COMMAND_RECOVERY_MAX_TERMINAL": "-1"}},
+		{name: "oversized cap", env: map[string]string{"EXECD_COMMAND_RECOVERY_MAX_TERMINAL": "10001"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			withCommandRecoveryFlagState(t, test.env, nil, func() {
+				require.Panics(t, InitFlags)
+			})
+		})
+	}
+}
+
+func TestCommandRecoveryRejectsInvalidCLIValues(t *testing.T) {
+	for _, args := range [][]string{
+		{"--command-recovery-ttl="},
+		{"--command-recovery-ttl=tomorrow"},
+		{"--command-recovery-ttl=-1s"},
+		{"--command-recovery-max-terminal="},
+		{"--command-recovery-max-terminal=many"},
+		{"--command-recovery-max-terminal=-1"},
+		{"--command-recovery-max-terminal=10001"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			withCommandRecoveryFlagState(t, nil, args, func() {
+				require.Panics(t, InitFlags)
+			})
+		})
+	}
+}
+
+func withCommandRecoveryFlagState(t *testing.T, env map[string]string, args []string, test func()) {
+	t.Helper()
+	previousArgs := os.Args
+	previousCommandLine := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	os.Args = []string{previousArgs[0]}
+	os.Args = append(os.Args, args...)
+	t.Cleanup(func() {
+		os.Args = previousArgs
+		flag.CommandLine = previousCommandLine
+	})
+
+	for _, name := range []string{"EXECD_COMMAND_RECOVERY_TTL", "EXECD_COMMAND_RECOVERY_MAX_TERMINAL"} {
+		previous, present := os.LookupEnv(name)
+		if value, ok := env[name]; ok {
+			require.NoError(t, os.Setenv(name, value))
+		} else {
+			require.NoError(t, os.Unsetenv(name))
+		}
+		t.Cleanup(func() {
+			if present {
+				require.NoError(t, os.Setenv(name, previous))
+				return
+			}
+			require.NoError(t, os.Unsetenv(name))
+		})
+	}
+
+	test()
+}

--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -202,6 +202,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	}
 	c.storeCommandKernel(session, kernel)
 	request.Hooks.OnExecuteInit(session)
+	c.registerCommandKernelRunning(session, kernel)
 
 	safego.Go(func() {
 		for {
@@ -273,12 +274,14 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 		})
 
 		log.Error("CommandExecError: error running commands: %v", err)
-		c.markCommandFinished(session, eCode, err.Error())
+		snapshot := c.markCommandFinished(session, eCode, err.Error())
+		c.transitionCommandTerminalSnapshot(snapshot)
 		return nil
 	}
 
-	c.markCommandFinished(session, 0, "")
+	snapshot := c.markCommandFinished(session, 0, "")
 	request.Hooks.OnExecuteComplete(time.Since(startAt))
+	c.transitionCommandTerminalSnapshot(snapshot)
 	return nil
 }
 
@@ -359,6 +362,7 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	// handler could return before the kernel was stored.
 	kernel.pid = cmd.Process.Pid
 	c.storeCommandKernel(session, kernel)
+	c.registerCommandKernelRunning(session, kernel)
 
 	safego.Go(func() {
 		defer pipe.Close()
@@ -372,10 +376,12 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 			if errors.As(err, &exitError) {
 				exitCode = exitError.ExitCode()
 			}
-			c.markCommandFinished(session, exitCode, err.Error())
+			snapshot := c.markCommandFinished(session, exitCode, err.Error())
+			c.transitionCommandTerminalSnapshot(snapshot)
 			return
 		}
-		c.markCommandFinished(session, 0, "")
+		snapshot := c.markCommandFinished(session, 0, "")
+		c.transitionCommandTerminalSnapshot(snapshot)
 	})
 
 	// ensure we kill the whole process group if the context is cancelled (e.g., timeout).

--- a/components/execd/pkg/runtime/command_inventory.go
+++ b/components/execd/pkg/runtime/command_inventory.go
@@ -1,0 +1,726 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/tidwall/btree"
+
+	"github.com/alibaba/opensandbox/execd/pkg/log"
+)
+
+const (
+	commandCursorVersion    = 1
+	commandCursorSort       = "started_at_desc_session_desc"
+	commandCursorMaxEncoded = 1366
+	commandCursorMaxDecoded = 1024
+	commandListDefaultLimit = 100
+	commandListMaxExamined  = 128
+	commandCleanupLimit     = 128
+)
+
+type commandCursorFilter string
+
+const (
+	commandCursorFilterAll      commandCursorFilter = "all"
+	commandCursorFilterRunning  commandCursorFilter = "running"
+	commandCursorFilterTerminal commandCursorFilter = "terminal"
+)
+
+// ListCommandsRequest selects command inventory summaries.
+type ListCommandsRequest struct {
+	Running *bool
+	Limit   int
+	Cursor  string
+}
+
+// CommandSummary is a snapshot of a command inventory entry.
+type CommandSummary struct {
+	Session    string
+	Running    bool
+	Background bool
+	StartedAt  time.Time
+	FinishedAt *time.Time
+	ExitCode   *int
+	Error      string
+}
+
+// ListCommandsResponse contains a command inventory page.
+type ListCommandsResponse struct {
+	Commands   []CommandSummary
+	Pagination CommandPagination
+}
+
+// CommandPagination describes command inventory page traversal.
+type CommandPagination struct {
+	Limit      int
+	NextCursor *string
+}
+
+type commandCursor struct {
+	Version  int                 `json:"version"`
+	Process  string              `json:"process"`
+	Filter   commandCursorFilter `json:"filter"`
+	Sort     string              `json:"sort"`
+	Frontier *commandCursorKey   `json:"frontier,omitempty"`
+}
+
+type commandCursorKey struct {
+	StartedAtUnixNano *int64 `json:"started_at_unix_nano"`
+	Session           string `json:"session"`
+}
+
+// inventoryEntry is an immutable snapshot of a command's inventory state.
+type inventoryEntry struct {
+	session          string
+	running          bool
+	background       bool
+	startedAt        time.Time
+	finishedAt       *time.Time
+	exitCode         *int
+	errMsg           string
+	terminalSequence uint64
+	indexSession     string
+	indexStartedAt   int64
+}
+
+// commandTerminalSnapshot is a value copy of the legacy command state at exit.
+// It may be consumed only after Controller.mu has been released.
+type commandTerminalSnapshot struct {
+	session    string
+	startedAt  time.Time
+	finishedAt time.Time
+	exitCode   int
+	errMsg     string
+	background bool
+}
+
+func inventoryEntryStartedLess(a, b *inventoryEntry) bool {
+	if a.startedAt.UnixNano() != b.startedAt.UnixNano() {
+		return a.startedAt.UnixNano() < b.startedAt.UnixNano()
+	}
+	return a.session < b.session
+}
+
+func inventoryEntryTerminalFinishedLess(a, b *inventoryEntry) bool {
+	if a.finishedAt.UnixNano() != b.finishedAt.UnixNano() {
+		return a.finishedAt.UnixNano() < b.finishedAt.UnixNano()
+	}
+	return a.terminalSequence < b.terminalSequence
+}
+
+func (c *Controller) registerRunningCommand(summary inventoryEntry) error {
+	if !summary.running {
+		return fmt.Errorf("command inventory invariant: running entry is not running")
+	}
+
+	c.inventoryMu.Lock()
+	defer c.inventoryMu.Unlock()
+
+	if _, ok := c.bySession[summary.session]; ok {
+		return fmt.Errorf("command inventory invariant: session %q already exists", summary.session)
+	}
+
+	entry := &inventoryEntry{
+		session:        summary.session,
+		running:        true,
+		background:     summary.background,
+		startedAt:      summary.startedAt,
+		indexSession:   summary.session,
+		indexStartedAt: summary.startedAt.UnixNano(),
+	}
+	if err := ensureIndexAbsent(c.runningByStartedAt, entry, "running start"); err != nil {
+		return err
+	}
+	if previous, replaced := c.runningByStartedAt.Set(entry); replaced {
+		c.runningByStartedAt.Set(previous)
+		return fmt.Errorf("command inventory invariant: running start index replaced %q", previous.session)
+	}
+	c.bySession[entry.session] = entry
+	return nil
+}
+
+func (c *Controller) registerRunningCommandSummary(summary inventoryEntry) {
+	if err := c.registerRunningCommand(summary); err != nil {
+		log.Error("command inventory registration failed: %v", err)
+	}
+}
+
+func (c *Controller) registerCommandKernelRunning(session string, kernel *commandKernel) {
+	c.registerRunningCommandSummary(inventoryEntry{
+		session:    session,
+		running:    true,
+		background: kernel.isBackground,
+		startedAt:  kernel.startedAt,
+	})
+}
+
+// transitionCommandTerminalSnapshot records a terminal inventory summary after
+// legacy command bookkeeping has released Controller.mu.
+func (c *Controller) transitionCommandTerminalSnapshot(snapshot commandTerminalSnapshot) {
+	if snapshot.session == "" {
+		return
+	}
+	finishedAt := snapshot.finishedAt
+	if err := c.transitionCommandTerminal(inventoryEntry{
+		session:    snapshot.session,
+		background: snapshot.background,
+		startedAt:  snapshot.startedAt,
+		finishedAt: &finishedAt,
+		exitCode:   &snapshot.exitCode,
+		errMsg:     snapshot.errMsg,
+	}); err != nil {
+		log.Error("command inventory terminal transition failed: %v", err)
+	}
+}
+
+func (c *Controller) transitionCommandTerminal(summary inventoryEntry) error {
+	c.inventoryMu.Lock()
+	defer c.inventoryMu.Unlock()
+
+	current, ok := c.bySession[summary.session]
+	if !ok {
+		return fmt.Errorf("command inventory invariant: session %q is absent", summary.session)
+	}
+	if !current.running {
+		return nil
+	}
+	if summary.running || summary.finishedAt == nil {
+		return fmt.Errorf("command inventory invariant: terminal entry is invalid")
+	}
+	if summary.background != current.background || !summary.startedAt.Equal(current.startedAt) {
+		return fmt.Errorf("command inventory invariant: terminal entry does not match running session %q", current.session)
+	}
+	if err := ensureIndexIdentity(c.runningByStartedAt, current, "running start"); err != nil {
+		return err
+	}
+
+	finishedAt := *summary.finishedAt
+	entry := &inventoryEntry{
+		session:          current.session,
+		background:       current.background,
+		startedAt:        current.startedAt,
+		finishedAt:       &finishedAt,
+		exitCode:         cloneExitCode(summary.exitCode),
+		errMsg:           summary.errMsg,
+		terminalSequence: c.terminalSequence + 1,
+		indexSession:     current.session,
+		indexStartedAt:   current.startedAt.UnixNano(),
+	}
+	if err := ensureIndexAbsent(c.terminalByStartedAt, entry, "terminal start"); err != nil {
+		return err
+	}
+	if err := ensureIndexAbsent(c.terminalByFinishedAt, entry, "terminal finish"); err != nil {
+		return err
+	}
+
+	if err := deleteInventoryEntry(c.runningByStartedAt, current, "running start"); err != nil {
+		return err
+	}
+	if previous, replaced := c.terminalByStartedAt.Set(entry); replaced {
+		c.terminalByStartedAt.Set(previous)
+		c.runningByStartedAt.Set(current)
+		return fmt.Errorf("command inventory invariant: terminal start index replaced %q", previous.session)
+	}
+	if previous, replaced := c.terminalByFinishedAt.Set(entry); replaced {
+		c.terminalByFinishedAt.Set(previous)
+		if _, deleted := c.terminalByStartedAt.Delete(entry); !deleted {
+			return fmt.Errorf("command inventory invariant: terminal start rollback failed for %q", entry.session)
+		}
+		c.runningByStartedAt.Set(current)
+		return fmt.Errorf("command inventory invariant: terminal finish index replaced %q", previous.session)
+	}
+	c.terminalSequence = entry.terminalSequence
+	c.bySession[entry.session] = entry
+
+	if c.commandInventoryConfig.RecoveryTTL <= 0 || c.commandInventoryConfig.MaxTerminal <= 0 {
+		if err := c.deleteTerminalLocked(entry); err != nil {
+			return err
+		}
+	} else if err := c.evictTerminalOverCapacityLocked(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) evictTerminalOverCapacityLocked() error {
+	maxTerminal := c.commandInventoryConfig.MaxTerminal
+	for c.terminalByFinishedAt.Len() > maxTerminal {
+		entry, ok := c.terminalByFinishedAt.Min()
+		if !ok {
+			return fmt.Errorf("command inventory invariant: terminal finish index is empty above capacity")
+		}
+		if err := c.deleteTerminalLocked(entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) deleteTerminalLocked(entry *inventoryEntry) error {
+	if c.bySession[entry.session] != entry {
+		return fmt.Errorf("command inventory invariant: session %q identity changed", entry.session)
+	}
+	if entry.running {
+		return fmt.Errorf("command inventory invariant: session %q is running", entry.session)
+	}
+	if err := ensureIndexIdentity(c.terminalByStartedAt, entry, "terminal start"); err != nil {
+		return err
+	}
+	if err := ensureIndexIdentity(c.terminalByFinishedAt, entry, "terminal finish"); err != nil {
+		return err
+	}
+	if err := deleteInventoryEntry(c.terminalByStartedAt, entry, "terminal start"); err != nil {
+		return err
+	}
+	if err := deleteInventoryEntry(c.terminalByFinishedAt, entry, "terminal finish"); err != nil {
+		if previous, replaced := c.terminalByStartedAt.Set(entry); replaced || previous != nil {
+			return fmt.Errorf("command inventory invariant: terminal start rollback failed for %q", entry.session)
+		}
+		return err
+	}
+	delete(c.bySession, entry.session)
+	return nil
+}
+
+func ensureIndexAbsent(index *btree.BTreeG[*inventoryEntry], entry *inventoryEntry, name string) error {
+	if existing, ok := index.Get(entry); ok {
+		return fmt.Errorf("command inventory invariant: %s index already contains %q", name, existing.session)
+	}
+	return nil
+}
+
+func ensureIndexIdentity(index *btree.BTreeG[*inventoryEntry], entry *inventoryEntry, name string) error {
+	stored, ok := index.Get(entry)
+	if !ok {
+		return fmt.Errorf("command inventory invariant: %s index is missing %q", name, entry.session)
+	}
+	if stored != entry {
+		return fmt.Errorf("command inventory invariant: %s index identity changed for %q", name, entry.session)
+	}
+	return nil
+}
+
+func deleteInventoryEntry(index *btree.BTreeG[*inventoryEntry], entry *inventoryEntry, name string) error {
+	deleted, ok := index.Delete(entry)
+	if !ok {
+		return fmt.Errorf("command inventory invariant: %s index is missing %q", name, entry.session)
+	}
+	if deleted != entry {
+		return fmt.Errorf("command inventory invariant: %s index identity changed for %q", name, entry.session)
+	}
+	return nil
+}
+
+func cloneExitCode(exitCode *int) *int {
+	if exitCode == nil {
+		return nil
+	}
+	cloned := *exitCode
+	return &cloned
+}
+
+// ListCommands returns a globally ordered page of inventory summaries. Entries
+// sort by started time and session in descending order.
+func (c *Controller) ListCommands(request ListCommandsRequest) (ListCommandsResponse, error) {
+	filter := commandFilterForRequest(request.Running)
+	cursor, err := c.parseCommandCursor(request.Cursor, filter)
+	if err != nil {
+		return ListCommandsResponse{}, err
+	}
+
+	limit := request.Limit
+	if limit <= 0 {
+		limit = commandListDefaultLimit
+	}
+	if limit > commandListMaxExamined {
+		limit = commandListMaxExamined
+	}
+
+	cleanupOwner := c.cleanupOwner.CompareAndSwap(false, true)
+	if cleanupOwner {
+		defer c.cleanupOwner.Store(false)
+	}
+	c.inventoryMu.Lock()
+	defer c.inventoryMu.Unlock()
+	now := time.Now()
+	if cleanupOwner {
+		if _, err := c.cleanupExpiredLocked(now); err != nil {
+			return ListCommandsResponse{}, err
+		}
+	}
+	return c.listCommandsLocked(filter, limit, cursor.Frontier, now)
+}
+
+func commandFilterForRequest(running *bool) commandCursorFilter {
+	if running == nil {
+		return commandCursorFilterAll
+	}
+	if *running {
+		return commandCursorFilterRunning
+	}
+	return commandCursorFilterTerminal
+}
+
+func (c *Controller) parseCommandCursor(raw string, filter commandCursorFilter) (commandCursor, error) {
+	if raw == "" {
+		return commandCursor{Filter: filter}, nil
+	}
+	if len(raw) > commandCursorMaxEncoded {
+		return commandCursor{}, invalidCommandCursor()
+	}
+	for i := range len(raw) {
+		if !isRawURLBase64Character(raw[i]) {
+			return commandCursor{}, invalidCommandCursor()
+		}
+	}
+	decoded, err := base64.RawURLEncoding.Strict().DecodeString(raw)
+	if err != nil || len(decoded) > commandCursorMaxDecoded {
+		return commandCursor{}, invalidCommandCursor()
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(decoded))
+	decoder.DisallowUnknownFields()
+	var cursor commandCursor
+	if err := decoder.Decode(&cursor); err != nil {
+		return commandCursor{}, invalidCommandCursor()
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return commandCursor{}, invalidCommandCursor()
+	}
+	if cursor.Version != commandCursorVersion || cursor.Process != c.inventoryProcessID ||
+		cursor.Filter != filter || !validCommandCursorFilter(cursor.Filter) || cursor.Sort != commandCursorSort {
+		return commandCursor{}, invalidCommandCursor()
+	}
+	if cursor.Frontier == nil || cursor.Frontier.StartedAtUnixNano == nil || cursor.Frontier.Session == "" {
+		return commandCursor{}, invalidCommandCursor()
+	}
+	return cursor, nil
+}
+
+func isRawURLBase64Character(character byte) bool {
+	return character >= 'A' && character <= 'Z' || character >= 'a' && character <= 'z' ||
+		character >= '0' && character <= '9' || character == '-' || character == '_'
+}
+
+func validCommandCursorFilter(filter commandCursorFilter) bool {
+	return filter == commandCursorFilterAll || filter == commandCursorFilterRunning || filter == commandCursorFilterTerminal
+}
+
+func invalidCommandCursor() error {
+	return fmt.Errorf("%w", ErrInvalidCommandCursor)
+}
+
+func (c *Controller) encodeCommandCursor(filter commandCursorFilter, frontier *commandCursorKey) (string, error) {
+	if !validCommandCursorFilter(filter) || frontier == nil || frontier.StartedAtUnixNano == nil || frontier.Session == "" {
+		return "", invalidCommandCursor()
+	}
+	payload, err := json.Marshal(commandCursor{
+		Version:  commandCursorVersion,
+		Process:  c.inventoryProcessID,
+		Filter:   filter,
+		Sort:     commandCursorSort,
+		Frontier: frontier,
+	})
+	if err != nil || len(payload) > commandCursorMaxDecoded {
+		return "", invalidCommandCursor()
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	if len(encoded) > commandCursorMaxEncoded {
+		return "", invalidCommandCursor()
+	}
+	return encoded, nil
+}
+
+func (c *Controller) listCommandsLocked(filter commandCursorFilter, limit int, frontier *commandCursorKey, now time.Time) (ListCommandsResponse, error) {
+	response := ListCommandsResponse{
+		Commands:   make([]CommandSummary, 0, limit),
+		Pagination: CommandPagination{Limit: limit},
+	}
+	var running, terminal *commandInventoryDescendingIterator
+	if filter != commandCursorFilterTerminal {
+		running = newCommandInventoryDescendingIterator(c.runningByStartedAt, frontier, false)
+		defer running.release()
+	}
+	if filter != commandCursorFilterRunning {
+		terminal = newCommandInventoryDescendingIterator(c.terminalByStartedAt, frontier, true)
+		defer terminal.release()
+	}
+
+	budget := commandInventoryPhysicalBudget{limit: commandListMaxExamined}
+	load := func(iterator *commandInventoryDescendingIterator) commandInventoryLoadResult {
+		if iterator == nil {
+			return commandInventoryLoadExhausted
+		}
+		return iterator.load(&budget)
+	}
+	runningLoad := load(running)
+	terminalLoad := load(terminal)
+	if runningLoad == commandInventoryLoadBudget || terminalLoad == commandInventoryLoadBudget {
+		return response, nil
+	}
+
+	var consumed *commandCursorKey
+	budgetExhausted := false
+	for {
+		winner, winnerIterator := commandInventoryWinner(running, terminal)
+		if winner == nil {
+			break
+		}
+		if err := c.validateListInventoryEntryLocked(winner, winnerIterator.terminal); err != nil {
+			return ListCommandsResponse{}, err
+		}
+
+		key := commandCursorKeyForEntry(winner)
+		if frontier != nil && !commandCursorKeyLess(&key, frontier) {
+			return ListCommandsResponse{}, fmt.Errorf("command inventory invariant: cursor did not strictly advance")
+		}
+		if winnerIterator.terminal && c.commandTerminalExpired(winner, now) {
+			if err := c.deleteTerminalLocked(winner); err != nil {
+				return ListCommandsResponse{}, err
+			}
+			consumed = &key
+			frontier = consumed
+			winnerIterator.clearAfterDelete(frontier)
+		} else {
+			if len(response.Commands) == limit {
+				break
+			}
+			response.Commands = append(response.Commands, commandSummaryFromInventoryEntry(winner))
+			consumed = &key
+			frontier = consumed
+			winnerIterator.advance()
+		}
+
+		if load(winnerIterator) == commandInventoryLoadBudget {
+			budgetExhausted = true
+			break
+		}
+	}
+
+	if consumed != nil {
+		remaining, _ := commandInventoryWinner(running, terminal)
+		knownExhausted := !budgetExhausted && remaining == nil
+		if !knownExhausted {
+			next, err := c.encodeCommandCursor(filter, consumed)
+			if err != nil {
+				return ListCommandsResponse{}, err
+			}
+			response.Pagination.NextCursor = &next
+		}
+	} else if remaining, _ := commandInventoryWinner(running, terminal); remaining != nil {
+		return ListCommandsResponse{}, fmt.Errorf("command inventory invariant: no progress while command inventory data remains")
+	}
+	return response, nil
+}
+
+type commandInventoryDescendingIterator struct {
+	index     *btree.BTreeG[*inventoryEntry]
+	iterator  btree.IterG[*inventoryEntry]
+	frontier  *commandCursorKey
+	entry     *inventoryEntry
+	loaded    bool
+	exhausted bool
+	terminal  bool
+	started   bool
+}
+
+type commandInventoryLoadResult uint8
+
+const (
+	commandInventoryLoadReady commandInventoryLoadResult = iota
+	commandInventoryLoadExhausted
+	commandInventoryLoadBudget
+)
+
+type commandInventoryPhysicalBudget struct {
+	limit        int
+	materialized int
+}
+
+func (budget *commandInventoryPhysicalBudget) item(iterator *btree.IterG[*inventoryEntry]) (*inventoryEntry, bool) {
+	if budget.materialized >= budget.limit {
+		return nil, false
+	}
+	budget.materialized++
+	return iterator.Item(), true
+}
+
+func newCommandInventoryDescendingIterator(index *btree.BTreeG[*inventoryEntry], frontier *commandCursorKey, terminal bool) *commandInventoryDescendingIterator {
+	return &commandInventoryDescendingIterator{index: index, iterator: index.Iter(), frontier: frontier, terminal: terminal}
+}
+
+func (iterator *commandInventoryDescendingIterator) release() {
+	iterator.iterator.Release()
+}
+
+func (iterator *commandInventoryDescendingIterator) load(budget *commandInventoryPhysicalBudget) commandInventoryLoadResult {
+	if iterator.loaded || iterator.exhausted {
+		if iterator.loaded {
+			return commandInventoryLoadReady
+		}
+		return commandInventoryLoadExhausted
+	}
+	if !iterator.started {
+		iterator.started = true
+		if iterator.frontier == nil {
+			if !iterator.iterator.Last() {
+				iterator.exhausted = true
+				return commandInventoryLoadExhausted
+			}
+		} else {
+			key := inventoryEntry{session: iterator.frontier.Session, startedAt: time.Unix(0, *iterator.frontier.StartedAtUnixNano)}
+			if iterator.iterator.Seek(&key) {
+				_, ok := budget.item(&iterator.iterator)
+				if !ok {
+					return commandInventoryLoadBudget
+				}
+				if !iterator.iterator.Prev() {
+					iterator.exhausted = true
+					return commandInventoryLoadExhausted
+				}
+			} else if !iterator.iterator.Last() {
+				iterator.exhausted = true
+				return commandInventoryLoadExhausted
+			}
+		}
+	} else if !iterator.iterator.Prev() {
+		iterator.exhausted = true
+		return commandInventoryLoadExhausted
+	}
+	entry, ok := budget.item(&iterator.iterator)
+	if !ok {
+		return commandInventoryLoadBudget
+	}
+	iterator.entry = entry
+	iterator.loaded = true
+	return commandInventoryLoadReady
+}
+
+func (iterator *commandInventoryDescendingIterator) advance() {
+	iterator.loaded = false
+	iterator.entry = nil
+}
+
+func (iterator *commandInventoryDescendingIterator) clearAfterDelete(frontier *commandCursorKey) {
+	iterator.iterator.Release()
+	iterator.iterator = iterator.index.Iter()
+	iterator.loaded = false
+	iterator.entry = nil
+	iterator.frontier = frontier
+	iterator.started = false
+}
+
+func commandInventoryWinner(running, terminal *commandInventoryDescendingIterator) (*inventoryEntry, *commandInventoryDescendingIterator) {
+	if running == nil || !running.loaded {
+		if terminal == nil || !terminal.loaded {
+			return nil, nil
+		}
+		return terminal.entry, terminal
+	}
+	if terminal == nil || !terminal.loaded {
+		return running.entry, running
+	}
+	if inventoryEntryStartedLess(running.entry, terminal.entry) {
+		return terminal.entry, terminal
+	}
+	return running.entry, running
+}
+
+func commandCursorKeyForEntry(entry *inventoryEntry) commandCursorKey {
+	startedAtUnixNano := entry.startedAt.UnixNano()
+	return commandCursorKey{StartedAtUnixNano: &startedAtUnixNano, Session: entry.session}
+}
+
+func commandCursorKeyLess(a, b *commandCursorKey) bool {
+	if *a.StartedAtUnixNano != *b.StartedAtUnixNano {
+		return *a.StartedAtUnixNano < *b.StartedAtUnixNano
+	}
+	return a.Session < b.Session
+}
+
+func (c *Controller) validateListInventoryEntryLocked(entry *inventoryEntry, terminal bool) error {
+	if entry == nil || c.bySession[entry.session] != entry {
+		return fmt.Errorf("command inventory invariant: list entry identity changed")
+	}
+	if entry.indexSession != entry.session || entry.indexStartedAt != entry.startedAt.UnixNano() {
+		return fmt.Errorf("command inventory invariant: list entry key changed")
+	}
+	if terminal {
+		if entry.running || entry.finishedAt == nil {
+			return fmt.Errorf("command inventory invariant: terminal list entry is invalid")
+		}
+		if err := ensureIndexIdentity(c.terminalByStartedAt, entry, "terminal start"); err != nil {
+			return err
+		}
+		return ensureIndexIdentity(c.terminalByFinishedAt, entry, "terminal finish")
+	}
+	if !entry.running {
+		return fmt.Errorf("command inventory invariant: running list entry is invalid")
+	}
+	return ensureIndexIdentity(c.runningByStartedAt, entry, "running start")
+}
+
+func commandSummaryFromInventoryEntry(entry *inventoryEntry) CommandSummary {
+	return CommandSummary{
+		Session: entry.session, Running: entry.running, Background: entry.background,
+		StartedAt: entry.startedAt, FinishedAt: cloneTime(entry.finishedAt),
+		ExitCode: cloneExitCode(entry.exitCode), Error: entry.errMsg,
+	}
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func (c *Controller) commandTerminalExpired(entry *inventoryEntry, now time.Time) bool {
+	return c.commandInventoryConfig.RecoveryTTL > 0 && entry.finishedAt != nil &&
+		!now.Before(entry.finishedAt.Add(c.commandInventoryConfig.RecoveryTTL))
+}
+
+func (c *Controller) cleanupExpiredLocked(now time.Time) (int, error) {
+	if c.commandInventoryConfig.RecoveryTTL <= 0 {
+		return 0, nil
+	}
+	deleted := 0
+	materialized := 0
+	for materialized < commandCleanupLimit {
+		entry, ok := c.terminalByFinishedAt.Min()
+		if !ok {
+			break
+		}
+		materialized++
+		if !c.commandTerminalExpired(entry, now) {
+			break
+		}
+		if err := c.deleteTerminalLocked(entry); err != nil {
+			return deleted, err
+		}
+		deleted++
+	}
+	return deleted, nil
+}

--- a/components/execd/pkg/runtime/command_inventory_fuzz_test.go
+++ b/components/execd/pkg/runtime/command_inventory_fuzz_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func FuzzCommandInventoryCursor(f *testing.F) {
+	process := "process"
+	valid := func(payload string) string {
+		return base64.RawURLEncoding.EncodeToString([]byte(payload))
+	}
+	malformed := make(map[string]bool)
+	addMalformed := func(cursor string) {
+		malformed[cursor] = true
+		f.Add(cursor)
+	}
+	f.Add("")
+	addMalformed(strings.Repeat("a", 1366))
+	addMalformed(strings.Repeat("a", 1367))
+	addMalformed(base64.RawURLEncoding.EncodeToString(make([]byte, 1024)))
+	addMalformed(base64.RawURLEncoding.EncodeToString(make([]byte, 1025)))
+	addMalformed(valid(`{"version":1,"process":"process","filter":"all","sort":"started_at_desc_session_desc"} trailing`))
+	addMalformed(valid(`{"version":1,"process":"process","filter":"all","sort":"started_at_desc_session_desc","extra":true}`))
+	addMalformed(valid(`{"version":1,"process":"process","filter":"all","sort":"started_at_desc_session_desc"}`))
+	addMalformed(valid(`{"version":1,"process":"process","filter":"all","sort":"started_at_desc_session_desc","frontier":null}`))
+	addMalformed(valid(`{"version":1,"process":"process","filter":"all","sort":"started_at_desc_session_desc","frontier":{"started_at_unix_nano":1,"session":"a"}}`) + "\n")
+	addMalformed(valid(`{"version":1,"process":"process","filter":"all","sort":"started_at_desc_session_desc","frontier":{"started_at_unix_nano":1,"session":"a"}}`) + "\r")
+
+	f.Fuzz(func(t *testing.T, cursor string) {
+		c := NewController("", "")
+		c.inventoryProcessID = process
+		_, err := c.ListCommands(ListCommandsRequest{Cursor: cursor})
+		if err != nil && !errors.Is(err, ErrInvalidCommandCursor) {
+			t.Fatalf("unexpected cursor error: %v", err)
+		}
+		if malformed[cursor] && !errors.Is(err, ErrInvalidCommandCursor) {
+			t.Fatalf("malformed cursor error = %v, want invalid cursor", err)
+		}
+	})
+}

--- a/components/execd/pkg/runtime/command_inventory_lifecycle_test.go
+++ b/components/execd/pkg/runtime/command_inventory_lifecycle_test.go
@@ -1,0 +1,470 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/alibaba/opensandbox/execd/pkg/jupyter/execute"
+)
+
+func TestCommandInventorySafePoint(t *testing.T) {
+	t.Run("foreground registration blocks lifecycle continuation after init", func(t *testing.T) {
+		c := NewController("", "")
+		c.inventoryMu.Lock()
+
+		initReturned := make(chan string, 1)
+		runDone := make(chan error, 1)
+		go func() {
+			runDone <- c.runCommand(context.Background(), &ExecuteCodeRequest{
+				Code: "exit 0", Cwd: t.TempDir(),
+				Hooks: ExecuteResultHook{
+					OnExecuteInit:     func(session string) { initReturned <- session },
+					OnExecuteStdout:   func(string) {},
+					OnExecuteStderr:   func(string) {},
+					OnExecuteError:    func(*execute.ErrorOutput) {},
+					OnExecuteComplete: func(time.Duration) {},
+				},
+			})
+		}()
+
+		session := <-initReturned
+		kernel := waitForStoredKernel(t, c, session)
+		assertProcessIsZombieWhenAvailable(t, kernel.pid)
+		_, exists := c.bySession[session]
+		require.False(t, exists)
+		assertNotReturned(t, runDone)
+
+		c.inventoryMu.Unlock()
+		require.NoError(t, <-runDone)
+		awaitTerminalInventoryState(t, c, session)
+	})
+
+	t.Run("background registration blocks return", func(t *testing.T) {
+		c := NewController("", "")
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		c.inventoryMu.Lock()
+
+		initReturned := make(chan string, 1)
+		runDone := make(chan error, 1)
+		go func() {
+			runDone <- c.runBackgroundCommand(ctx, cancel, &ExecuteCodeRequest{
+				Code: "exit 0", Cwd: t.TempDir(),
+				Hooks: ExecuteResultHook{
+					OnExecuteInit:     func(session string) { initReturned <- session },
+					OnExecuteComplete: func(time.Duration) {},
+				},
+			})
+		}()
+
+		session := <-initReturned
+		kernel := waitForStoredKernel(t, c, session)
+		assertProcessIsZombieWhenAvailable(t, kernel.pid)
+		_, exists := c.bySession[session]
+		require.False(t, exists)
+		assertNotReturned(t, runDone)
+
+		c.inventoryMu.Unlock()
+		require.NoError(t, <-runDone)
+		awaitTerminalInventoryState(t, c, session)
+	})
+}
+
+func TestCommandInventoryStartFailure(t *testing.T) {
+	for _, background := range []bool{false, true} {
+		name := "foreground"
+		if background {
+			name = "background"
+		}
+		t.Run(name, func(t *testing.T) {
+			c := NewController("", "")
+			var session string
+			req := &ExecuteCodeRequest{
+				Code: "exit 0", Cwd: filepath.Join(t.TempDir(), "missing"),
+				Hooks: ExecuteResultHook{
+					OnExecuteInit:     func(id string) { session = id },
+					OnExecuteError:    func(*execute.ErrorOutput) {},
+					OnExecuteComplete: func(time.Duration) {},
+				},
+			}
+			if background {
+				require.Error(t, c.runBackgroundCommand(context.Background(), func() {}, req))
+			} else {
+				require.NoError(t, c.runCommand(context.Background(), req))
+			}
+			require.NotEmpty(t, session)
+			assertInventoryAbsent(t, c, session)
+		})
+	}
+}
+
+func TestCommandInventoryForegroundLifecycle(t *testing.T) {
+	t.Run("success transitions after complete callback returns", func(t *testing.T) {
+		c := NewController("", "")
+		callbackEntered := make(chan struct{})
+		releaseCallback := make(chan struct{})
+		var session string
+		runDone := make(chan error, 1)
+		go func() {
+			runDone <- c.runCommand(context.Background(), &ExecuteCodeRequest{
+				Code: "exit 0", Cwd: t.TempDir(),
+				Hooks: ExecuteResultHook{
+					OnExecuteInit:   func(id string) { session = id },
+					OnExecuteStdout: func(string) {},
+					OnExecuteStderr: func(string) {},
+					OnExecuteError:  func(*execute.ErrorOutput) {},
+					OnExecuteComplete: func(time.Duration) {
+						close(callbackEntered)
+						<-releaseCallback
+					},
+				},
+			})
+		}()
+
+		awaitSignal(t, callbackEntered, "complete callback")
+		status, err := c.GetCommandStatus(session)
+		require.NoError(t, err)
+		require.False(t, status.Running, "success mutation must precede the complete callback")
+		requireRunningInventoryState(t, c, session)
+		assertNotReturned(t, runDone)
+
+		close(releaseCallback)
+		require.NoError(t, <-runDone)
+		requireTerminalInventoryState(t, c, session)
+	})
+
+	t.Run("error transitions after error callback returns", func(t *testing.T) {
+		c := NewController("", "")
+		callbackEntered := make(chan struct{})
+		releaseCallback := make(chan struct{})
+		var session string
+		runDone := make(chan error, 1)
+		go func() {
+			runDone <- c.runCommand(context.Background(), &ExecuteCodeRequest{
+				Code: "exit 17", Cwd: t.TempDir(),
+				Hooks: ExecuteResultHook{
+					OnExecuteInit:     func(id string) { session = id },
+					OnExecuteStdout:   func(string) {},
+					OnExecuteStderr:   func(string) {},
+					OnExecuteComplete: func(time.Duration) {},
+					OnExecuteError: func(*execute.ErrorOutput) {
+						close(callbackEntered)
+						<-releaseCallback
+					},
+				},
+			})
+		}()
+
+		awaitSignal(t, callbackEntered, "error callback")
+		status, err := c.GetCommandStatus(session)
+		require.NoError(t, err)
+		require.True(t, status.Running, "error callback must precede the legacy terminal mutation")
+		requireRunningInventoryState(t, c, session)
+		assertNotReturned(t, runDone)
+
+		close(releaseCallback)
+		require.NoError(t, <-runDone)
+		status, err = c.GetCommandStatus(session)
+		require.NoError(t, err)
+		require.False(t, status.Running)
+		require.Equal(t, 17, *status.ExitCode)
+		requireTerminalInventoryState(t, c, session)
+	})
+}
+
+func TestCommandInventoryBackgroundLifecycle(t *testing.T) {
+	t.Run("waiter transitions while startup callback is blocked", func(t *testing.T) {
+		c := NewController("", "")
+		startupEntered := make(chan struct{})
+		releaseStartup := make(chan struct{})
+		sessionReady := make(chan string, 1)
+		runDone := make(chan error, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go func() {
+			runDone <- c.runBackgroundCommand(ctx, cancel, &ExecuteCodeRequest{
+				Code: "exit 0", Cwd: t.TempDir(),
+				Hooks: ExecuteResultHook{
+					OnExecuteInit: func(id string) { sessionReady <- id },
+					OnExecuteComplete: func(time.Duration) {
+						close(startupEntered)
+						<-releaseStartup
+					},
+				},
+			})
+		}()
+
+		session := <-sessionReady
+		awaitSignal(t, startupEntered, "background startup callback")
+		awaitCommandTerminalStatus(t, c, session)
+		awaitTerminalInventoryState(t, c, session)
+		assertNotReturned(t, runDone)
+
+		close(releaseStartup)
+		require.NoError(t, <-runDone)
+	})
+
+	t.Run("fast exits retain terminal summaries without stale running entries", func(t *testing.T) {
+		// These index assertions verify the registration and terminal-transition invariant.
+		const commands = 8
+		c := NewController("", "")
+		sessions := make([]string, 0, commands)
+		for range commands {
+			var session string
+			ctx, cancel := context.WithCancel(context.Background())
+			require.NoError(t, c.runBackgroundCommand(ctx, cancel, &ExecuteCodeRequest{
+				Code: "exit 0", Cwd: t.TempDir(),
+				Hooks: ExecuteResultHook{
+					OnExecuteInit:     func(id string) { session = id },
+					OnExecuteComplete: func(time.Duration) {},
+				},
+			}))
+			cancel()
+			require.NotEmpty(t, session)
+			sessions = append(sessions, session)
+		}
+
+		for _, session := range sessions {
+			awaitCommandTerminalStatus(t, c, session)
+			awaitTerminalInventoryState(t, c, session)
+		}
+
+		c.inventoryMu.Lock()
+		defer c.inventoryMu.Unlock()
+		require.Zero(t, c.runningByStartedAt.Len())
+		require.Equal(t, commands, c.terminalByStartedAt.Len())
+		require.Equal(t, commands, c.terminalByFinishedAt.Len())
+		for _, session := range sessions {
+			entry := c.bySession[session]
+			require.NotNil(t, entry, "terminal transition must not overtake registration")
+			require.False(t, entry.running)
+		}
+	})
+}
+
+func TestCommandInventoryLegacyCompatibility(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		config CommandInventoryConfig
+	}{
+		{
+			name:   "zero recovery TTL",
+			config: CommandInventoryConfig{RecoveryTTL: 0, MaxTerminal: 1000},
+		},
+		{
+			name:   "zero terminal capacity",
+			config: CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 0},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("foreground", func(t *testing.T) {
+				c := NewController("", "", WithCommandInventory(test.config))
+				var session string
+				require.NoError(t, c.runCommand(context.Background(), &ExecuteCodeRequest{
+					Code: "exit 0", Cwd: t.TempDir(),
+					Hooks: ExecuteResultHook{
+						OnExecuteInit:     func(id string) { session = id },
+						OnExecuteStdout:   func(string) {},
+						OnExecuteStderr:   func(string) {},
+						OnExecuteError:    func(*execute.ErrorOutput) {},
+						OnExecuteComplete: func(time.Duration) {},
+					},
+				}))
+				awaitInventoryAbsent(t, c, session)
+
+				status, err := c.GetCommandStatus(session)
+				require.NoError(t, err)
+				require.Equal(t, "exit 0", status.Content)
+				_, _, err = c.SeekBackgroundCommandOutput(session, 0)
+				require.EqualError(t, err, "command "+session+" is not running in background")
+				err = c.Interrupt(session)
+				require.EqualError(t, err, "command session "+session+" is not running")
+			})
+
+			t.Run("background", func(t *testing.T) {
+				c := NewController("", "", WithCommandInventory(test.config))
+				var session string
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				require.NoError(t, c.runBackgroundCommand(ctx, cancel, &ExecuteCodeRequest{
+					Code: "printf retained-output", Cwd: t.TempDir(),
+					Hooks: ExecuteResultHook{
+						OnExecuteInit:     func(id string) { session = id },
+						OnExecuteComplete: func(time.Duration) {},
+					},
+				}))
+				awaitCommandTerminalStatus(t, c, session)
+				awaitInventoryAbsent(t, c, session)
+
+				status, err := c.GetCommandStatus(session)
+				require.NoError(t, err)
+				require.Equal(t, "printf retained-output", status.Content)
+				output, _, err := c.SeekBackgroundCommandOutput(session, 0)
+				require.NoError(t, err)
+				require.Equal(t, "retained-output", string(output))
+				err = c.Interrupt(session)
+				require.EqualError(t, err, "command session "+session+" is not running")
+			})
+		})
+	}
+}
+
+func awaitSignal(t *testing.T, signal <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout waiting for %s", name)
+	}
+}
+
+func awaitCommandTerminalStatus(t *testing.T, c *Controller, session string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		status, err := c.GetCommandStatus(session)
+		if err == nil && !status.Running {
+			return
+		}
+		runtime.Gosched()
+	}
+	t.Fatalf("command session %s did not reach terminal status", session)
+}
+
+func requireRunningInventoryState(t *testing.T, c *Controller, session string) {
+	t.Helper()
+	c.inventoryMu.Lock()
+	defer c.inventoryMu.Unlock()
+	entry := c.bySession[session]
+	require.NotNil(t, entry)
+	require.True(t, entry.running)
+	require.Equal(t, 1, c.runningByStartedAt.Len())
+	require.Zero(t, c.terminalByStartedAt.Len())
+	require.Zero(t, c.terminalByFinishedAt.Len())
+}
+
+func requireTerminalInventoryState(t *testing.T, c *Controller, session string) {
+	t.Helper()
+	c.inventoryMu.Lock()
+	defer c.inventoryMu.Unlock()
+	entry := c.bySession[session]
+	require.NotNil(t, entry)
+	require.False(t, entry.running)
+	require.Zero(t, c.runningByStartedAt.Len())
+	require.Equal(t, 1, c.terminalByStartedAt.Len())
+	require.Equal(t, 1, c.terminalByFinishedAt.Len())
+}
+
+func awaitTerminalInventoryState(t *testing.T, c *Controller, session string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		c.inventoryMu.Lock()
+		entry := c.bySession[session]
+		terminal := entry != nil && !entry.running
+		c.inventoryMu.Unlock()
+		if terminal {
+			return
+		}
+		runtime.Gosched()
+	}
+	t.Fatalf("command session %s did not reach terminal inventory state", session)
+}
+
+func awaitInventoryAbsent(t *testing.T, c *Controller, session string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		c.inventoryMu.Lock()
+		_, exists := c.bySession[session]
+		c.inventoryMu.Unlock()
+		if !exists {
+			return
+		}
+		runtime.Gosched()
+	}
+	t.Fatalf("command session %s was retained by inventory", session)
+}
+
+func waitForStoredKernel(t *testing.T, c *Controller, session string) *commandKernel {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if kernel := c.getCommandKernel(session); kernel != nil && kernel.pid > 0 {
+			return kernel
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("command kernel was not stored after init callback")
+	return nil
+}
+
+func assertProcessIsZombieWhenAvailable(t *testing.T, pid int) {
+	t.Helper()
+	if _, err := os.Stat("/proc"); err != nil {
+		return
+	}
+	path := filepath.Join("/proc", strconv.Itoa(pid), "stat")
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		contents, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			t.Fatal("command was reaped before inventory registration completed")
+		}
+		if err == nil && processState(contents) == 'Z' {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("command pid %d did not reach zombie state", pid)
+}
+
+func processState(stat []byte) byte {
+	end := strings.LastIndexByte(string(stat), ')')
+	if end < 0 || len(stat) <= end+2 {
+		return 0
+	}
+	return stat[end+2]
+}
+
+func assertInventoryAbsent(t *testing.T, c *Controller, session string) {
+	t.Helper()
+	c.inventoryMu.Lock()
+	defer c.inventoryMu.Unlock()
+	_, exists := c.bySession[session]
+	require.False(t, exists)
+}
+
+func assertNotReturned(t *testing.T, done <-chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		t.Fatalf("command returned before inventory registration completed: %v", err)
+	default:
+	}
+}

--- a/components/execd/pkg/runtime/command_inventory_test.go
+++ b/components/execd/pkg/runtime/command_inventory_test.go
@@ -1,0 +1,1117 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandInventoryList(t *testing.T) {
+	t.Run("global pagination", testCommandInventoryListGlobalPagination)
+	t.Run("limit does not skip opposing lookahead", testCommandInventoryListLimitDoesNotSkipOpposingLookahead)
+	t.Run("exact final page omits cursor", testCommandInventoryListExactFinalPageOmitsCursor)
+	t.Run("filters and cursor binding", testCommandInventoryListFiltersAndCursorBinding)
+	t.Run("deleted anchor is an exclusive seek", testCommandInventoryListDeletedAnchor)
+	t.Run("running migration does not duplicate past frontier", testCommandInventoryListRunningMigrationDoesNotDuplicate)
+	t.Run("same timestamp sorts session descending", testCommandInventoryListSameTimestampSessions)
+	t.Run("expired discard advances cursor", testCommandInventoryListExpiredDiscardAdvancesCursor)
+	t.Run("cleanup removed cursor anchor", testCommandInventoryListCleanupRemovedAnchor)
+	t.Run("summary pointers are isolated", testCommandInventoryListSummaryIsolation)
+	t.Run("invariant failures", testCommandInventoryListInvariantFailures)
+	t.Run("physical budget is bounded", testCommandInventoryListPhysicalBudget)
+}
+
+func testCommandInventoryListGlobalPagination(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{
+		RecoveryTTL: time.Hour,
+		MaxTerminal: 100,
+	}))
+	base := time.Now().UTC().Add(-time.Minute)
+	for _, command := range []struct {
+		session string
+		started int
+		running bool
+	}{
+		{session: "running-z", started: 4, running: true},
+		{session: "terminal-y", started: 3},
+		{session: "running-x", started: 2, running: true},
+		{session: "terminal-w", started: 1},
+	} {
+		startedAt := base.Add(time.Duration(command.started) * time.Nanosecond)
+		mustRegisterRunning(t, c, inventoryEntry{
+			session: command.session, running: true, startedAt: startedAt,
+		})
+		if !command.running {
+			finishedAt := startedAt.Add(time.Second)
+			mustTransitionTerminal(t, c, inventoryEntry{
+				session: command.session, startedAt: startedAt, finishedAt: &finishedAt,
+			})
+		}
+	}
+
+	var got []string
+	seen := make(map[string]struct{})
+	request := ListCommandsRequest{Limit: 1}
+	var previous *commandCursorKey
+	for {
+		response, err := c.ListCommands(request)
+		require.NoError(t, err)
+		require.Equal(t, 1, response.Pagination.Limit)
+		for _, command := range response.Commands {
+			_, duplicate := seen[command.Session]
+			require.Falsef(t, duplicate, "duplicate command %q across pages", command.Session)
+			seen[command.Session] = struct{}{}
+			got = append(got, command.Session)
+		}
+		if response.Pagination.NextCursor == nil {
+			break
+		}
+		cursor, err := c.parseCommandCursor(*response.Pagination.NextCursor, commandCursorFilterAll)
+		require.NoError(t, err)
+		if previous != nil {
+			require.True(t, commandCursorKeyLess(cursor.Frontier, previous), "cursor must strictly progress")
+		}
+		previous = cursor.Frontier
+		request.Cursor = *response.Pagination.NextCursor
+	}
+	require.Equal(t, []string{"running-z", "terminal-y", "running-x", "terminal-w"}, got)
+}
+
+func testCommandInventoryListLimitDoesNotSkipOpposingLookahead(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{
+		RecoveryTTL: time.Hour,
+		MaxTerminal: 10,
+	}))
+	base := time.Now().UTC().Add(-time.Minute)
+	for _, command := range []struct {
+		session string
+		started int
+		running bool
+	}{
+		{session: "running-newest", started: 2, running: true},
+		{session: "terminal-next", started: 1},
+	} {
+		startedAt := base.Add(time.Duration(command.started) * time.Nanosecond)
+		mustRegisterRunning(t, c, inventoryEntry{session: command.session, running: true, startedAt: startedAt})
+		if !command.running {
+			finishedAt := startedAt.Add(time.Second)
+			mustTransitionTerminal(t, c, inventoryEntry{session: command.session, startedAt: startedAt, finishedAt: &finishedAt})
+		}
+	}
+
+	first, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, []string{"running-newest"}, commandSummarySessions(first.Commands))
+	require.NotNil(t, first.Pagination.NextCursor)
+
+	second, err := c.ListCommands(ListCommandsRequest{Limit: 1, Cursor: *first.Pagination.NextCursor})
+	require.NoError(t, err)
+	require.Equal(t, []string{"terminal-next"}, commandSummarySessions(second.Commands))
+}
+
+func testCommandInventoryListExactFinalPageOmitsCursor(t *testing.T) {
+	base := time.Now().UTC().Add(-time.Minute)
+	newController := func() *Controller {
+		return NewController("", "", WithCommandInventory(CommandInventoryConfig{
+			RecoveryTTL: time.Hour,
+			MaxTerminal: 10,
+		}))
+	}
+
+	t.Run("running only", func(t *testing.T) {
+		c := newController()
+		mustRegisterRunning(t, c, inventoryEntry{session: "newer", running: true, startedAt: base.Add(time.Nanosecond)})
+		mustRegisterRunning(t, c, inventoryEntry{session: "older", running: true, startedAt: base})
+		running := true
+
+		response, err := c.ListCommands(ListCommandsRequest{Running: &running, Limit: 2})
+		require.NoError(t, err)
+		require.Equal(t, []string{"newer", "older"}, commandSummarySessions(response.Commands))
+		require.Nil(t, response.Pagination.NextCursor)
+	})
+
+	t.Run("terminal only", func(t *testing.T) {
+		c := newController()
+		registerTerminalInventory(t, c, "newer", base.Add(time.Nanosecond), base.Add(time.Second))
+		registerTerminalInventory(t, c, "older", base, base.Add(time.Second))
+		terminal := false
+
+		response, err := c.ListCommands(ListCommandsRequest{Running: &terminal, Limit: 2})
+		require.NoError(t, err)
+		require.Equal(t, []string{"newer", "older"}, commandSummarySessions(response.Commands))
+		require.Nil(t, response.Pagination.NextCursor)
+	})
+
+	t.Run("mixed", func(t *testing.T) {
+		c := newController()
+		mustRegisterRunning(t, c, inventoryEntry{session: "running", running: true, startedAt: base.Add(time.Nanosecond)})
+		registerTerminalInventory(t, c, "terminal", base, base.Add(time.Second))
+
+		response, err := c.ListCommands(ListCommandsRequest{Limit: 2})
+		require.NoError(t, err)
+		require.Equal(t, []string{"running", "terminal"}, commandSummarySessions(response.Commands))
+		require.Nil(t, response.Pagination.NextCursor)
+	})
+
+	t.Run("filtered", func(t *testing.T) {
+		c := newController()
+		mustRegisterRunning(t, c, inventoryEntry{session: "running-newer", running: true, startedAt: base.Add(3 * time.Nanosecond)})
+		registerTerminalInventory(t, c, "terminal-newer", base.Add(2*time.Nanosecond), base.Add(time.Second))
+		mustRegisterRunning(t, c, inventoryEntry{session: "running-older", running: true, startedAt: base.Add(time.Nanosecond)})
+		registerTerminalInventory(t, c, "terminal-older", base, base.Add(time.Second))
+		running := true
+
+		response, err := c.ListCommands(ListCommandsRequest{Running: &running, Limit: 2})
+		require.NoError(t, err)
+		require.Equal(t, []string{"running-newer", "running-older"}, commandSummarySessions(response.Commands))
+		require.Nil(t, response.Pagination.NextCursor)
+	})
+}
+
+func testCommandInventoryListFiltersAndCursorBinding(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 10}))
+	startedAt := time.Now().UTC().Add(-time.Minute)
+	mustRegisterRunning(t, c, inventoryEntry{session: "running", running: true, startedAt: startedAt.Add(time.Nanosecond)})
+	mustRegisterRunning(t, c, inventoryEntry{session: "terminal", running: true, startedAt: startedAt})
+	mustRegisterRunning(t, c, inventoryEntry{session: "running-older", running: true, startedAt: startedAt.Add(-time.Nanosecond)})
+	finishedAt := startedAt.Add(time.Second)
+	mustTransitionTerminal(t, c, inventoryEntry{session: "terminal", startedAt: startedAt, finishedAt: &finishedAt})
+
+	running := true
+	response, err := c.ListCommands(ListCommandsRequest{Running: &running, Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, []string{"running"}, commandSummarySessions(response.Commands))
+	require.NotNil(t, response.Pagination.NextCursor)
+
+	terminal := false
+	_, err = c.ListCommands(ListCommandsRequest{Running: &terminal, Limit: 1, Cursor: *response.Pagination.NextCursor})
+	require.ErrorIs(t, err, ErrInvalidCommandCursor)
+
+	other := NewController("", "")
+	_, err = other.ListCommands(ListCommandsRequest{Running: &running, Limit: 1, Cursor: *response.Pagination.NextCursor})
+	require.ErrorIs(t, err, ErrInvalidCommandCursor)
+}
+
+func testCommandInventoryListDeletedAnchor(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 10}))
+	base := time.Now().UTC().Add(-time.Minute)
+	for i, session := range []string{"newer", "older"} {
+		startedAt := base.Add(time.Duration(2-i) * time.Nanosecond)
+		mustRegisterRunning(t, c, inventoryEntry{session: session, running: true, startedAt: startedAt})
+	}
+	first, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, []string{"newer"}, commandSummarySessions(first.Commands))
+	c.inventoryMu.Lock()
+	entry := c.bySession["newer"]
+	require.NoError(t, deleteInventoryEntry(c.runningByStartedAt, entry, "running start"))
+	delete(c.bySession, entry.session)
+	c.inventoryMu.Unlock()
+	second, err := c.ListCommands(ListCommandsRequest{Limit: 1, Cursor: *first.Pagination.NextCursor})
+	require.NoError(t, err)
+	require.Equal(t, []string{"older"}, commandSummarySessions(second.Commands))
+}
+
+func testCommandInventoryListRunningMigrationDoesNotDuplicate(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 10}))
+	startedAt := time.Now().UTC().Add(-time.Minute)
+	mustRegisterRunning(t, c, inventoryEntry{session: "session", running: true, startedAt: startedAt})
+	mustRegisterRunning(t, c, inventoryEntry{session: "older", running: true, startedAt: startedAt.Add(-time.Nanosecond)})
+	first, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, []string{"session"}, commandSummarySessions(first.Commands))
+	finishedAt := startedAt.Add(time.Second)
+	mustTransitionTerminal(t, c, inventoryEntry{session: "session", startedAt: startedAt, finishedAt: &finishedAt})
+	second, err := c.ListCommands(ListCommandsRequest{Limit: 1, Cursor: *first.Pagination.NextCursor})
+	require.NoError(t, err)
+	require.Equal(t, []string{"older"}, commandSummarySessions(second.Commands))
+}
+
+func testCommandInventoryListSameTimestampSessions(t *testing.T) {
+	c := NewController("", "")
+	startedAt := time.Now().UTC().Add(-time.Minute)
+	for _, session := range []string{"a", "c", "b"} {
+		mustRegisterRunning(t, c, inventoryEntry{session: session, running: true, startedAt: startedAt})
+	}
+	response, err := c.ListCommands(ListCommandsRequest{Limit: 3})
+	require.NoError(t, err)
+	require.Equal(t, []string{"c", "b", "a"}, commandSummarySessions(response.Commands))
+}
+
+func testCommandInventoryListExpiredDiscardAdvancesCursor(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 300}))
+	base := time.Now().UTC().Add(-2 * time.Hour)
+	for i := range 257 {
+		registerTerminalInventory(t, c, fmt.Sprintf("expired-%03d", i), base.Add(time.Duration(i)*time.Nanosecond), base)
+	}
+	response, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+	require.NoError(t, err)
+	require.Empty(t, response.Commands)
+	require.NotNil(t, response.Pagination.NextCursor, "expired winner consumption must preserve continuation")
+	following, err := c.ListCommands(ListCommandsRequest{Limit: 1, Cursor: *response.Pagination.NextCursor})
+	require.NoError(t, err)
+	require.Empty(t, following.Commands)
+	require.Nil(t, following.Pagination.NextCursor)
+}
+
+func testCommandInventoryListCleanupRemovedAnchor(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 10}))
+	base := time.Now().UTC().Add(-time.Minute)
+	registerTerminalInventory(t, c, "anchor", base.Add(time.Nanosecond), base)
+	registerTerminalInventory(t, c, "older", base, base)
+	first, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, []string{"anchor"}, commandSummarySessions(first.Commands))
+	c.inventoryMu.Lock()
+	_, err = c.cleanupExpiredLocked(base.Add(time.Hour))
+	c.inventoryMu.Unlock()
+	require.NoError(t, err)
+	next, err := c.ListCommands(ListCommandsRequest{Limit: 1, Cursor: *first.Pagination.NextCursor})
+	require.NoError(t, err)
+	require.Empty(t, next.Commands)
+}
+
+func testCommandInventoryListSummaryIsolation(t *testing.T) {
+	c := NewController("", "")
+	startedAt := time.Now().UTC().Add(-time.Minute)
+	finishedAt := startedAt.Add(time.Second)
+	exitCode := 17
+	mustRegisterRunning(t, c, inventoryEntry{session: "terminal", running: true, startedAt: startedAt})
+	mustTransitionTerminal(t, c, inventoryEntry{session: "terminal", startedAt: startedAt, finishedAt: &finishedAt, exitCode: &exitCode})
+	first, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+	require.NoError(t, err)
+	*first.Commands[0].FinishedAt = time.Time{}
+	*first.Commands[0].ExitCode = 99
+	c.inventoryMu.Lock()
+	entry := c.bySession["terminal"]
+	require.Equal(t, finishedAt, *entry.finishedAt)
+	require.Equal(t, 17, *entry.exitCode)
+	assertIndexIdentity(t, c.terminalByFinishedAt, entry, "terminal finish")
+	c.inventoryMu.Unlock()
+	second, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, finishedAt, *second.Commands[0].FinishedAt)
+	require.Equal(t, 17, *second.Commands[0].ExitCode)
+}
+
+func testCommandInventoryListInvariantFailures(t *testing.T) {
+	newRunning := func(t *testing.T) (*Controller, *inventoryEntry) {
+		t.Helper()
+		c := NewController("", "")
+		mustRegisterRunning(t, c, inventoryEntry{session: "entry", running: true, startedAt: time.Now().UTC().Add(-time.Minute)})
+		return c, c.bySession["entry"]
+	}
+	t.Run("map identity", func(t *testing.T) {
+		c, entry := newRunning(t)
+		c.inventoryMu.Lock()
+		c.bySession[entry.session] = &inventoryEntry{session: entry.session, running: true, startedAt: entry.startedAt}
+		c.inventoryMu.Unlock()
+		_, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+		require.ErrorContains(t, err, "invariant")
+	})
+	t.Run("key mismatch", func(t *testing.T) {
+		c, entry := newRunning(t)
+		c.inventoryMu.Lock()
+		entry.startedAt = entry.startedAt.Add(time.Nanosecond)
+		c.inventoryMu.Unlock()
+		_, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+		require.ErrorContains(t, err, "invariant")
+	})
+	t.Run("state mismatch", func(t *testing.T) {
+		c, entry := newRunning(t)
+		c.inventoryMu.Lock()
+		entry.running = false
+		c.inventoryMu.Unlock()
+		_, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+		require.ErrorContains(t, err, "invariant")
+	})
+	t.Run("terminal finish tree missing", func(t *testing.T) {
+		c := NewController("", "")
+		startedAt := time.Now().UTC().Add(-time.Minute)
+		finishedAt := startedAt.Add(time.Second)
+		registerTerminalInventory(t, c, "terminal", startedAt, finishedAt)
+		c.inventoryMu.Lock()
+		entry := c.bySession["terminal"]
+		_, _ = c.terminalByFinishedAt.Delete(entry)
+		c.inventoryMu.Unlock()
+		_, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+		require.ErrorContains(t, err, "invariant")
+	})
+	t.Run("no progress", func(t *testing.T) {
+		c, _ := newRunning(t)
+		c.inventoryMu.Lock()
+		_, err := c.listCommandsLocked(commandCursorFilterAll, 0, nil, time.Now())
+		c.inventoryMu.Unlock()
+		require.ErrorContains(t, err, "no progress")
+	})
+}
+
+func testCommandInventoryListPhysicalBudget(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 400}))
+	base := time.Now().UTC().Add(-2 * time.Hour)
+	for i := range 260 {
+		registerTerminalInventory(t, c, fmt.Sprintf("expired-%03d", i), base.Add(time.Duration(i)*time.Nanosecond), base)
+	}
+	mustRegisterRunning(t, c, inventoryEntry{session: "running", running: true, startedAt: base.Add(-time.Hour)})
+	response, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+	require.NoError(t, err)
+	require.Empty(t, response.Commands, "expired terminal winners consume the physical budget before older running data")
+	require.NotNil(t, response.Pagination.NextCursor, "the short page must strictly continue past discarded winners")
+	following, err := c.ListCommands(ListCommandsRequest{Limit: 1, Cursor: *response.Pagination.NextCursor})
+	require.NoError(t, err)
+	require.Equal(t, []string{"running"}, commandSummarySessions(following.Commands))
+	require.Nil(t, following.Pagination.NextCursor, "cleanup proved that no further entries remain")
+}
+
+func TestCommandInventoryCursor(t *testing.T) {
+	c := NewController("", "")
+	valid := func(payload string) string {
+		return base64.RawURLEncoding.EncodeToString([]byte(payload))
+	}
+	for _, cursor := range []string{
+		"%", "=", valid(`[]`), valid(`{"version":1,"process":"` + c.inventoryProcessID + `","filter":"all","sort":"started_at_desc_session_desc","extra":true}`),
+		valid(`{"version":1,"process":"` + c.inventoryProcessID + `","filter":"all","sort":"started_at_desc_session_desc"} trailing`),
+		valid(`{"version":2,"process":"` + c.inventoryProcessID + `","filter":"all","sort":"started_at_desc_session_desc"}`),
+		valid(`{"version":1,"process":"other","filter":"all","sort":"started_at_desc_session_desc"}`),
+		valid(`{"version":1,"process":"` + c.inventoryProcessID + `","filter":"other","sort":"started_at_desc_session_desc"}`),
+		valid(`{"version":1,"process":"` + c.inventoryProcessID + `","filter":"all","sort":"other"}`),
+		valid(`{"version":1,"process":"` + c.inventoryProcessID + `","filter":"all","sort":"started_at_desc_session_desc","frontier":{"started_at_unix_nano":1}}`),
+		valid(`{"version":1,"process":"` + c.inventoryProcessID + `","filter":"all","sort":"started_at_desc_session_desc","frontier":{"started_at_unix_nano":1,"session":""}}`),
+		valid(`{"version":1,"process":"` + c.inventoryProcessID + `","filter":"all","sort":"started_at_desc_session_desc"}`),
+		valid(`{"version":1,"process":"` + c.inventoryProcessID + `","filter":"all","sort":"started_at_desc_session_desc","frontier":null}`),
+		valid(`{"version":1,"process":"`+c.inventoryProcessID+`","filter":"all","sort":"started_at_desc_session_desc","frontier":{"started_at_unix_nano":1,"session":"a"}}`) + "\n",
+		string(make([]byte, 1367)),
+	} {
+		_, err := c.ListCommands(ListCommandsRequest{Cursor: cursor})
+		if !errors.Is(err, ErrInvalidCommandCursor) {
+			t.Fatalf("cursor %q error = %v, want invalid cursor", cursor, err)
+		}
+	}
+}
+
+func TestCommandInventoryRetention(t *testing.T) {
+	t.Run("cap eviction and cleanup", testCommandInventoryRetentionCapEvictionAndCleanup)
+	t.Run("exact TTL boundary", testCommandInventoryRetentionTTLBoundary)
+	t.Run("cleanup batch removes map and index identities", testCommandInventoryCleanupExpiredRemovesMatchingIdentities)
+	t.Run("concurrent nonowner skips active cleanup", testCommandInventoryRetentionConcurrentNonownerSkipsCleanup)
+	t.Run("later request gets a fresh cleanup pass", testCommandInventoryRetentionLaterRequestGetsFreshCleanupPass)
+	t.Run("later list cleans newly expired entry", testCommandInventoryRetentionLaterListCleansNewlyExpiredEntry)
+}
+
+func testCommandInventoryRetentionCapEvictionAndCleanup(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{
+		RecoveryTTL: time.Hour,
+		MaxTerminal: 1,
+	}))
+	base := time.Now().UTC().Add(-2 * time.Hour)
+	for i := range 2 {
+		session := fmt.Sprintf("terminal-%d", i)
+		startedAt := base.Add(time.Duration(i) * time.Minute)
+		finishedAt := startedAt.Add(time.Second)
+		mustRegisterRunning(t, c, inventoryEntry{session: session, running: true, startedAt: startedAt})
+		mustTransitionTerminal(t, c, inventoryEntry{session: session, startedAt: startedAt, finishedAt: &finishedAt})
+	}
+	c.inventoryMu.Lock()
+	require.Equal(t, 1, c.terminalByFinishedAt.Len())
+	c.commandInventoryConfig.MaxTerminal = 10
+	c.inventoryMu.Unlock()
+
+	response, err := c.ListCommands(ListCommandsRequest{Limit: 1})
+	require.NoError(t, err)
+	require.Empty(t, response.Commands)
+	c.inventoryMu.Lock()
+	require.Zero(t, c.terminalByFinishedAt.Len())
+	c.inventoryMu.Unlock()
+}
+
+func testCommandInventoryRetentionTTLBoundary(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 10}))
+	finishedAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	registerTerminalInventory(t, c, "terminal", finishedAt.Add(-time.Second), finishedAt)
+	c.inventoryMu.Lock()
+	deleted, err := c.cleanupExpiredLocked(finishedAt.Add(time.Hour).Add(-time.Nanosecond))
+	require.NoError(t, err)
+	require.Zero(t, deleted)
+	deleted, err = c.cleanupExpiredLocked(finishedAt.Add(time.Hour))
+	c.inventoryMu.Unlock()
+	require.NoError(t, err)
+	require.Equal(t, 1, deleted)
+}
+
+func testCommandInventoryCleanupExpiredRemovesMatchingIdentities(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 10}))
+	base := time.Now().UTC().Add(-2 * time.Hour)
+	registerTerminalInventory(t, c, "expired-a", base, base)
+	registerTerminalInventory(t, c, "expired-b", base.Add(time.Nanosecond), base.Add(time.Nanosecond))
+
+	c.inventoryMu.Lock()
+	deleted, err := c.cleanupExpiredLocked(time.Now().UTC())
+	assertCommandInventoryInvariantLocked(t, c)
+	terminalStarted := c.terminalByStartedAt.Len()
+	terminalFinished := c.terminalByFinishedAt.Len()
+	bySession := len(c.bySession)
+	c.inventoryMu.Unlock()
+	require.NoError(t, err)
+	require.Equal(t, 2, deleted)
+	require.Zero(t, terminalStarted)
+	require.Zero(t, terminalFinished)
+	require.Zero(t, bySession)
+}
+
+func testCommandInventoryRetentionConcurrentNonownerSkipsCleanup(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 300}))
+	base := time.Now().UTC().Add(-2 * time.Hour)
+	for i := range 200 {
+		registerTerminalInventory(t, c, fmt.Sprintf("expired-%03d", i), base.Add(time.Duration(i)*time.Nanosecond), base)
+	}
+
+	running := true
+	c.cleanupOwner.Store(true)
+	c.inventoryMu.Lock()
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		_, err := c.ListCommands(ListCommandsRequest{Running: &running, Limit: 1})
+		done <- err
+	}()
+	<-started
+	c.inventoryMu.Unlock()
+	require.NoError(t, <-done)
+
+	c.inventoryMu.Lock()
+	require.Equal(t, 200, c.terminalByFinishedAt.Len())
+	assertCommandInventoryInvariantLocked(t, c)
+	c.inventoryMu.Unlock()
+	c.cleanupOwner.Store(false)
+}
+
+func testCommandInventoryRetentionLaterRequestGetsFreshCleanupPass(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 300}))
+	base := time.Now().UTC().Add(-2 * time.Hour)
+	for i := range 200 {
+		registerTerminalInventory(t, c, fmt.Sprintf("expired-%03d", i), base.Add(time.Duration(i)*time.Nanosecond), base)
+	}
+
+	running := true
+	_, err := c.ListCommands(ListCommandsRequest{Running: &running, Limit: 1})
+	require.NoError(t, err)
+	c.inventoryMu.Lock()
+	require.Equal(t, 72, c.terminalByFinishedAt.Len())
+	assertCommandInventoryInvariantLocked(t, c)
+	c.inventoryMu.Unlock()
+
+	_, err = c.ListCommands(ListCommandsRequest{Running: &running, Limit: 1})
+	require.NoError(t, err)
+	c.inventoryMu.Lock()
+	defer c.inventoryMu.Unlock()
+	require.Zero(t, c.terminalByFinishedAt.Len())
+	assertCommandInventoryInvariantLocked(t, c)
+}
+
+func testCommandInventoryRetentionLaterListCleansNewlyExpiredEntry(t *testing.T) {
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 10}))
+	startedAt := time.Now().UTC().Add(-time.Minute)
+	finishedAt := time.Now().UTC()
+	registerTerminalInventory(t, c, "terminal", startedAt, finishedAt)
+
+	running := true
+	_, err := c.ListCommands(ListCommandsRequest{Running: &running, Limit: 1})
+	require.NoError(t, err)
+	c.inventoryMu.Lock()
+	require.Equal(t, 1, c.terminalByFinishedAt.Len())
+	assertCommandInventoryInvariantLocked(t, c)
+	entry := c.bySession["terminal"]
+	expiredAt := time.Now().UTC().Add(-2 * time.Hour)
+	entry.finishedAt = &expiredAt
+	c.inventoryMu.Unlock()
+
+	_, err = c.ListCommands(ListCommandsRequest{Running: &running, Limit: 1})
+	require.NoError(t, err)
+	c.inventoryMu.Lock()
+	defer c.inventoryMu.Unlock()
+	require.Zero(t, c.terminalByFinishedAt.Len())
+	assertCommandInventoryInvariantLocked(t, c)
+}
+
+func TestCommandInventoryConcurrentLifecycleAndList(t *testing.T) {
+	const (
+		writers           = 2
+		commandsPerWriter = 100
+		readers           = 2
+	)
+	c := NewController("", "", WithCommandInventory(CommandInventoryConfig{
+		RecoveryTTL: time.Hour,
+		MaxTerminal: writers * commandsPerWriter,
+	}))
+	base := time.Now().UTC().Add(-time.Minute)
+	sessions := make([]string, 0, writers*commandsPerWriter)
+	for writer := range writers {
+		for command := range commandsPerWriter {
+			session := fmt.Sprintf("writer-%d-command-%03d", writer, command)
+			sessions = append(sessions, session)
+			c.storeCommandKernel(session, &commandKernel{running: true, startedAt: base})
+		}
+	}
+
+	start := make(chan struct{})
+	stop := make(chan struct{})
+	errs := make(chan error, writers+readers+1)
+	var writersDone sync.WaitGroup
+	var workers sync.WaitGroup
+	report := func(err error) {
+		select {
+		case errs <- err:
+		default:
+		}
+	}
+
+	for writer := range writers {
+		workers.Add(1)
+		writersDone.Add(1)
+		go func(writer int) {
+			defer workers.Done()
+			defer writersDone.Done()
+			<-start
+			for command := range commandsPerWriter {
+				session := fmt.Sprintf("writer-%d-command-%03d", writer, command)
+				startedAt := base.Add(time.Duration(writer*commandsPerWriter+command) * time.Nanosecond)
+				if err := c.registerRunningCommand(inventoryEntry{session: session, running: true, startedAt: startedAt}); err != nil {
+					report(fmt.Errorf("register %s: %w", session, err))
+					return
+				}
+				finishedAt := startedAt.Add(time.Nanosecond)
+				if err := c.transitionCommandTerminal(inventoryEntry{session: session, startedAt: startedAt, finishedAt: &finishedAt}); err != nil {
+					report(fmt.Errorf("transition %s: %w", session, err))
+					return
+				}
+			}
+		}(writer)
+	}
+
+	for range readers {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if _, err := c.ListCommands(ListCommandsRequest{Limit: 25}); err != nil {
+					report(fmt.Errorf("list commands: %w", err))
+					return
+				}
+			}
+		}()
+	}
+
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		<-start
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if _, err := c.GetCommandStatus(sessions[0]); err != nil {
+				report(fmt.Errorf("legacy command status: %w", err))
+				return
+			}
+		}
+	}()
+
+	close(start)
+	writersDone.Wait()
+	close(stop)
+	workers.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	c.inventoryMu.Lock()
+	defer c.inventoryMu.Unlock()
+	require.Zero(t, c.runningByStartedAt.Len())
+	require.Equal(t, writers*commandsPerWriter, c.terminalByStartedAt.Len())
+	require.Equal(t, writers*commandsPerWriter, c.terminalByFinishedAt.Len())
+	require.Len(t, c.bySession, writers*commandsPerWriter)
+	assertCommandInventoryInvariantLocked(t, c)
+}
+
+func registerTerminalInventory(t *testing.T, c *Controller, session string, startedAt, finishedAt time.Time) {
+	t.Helper()
+	mustRegisterRunning(t, c, inventoryEntry{session: session, running: true, startedAt: startedAt})
+	mustTransitionTerminal(t, c, inventoryEntry{session: session, startedAt: startedAt, finishedAt: &finishedAt})
+}
+
+func commandSummarySessions(commands []CommandSummary) []string {
+	sessions := make([]string, 0, len(commands))
+	for _, command := range commands {
+		sessions = append(sessions, command.Session)
+	}
+	return sessions
+}
+
+func TestCommandInventoryStateMachine(t *testing.T) {
+	startedAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	finishedAt := startedAt.Add(time.Minute)
+	exitCode := 17
+	running := inventoryEntry{
+		session:    "session-1",
+		running:    true,
+		background: true,
+		startedAt:  startedAt,
+	}
+	terminal := inventoryEntry{
+		session:    running.session,
+		background: running.background,
+		startedAt:  startedAt,
+		finishedAt: &finishedAt,
+		exitCode:   &exitCode,
+		errMsg:     "command failed",
+	}
+
+	newController := func(config CommandInventoryConfig) *Controller {
+		return NewController("", "", WithCommandInventory(config))
+	}
+	retainedConfig := CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 1000}
+
+	t.Run("absent to running", func(t *testing.T) {
+		c := newController(retainedConfig)
+		if err := c.registerRunningCommand(running); err != nil {
+			t.Fatalf("register running command: %v", err)
+		}
+		entry := c.bySession[running.session]
+		if entry == nil || entry == &running || !entry.running {
+			t.Fatal("running command was not stored as a running snapshot")
+		}
+		assertInventoryIndexes(t, c, entry, 1, 0, 0)
+		assertIndexIdentity(t, c.runningByStartedAt, entry, "running")
+	})
+
+	t.Run("running to terminal", func(t *testing.T) {
+		c := newController(retainedConfig)
+		mustRegisterRunning(t, c, running)
+		runningEntry := c.bySession[running.session]
+		if err := c.transitionCommandTerminal(terminal); err != nil {
+			t.Fatalf("transition command terminal: %v", err)
+		}
+		entry := c.bySession[running.session]
+		if entry == nil || entry == runningEntry || entry.running {
+			t.Fatal("terminal command did not replace the running map identity")
+		}
+		assertInventoryIndexes(t, c, entry, 0, 1, 1)
+		if _, ok := c.runningByStartedAt.Get(runningEntry); ok {
+			t.Fatal("running index retained the replaced running entry")
+		}
+		assertIndexIdentity(t, c.terminalByStartedAt, entry, "terminal start")
+		assertIndexIdentity(t, c.terminalByFinishedAt, entry, "terminal finish")
+	})
+
+	t.Run("duplicate terminal is a no-op", func(t *testing.T) {
+		c := newController(retainedConfig)
+		mustRegisterRunning(t, c, running)
+		mustTransitionTerminal(t, c, terminal)
+		entry := c.bySession[running.session]
+		sequence := c.terminalSequence
+		if err := c.transitionCommandTerminal(terminal); err != nil {
+			t.Fatalf("duplicate terminal transition: %v", err)
+		}
+		if c.bySession[running.session] != entry || c.terminalSequence != sequence {
+			t.Fatal("duplicate terminal transition changed map identity or sequence")
+		}
+		assertInventoryIndexes(t, c, entry, 0, 1, 1)
+		assertIndexIdentity(t, c.terminalByStartedAt, entry, "terminal start")
+		assertIndexIdentity(t, c.terminalByFinishedAt, entry, "terminal finish")
+	})
+
+	t.Run("absent to terminal is rejected without index writes", func(t *testing.T) {
+		c := newController(retainedConfig)
+		if err := c.transitionCommandTerminal(terminal); err == nil {
+			t.Fatal("transitioning an absent command to terminal succeeded")
+		}
+		if _, ok := c.bySession[running.session]; ok {
+			t.Fatal("absent terminal transition inserted a map entry")
+		}
+		assertInventoryIndexes(t, c, nil, 0, 0, 0)
+	})
+
+	t.Run("terminal to running is rejected without index writes", func(t *testing.T) {
+		c := newController(retainedConfig)
+		mustRegisterRunning(t, c, running)
+		mustTransitionTerminal(t, c, terminal)
+		entry := c.bySession[running.session]
+		sequence := c.terminalSequence
+		if err := c.registerRunningCommand(running); err == nil {
+			t.Fatal("transitioning a terminal command to running succeeded")
+		}
+		if c.bySession[running.session] != entry || c.terminalSequence != sequence {
+			t.Fatal("terminal to running changed map identity or sequence")
+		}
+		assertInventoryIndexes(t, c, entry, 0, 1, 1)
+	})
+
+	t.Run("mismatched terminal summary is rejected without mutation", func(t *testing.T) {
+		c := newController(retainedConfig)
+		mustRegisterRunning(t, c, running)
+		entry := c.bySession[running.session]
+		mismatched := terminal
+		mismatched.background = !running.background
+		if err := c.transitionCommandTerminal(mismatched); err == nil {
+			t.Fatal("mismatched terminal summary succeeded")
+		}
+		if c.bySession[running.session] != entry || c.terminalSequence != 0 {
+			t.Fatal("mismatched terminal summary changed the running state")
+		}
+		assertInventoryIndexes(t, c, entry, 1, 0, 0)
+	})
+
+	t.Run("terminal without finished time is rejected without mutation", func(t *testing.T) {
+		c := newController(retainedConfig)
+		mustRegisterRunning(t, c, running)
+		entry := c.bySession[running.session]
+		invalid := terminal
+		invalid.finishedAt = nil
+		if err := c.transitionCommandTerminal(invalid); err == nil {
+			t.Fatal("terminal summary without finished time succeeded")
+		}
+		if c.bySession[running.session] != entry || c.terminalSequence != 0 {
+			t.Fatal("invalid terminal summary changed the running state")
+		}
+		assertInventoryIndexes(t, c, entry, 1, 0, 0)
+	})
+
+	for _, test := range []struct {
+		name   string
+		config CommandInventoryConfig
+	}{
+		{name: "zero TTL", config: CommandInventoryConfig{RecoveryTTL: 0, MaxTerminal: 1000}},
+		{name: "zero cap", config: CommandInventoryConfig{RecoveryTTL: time.Hour, MaxTerminal: 0}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := newController(test.config)
+			mustRegisterRunning(t, c, running)
+			mustTransitionTerminal(t, c, terminal)
+			if _, ok := c.bySession[running.session]; ok {
+				t.Fatal("zero retention terminal transition did not delete the map entry")
+			}
+			assertInventoryIndexes(t, c, nil, 0, 0, 0)
+			if err := c.transitionCommandTerminal(terminal); err == nil {
+				t.Fatal("duplicate zero retention terminal transition succeeded")
+			}
+			if _, ok := c.bySession[running.session]; ok {
+				t.Fatal("duplicate terminal transition resurrected the map entry")
+			}
+			assertInventoryIndexes(t, c, nil, 0, 0, 0)
+		})
+	}
+
+	t.Run("source index inconsistency does not mutate further", func(t *testing.T) {
+		c := newController(retainedConfig)
+		mustRegisterRunning(t, c, running)
+		entry := c.bySession[running.session]
+		if _, ok := c.runningByStartedAt.Delete(entry); !ok {
+			t.Fatal("delete running index entry")
+		}
+		if err := c.transitionCommandTerminal(terminal); err == nil {
+			t.Fatal("transition with missing running index succeeded")
+		}
+		if c.bySession[running.session] != entry || c.terminalSequence != 0 {
+			t.Fatal("transition with missing running index mutated map or sequence")
+		}
+		assertInventoryIndexes(t, c, nil, 0, 0, 0)
+	})
+
+	t.Run("target index inconsistency does not mutate running state", func(t *testing.T) {
+		c := newController(retainedConfig)
+		mustRegisterRunning(t, c, running)
+		entry := c.bySession[running.session]
+		blocker := &inventoryEntry{
+			session:          running.session,
+			startedAt:        running.startedAt,
+			finishedAt:       &finishedAt,
+			terminalSequence: 1,
+		}
+		if _, replaced := c.terminalByStartedAt.Set(blocker); replaced {
+			t.Fatal("set target index blocker replaced an entry")
+		}
+		if err := c.transitionCommandTerminal(terminal); err == nil {
+			t.Fatal("transition with occupied target index succeeded")
+		}
+		if c.bySession[running.session] != entry || c.terminalSequence != 0 {
+			t.Fatal("transition with occupied target index mutated map or sequence")
+		}
+		assertIndexIdentity(t, c.runningByStartedAt, entry, "running")
+		assertIndexIdentity(t, c.terminalByStartedAt, blocker, "target blocker")
+		if c.runningByStartedAt.Len() != 1 || c.terminalByStartedAt.Len() != 1 || c.terminalByFinishedAt.Len() != 0 {
+			t.Fatal("transition with occupied target index changed tree lengths")
+		}
+	})
+
+	t.Run("terminal delete preflight prevents partial deletion", func(t *testing.T) {
+		c := newController(retainedConfig)
+		mustRegisterRunning(t, c, running)
+		mustTransitionTerminal(t, c, terminal)
+		entry := c.bySession[running.session]
+		if _, ok := c.terminalByFinishedAt.Delete(entry); !ok {
+			t.Fatal("delete terminal finish index entry")
+		}
+		if err := c.deleteTerminalLocked(entry); err == nil {
+			t.Fatal("terminal delete with missing finish index succeeded")
+		}
+		if c.bySession[running.session] != entry {
+			t.Fatal("terminal delete with missing finish index changed map identity")
+		}
+		assertIndexIdentity(t, c.terminalByStartedAt, entry, "terminal start")
+		if c.runningByStartedAt.Len() != 0 || c.terminalByStartedAt.Len() != 1 || c.terminalByFinishedAt.Len() != 0 {
+			t.Fatal("terminal delete preflight changed tree lengths")
+		}
+	})
+
+	t.Run("index key contracts", testCommandInventoryIndexKeys)
+}
+
+func testCommandInventoryIndexKeys(t *testing.T) {
+	c := NewController("", "")
+	startedAt := time.Unix(0, 42).UTC()
+	finishedAt := time.Unix(0, 84).UTC()
+
+	runningB := &inventoryEntry{session: "b", startedAt: startedAt}
+	runningA := &inventoryEntry{session: "a", startedAt: startedAt}
+	if _, replaced := c.runningByStartedAt.Set(runningB); replaced {
+		t.Fatal("running B unexpectedly replaced an entry")
+	}
+	if _, replaced := c.runningByStartedAt.Set(runningA); replaced {
+		t.Fatal("running A unexpectedly replaced an entry")
+	}
+	assertIndexSessions(t, c.runningByStartedAt, []string{"a", "b"})
+	if previous, replaced := c.runningByStartedAt.Set(&inventoryEntry{session: "a", startedAt: startedAt}); !replaced || previous != runningA {
+		t.Fatal("running index did not use exactly startedAt/session as its unique key")
+	}
+
+	terminalStartB := &inventoryEntry{session: "b", startedAt: startedAt, finishedAt: &finishedAt, terminalSequence: 2}
+	terminalStartA := &inventoryEntry{session: "a", startedAt: startedAt, finishedAt: &finishedAt, terminalSequence: 3}
+	if _, replaced := c.terminalByStartedAt.Set(terminalStartB); replaced {
+		t.Fatal("terminal start B unexpectedly replaced an entry")
+	}
+	if _, replaced := c.terminalByStartedAt.Set(terminalStartA); replaced {
+		t.Fatal("terminal start A unexpectedly replaced an entry")
+	}
+	assertIndexSessions(t, c.terminalByStartedAt, []string{"a", "b"})
+	if previous, replaced := c.terminalByStartedAt.Set(&inventoryEntry{session: "a", startedAt: startedAt, finishedAt: &finishedAt, terminalSequence: 99}); !replaced || previous != terminalStartA {
+		t.Fatal("terminal start index did not use exactly startedAt/session as its unique key")
+	}
+
+	terminalFinishSequenceTwo := &inventoryEntry{session: "a", startedAt: startedAt, finishedAt: &finishedAt, terminalSequence: 2}
+	terminalFinishSequenceOne := &inventoryEntry{session: "z", startedAt: startedAt, finishedAt: &finishedAt, terminalSequence: 1}
+	if _, replaced := c.terminalByFinishedAt.Set(terminalFinishSequenceTwo); replaced {
+		t.Fatal("terminal finish sequence two unexpectedly replaced an entry")
+	}
+	if _, replaced := c.terminalByFinishedAt.Set(terminalFinishSequenceOne); replaced {
+		t.Fatal("terminal finish sequence one unexpectedly replaced an entry")
+	}
+	assertIndexSessions(t, c.terminalByFinishedAt, []string{"z", "a"})
+	if previous, replaced := c.terminalByFinishedAt.Set(&inventoryEntry{session: "other", startedAt: startedAt, finishedAt: &finishedAt, terminalSequence: 1}); !replaced || previous != terminalFinishSequenceOne {
+		t.Fatal("terminal finish index did not use exactly finishedAt/terminalSequence as its unique key")
+	}
+}
+
+func TestCommandInventoryProcessIdentity(t *testing.T) {
+	c := NewController("", "")
+	originalID := c.inventoryProcessID
+	if originalID == "" {
+		t.Fatal("controller process identity is empty")
+	}
+	startedAt := time.Now().UTC()
+	finishedAt := startedAt.Add(time.Second)
+	running := inventoryEntry{session: "session-1", running: true, startedAt: startedAt}
+	terminal := inventoryEntry{session: running.session, startedAt: startedAt, finishedAt: &finishedAt}
+	mustRegisterRunning(t, c, running)
+	mustTransitionTerminal(t, c, terminal)
+	if c.inventoryProcessID != originalID {
+		t.Fatal("controller process identity changed during a command transition")
+	}
+
+	other := NewController("", "")
+	if other.inventoryProcessID == "" {
+		t.Fatal("second controller process identity is empty")
+	}
+	if c.inventoryProcessID == other.inventoryProcessID {
+		t.Fatal("controllers share a process-local inventory identity")
+	}
+}
+
+func mustRegisterRunning(t *testing.T, c *Controller, summary inventoryEntry) {
+	t.Helper()
+	if err := c.registerRunningCommand(summary); err != nil {
+		t.Fatalf("register running command: %v", err)
+	}
+}
+
+func mustTransitionTerminal(t *testing.T, c *Controller, summary inventoryEntry) {
+	t.Helper()
+	if err := c.transitionCommandTerminal(summary); err != nil {
+		t.Fatalf("transition terminal command: %v", err)
+	}
+}
+
+func assertInventoryIndexes(t *testing.T, c *Controller, entry *inventoryEntry, running, terminalStarted, terminalFinished int) {
+	t.Helper()
+	if c.runningByStartedAt.Len() != running || c.terminalByStartedAt.Len() != terminalStarted || c.terminalByFinishedAt.Len() != terminalFinished {
+		t.Fatalf("unexpected index lengths: running=%d terminal-start=%d terminal-finish=%d", c.runningByStartedAt.Len(), c.terminalByStartedAt.Len(), c.terminalByFinishedAt.Len())
+	}
+	if entry == nil {
+		return
+	}
+	if entry.running {
+		assertIndexIdentity(t, c.runningByStartedAt, entry, "running")
+		return
+	}
+	assertIndexIdentity(t, c.terminalByStartedAt, entry, "terminal start")
+	assertIndexIdentity(t, c.terminalByFinishedAt, entry, "terminal finish")
+}
+
+func assertIndexIdentity(t *testing.T, index interface {
+	Get(*inventoryEntry) (*inventoryEntry, bool)
+}, entry *inventoryEntry, name string) {
+	t.Helper()
+	stored, ok := index.Get(entry)
+	if !ok || stored != entry {
+		t.Fatalf("%s index does not contain the expected identity", name)
+	}
+}
+
+func assertIndexSessions(t *testing.T, index interface {
+	Scan(func(*inventoryEntry) bool)
+}, expected []string) {
+	t.Helper()
+	var actual []string
+	index.Scan(func(entry *inventoryEntry) bool {
+		actual = append(actual, entry.session)
+		return true
+	})
+	if len(actual) != len(expected) {
+		t.Fatalf("unexpected index scan length: got %v, want %v", actual, expected)
+	}
+	for i := range expected {
+		if actual[i] != expected[i] {
+			t.Fatalf("unexpected index scan: got %v, want %v", actual, expected)
+		}
+	}
+}
+
+// assertCommandInventoryInvariantLocked verifies every map entry has exactly
+// one state-appropriate index identity. Callers must hold inventoryMu.
+func assertCommandInventoryInvariantLocked(t *testing.T, c *Controller) {
+	t.Helper()
+	running := make(map[string]*inventoryEntry, c.runningByStartedAt.Len())
+	c.runningByStartedAt.Scan(func(entry *inventoryEntry) bool {
+		if entry == nil {
+			t.Fatal("nil running index entry")
+		}
+		if !entry.running || running[entry.session] != nil {
+			t.Fatalf("invalid or duplicate running index entry for %q", entry.session)
+		}
+		running[entry.session] = entry
+		return true
+	})
+	terminalStarted := make(map[string]*inventoryEntry, c.terminalByStartedAt.Len())
+	c.terminalByStartedAt.Scan(func(entry *inventoryEntry) bool {
+		if entry == nil {
+			t.Fatal("nil terminal-start index entry")
+		}
+		if entry.running || entry.finishedAt == nil || terminalStarted[entry.session] != nil {
+			t.Fatalf("invalid or duplicate terminal-start index entry for %q", entry.session)
+		}
+		terminalStarted[entry.session] = entry
+		return true
+	})
+	terminalFinished := make(map[string]*inventoryEntry, c.terminalByFinishedAt.Len())
+	c.terminalByFinishedAt.Scan(func(entry *inventoryEntry) bool {
+		if entry == nil {
+			t.Fatal("nil terminal-finish index entry")
+		}
+		if entry.running || entry.finishedAt == nil || terminalFinished[entry.session] != nil {
+			t.Fatalf("invalid or duplicate terminal-finish index entry for %q", entry.session)
+		}
+		terminalFinished[entry.session] = entry
+		return true
+	})
+	if len(c.bySession) != len(running)+len(terminalStarted) || len(terminalStarted) != len(terminalFinished) {
+		t.Fatalf("inventory cardinality mismatch: map=%d running=%d terminal-start=%d terminal-finish=%d", len(c.bySession), len(running), len(terminalStarted), len(terminalFinished))
+	}
+	for session, entry := range c.bySession {
+		if entry == nil || entry.session != session || entry.indexSession != session || entry.indexStartedAt != entry.startedAt.UnixNano() {
+			t.Fatalf("invalid map entry for %q", session)
+		}
+		if entry.running {
+			if running[session] != entry || terminalStarted[session] != nil || terminalFinished[session] != nil {
+				t.Fatalf("running map/index identity mismatch for %q", session)
+			}
+			continue
+		}
+		if terminalStarted[session] != entry || terminalFinished[session] != entry || running[session] != nil {
+			t.Fatalf("terminal map/index identity mismatch for %q", session)
+		}
+	}
+}
+
+func TestCommandInventoryTerminalSnapshotReleasesControllerLock(t *testing.T) {
+	c := NewController("", "")
+	startedAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	c.storeCommandKernel("session", &commandKernel{
+		startedAt: startedAt, running: true, isBackground: true,
+	})
+
+	snapshot := c.markCommandFinished("session", 17, "command failed")
+	require.Equal(t, "session", snapshot.session)
+	require.Equal(t, startedAt, snapshot.startedAt)
+	require.Equal(t, 17, snapshot.exitCode)
+	require.Equal(t, "command failed", snapshot.errMsg)
+	require.True(t, snapshot.background)
+	require.False(t, snapshot.finishedAt.IsZero())
+
+	locked := make(chan struct{})
+	go func() {
+		c.mu.Lock()
+		close(locked)
+		c.mu.Unlock()
+	}()
+	select {
+	case <-locked:
+	case <-time.After(time.Second):
+		t.Fatal("markCommandFinished returned with c.mu held")
+	}
+
+	c.mu.Lock()
+	kernel := c.getCommandKernel("session")
+	kernel.startedAt = time.Time{}
+	kernel.errMsg = "mutated"
+	c.mu.Unlock()
+	require.Equal(t, startedAt, snapshot.startedAt)
+	require.Equal(t, "command failed", snapshot.errMsg)
+}

--- a/components/execd/pkg/runtime/command_inventory_windows_test.go
+++ b/components/execd/pkg/runtime/command_inventory_windows_test.go
@@ -1,0 +1,304 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/alibaba/opensandbox/execd/pkg/jupyter/execute"
+)
+
+// TestCommandInventoryWindows exercises the Windows cmd.exe implementation,
+// rather than merely cross-compiling the shared inventory tests.
+func TestCommandInventoryWindows(t *testing.T) {
+	for _, background := range []bool{false, true} {
+		for _, success := range []bool{true, false} {
+			background, success := background, success
+			name := "foreground"
+			if background {
+				name = "background"
+			}
+			if success {
+				name += "/success"
+			} else {
+				name += "/nonzero"
+			}
+			t.Run(name, func(t *testing.T) {
+				testCommandInventoryWindowsTerminalLifecycle(t, background, success)
+			})
+		}
+	}
+}
+
+func testCommandInventoryWindowsTerminalLifecycle(t *testing.T, background, success bool) {
+	t.Helper()
+	c := NewController("", "")
+	label := fmt.Sprintf("inventory-windows-%t-%t", background, success)
+	exitCode := 17
+	if success {
+		exitCode = 0
+	}
+
+	var session string
+	request := &ExecuteCodeRequest{
+		// cmd-compatible syntax is intentional: Windows runtime invokes cmd /C.
+		Code: fmt.Sprintf("echo %s & exit /b %d", label, exitCode),
+		Cwd:  t.TempDir(),
+		Hooks: ExecuteResultHook{
+			OnExecuteInit:     func(id string) { session = id },
+			OnExecuteStdout:   func(string) {},
+			OnExecuteStderr:   func(string) {},
+			OnExecuteError:    func(*execute.ErrorOutput) {},
+			OnExecuteComplete: func(time.Duration) {},
+		},
+	}
+
+	if background {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		require.NoError(t, c.runBackgroundCommand(ctx, cancel, request))
+	} else {
+		require.NoError(t, c.runCommand(context.Background(), request))
+	}
+	require.NotEmpty(t, session)
+
+	status := awaitWindowsTerminalStatus(t, c, session)
+	require.Equal(t, exitCode, *status.ExitCode)
+	awaitWindowsTerminalInventory(t, c, session, background, exitCode)
+
+	logs, _, logsErr := c.SeekBackgroundCommandOutput(session, 0)
+	if background {
+		require.NoError(t, logsErr)
+		require.Contains(t, string(logs), label)
+	} else {
+		require.EqualError(t, logsErr, "command "+session+" is not running in background")
+	}
+	require.EqualError(t, c.Interrupt(session), "command session "+session+" is not running")
+}
+
+// TestCommandInventorySafePoint is run by the Windows CI matrix alongside the
+// Windows-specific lifecycle test. It verifies that cmd command startup is
+// registered before the background call returns.
+func TestCommandInventorySafePoint(t *testing.T) {
+	for _, background := range []bool{false, true} {
+		name := "foreground"
+		if background {
+			name = "background"
+		}
+		t.Run(name, func(t *testing.T) {
+			testCommandInventoryWindowsSafePoint(t, background)
+		})
+	}
+}
+
+func testCommandInventoryWindowsSafePoint(t *testing.T, background bool) {
+	t.Helper()
+	c := NewController("", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The inventory mutex is the approved registration barrier. Holding it
+	// proves registration is pending without relying on command duration.
+	c.inventoryMu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			c.inventoryMu.Unlock()
+		}
+	}()
+
+	initReturned := make(chan string, 1)
+	callbackEntered := make(chan struct{}, 1)
+	releaseCallback := make(chan struct{})
+	runDone := make(chan error, 1)
+	request := &ExecuteCodeRequest{
+		Cwd: t.TempDir(),
+		Hooks: ExecuteResultHook{
+			OnExecuteInit:   func(id string) { initReturned <- id },
+			OnExecuteStdout: func(string) {},
+			OnExecuteStderr: func(string) {},
+			OnExecuteError:  func(*execute.ErrorOutput) {},
+			OnExecuteComplete: func(time.Duration) {
+				callbackEntered <- struct{}{}
+				<-releaseCallback
+			},
+		},
+	}
+	if background {
+		// Keep the real cmd process alive until this test interrupts it.
+		request.Code = "ping -n 20 127.0.0.1 >nul & exit /b 0"
+		go func() { runDone <- c.runBackgroundCommand(ctx, cancel, request) }()
+	} else {
+		// The completion callback keeps the terminal inventory transition from
+		// overtaking the post-registration running assertion.
+		request.Code = "exit /b 0"
+		go func() { runDone <- c.runCommand(ctx, request) }()
+	}
+
+	session := <-initReturned
+	require.NotEmpty(t, session)
+	waitForWindowsStoredKernel(t, c, session)
+	_, registered := c.bySession[session]
+	require.False(t, registered, "inventory registration must block at the safe point")
+	assertWindowsCommandBlocked(t, runDone)
+
+	c.inventoryMu.Unlock()
+	locked = false
+	if background {
+		awaitWindowsSignal(t, callbackEntered, "background startup callback")
+		requireWindowsRunningInventory(t, c, session)
+		require.NoError(t, c.Interrupt(session))
+		close(releaseCallback)
+		require.NoError(t, <-runDone)
+		awaitWindowsTerminalStatus(t, c, session)
+		return
+	}
+
+	awaitWindowsSignal(t, callbackEntered, "foreground completion callback")
+	requireWindowsRunningInventory(t, c, session)
+	assertWindowsCommandBlocked(t, runDone)
+	close(releaseCallback)
+	require.NoError(t, <-runDone)
+	awaitWindowsTerminalStatus(t, c, session)
+}
+
+// TestCommandInventoryStartFailure verifies that failed cmd startup does not
+// create an inventory summary on Windows.
+func TestCommandInventoryStartFailure(t *testing.T) {
+	for _, background := range []bool{false, true} {
+		name := "foreground"
+		if background {
+			name = "background"
+		}
+		t.Run(name, func(t *testing.T) {
+			c := NewController("", "")
+			var session string
+			req := &ExecuteCodeRequest{
+				Code: "exit /b 0",
+				Cwd:  filepath.Join(t.TempDir(), "missing"),
+				Hooks: ExecuteResultHook{
+					OnExecuteInit:     func(id string) { session = id },
+					OnExecuteError:    func(*execute.ErrorOutput) {},
+					OnExecuteComplete: func(time.Duration) {},
+				},
+			}
+			if background {
+				require.Error(t, c.runBackgroundCommand(context.Background(), func() {}, req))
+			} else {
+				require.NoError(t, c.runCommand(context.Background(), req))
+			}
+			require.NotEmpty(t, session)
+			listed, err := c.ListCommands(ListCommandsRequest{Limit: 100})
+			require.NoError(t, err)
+			require.NotContains(t, commandInventorySessions(listed.Commands), session)
+			_, err = c.GetCommandStatus(session)
+			require.EqualError(t, err, "command not found: "+session)
+		})
+	}
+}
+
+func awaitWindowsTerminalStatus(t *testing.T, c *Controller, session string) *CommandStatus {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		status, err := c.GetCommandStatus(session)
+		if err == nil && !status.Running {
+			return status
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("Windows command session %s did not reach terminal status", session)
+	return nil
+}
+
+func awaitWindowsTerminalInventory(t *testing.T, c *Controller, session string, background bool, exitCode int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		listed, err := c.ListCommands(ListCommandsRequest{Limit: 100})
+		require.NoError(t, err)
+		for _, summary := range listed.Commands {
+			if summary.Session != session {
+				continue
+			}
+			if !summary.Running && summary.Background == background && summary.ExitCode != nil && *summary.ExitCode == exitCode {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf(
+		"Windows command session %s did not reach expected terminal inventory state (background=%t exit_code=%d)",
+		session,
+		background,
+		exitCode,
+	)
+}
+
+func waitForWindowsStoredKernel(t *testing.T, c *Controller, session string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.getCommandKernel(session) != nil {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("Windows command session %s was not stored after init callback", session)
+}
+
+func requireWindowsRunningInventory(t *testing.T, c *Controller, session string) {
+	t.Helper()
+	c.inventoryMu.Lock()
+	defer c.inventoryMu.Unlock()
+	entry := c.bySession[session]
+	require.NotNil(t, entry)
+	require.True(t, entry.running)
+	require.Equal(t, 1, c.runningByStartedAt.Len())
+}
+
+func assertWindowsCommandBlocked(t *testing.T, done <-chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		t.Fatalf("Windows command returned before inventory registration completed: %v", err)
+	default:
+	}
+}
+
+func awaitWindowsSignal(t *testing.T, signal <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout waiting for %s", name)
+	}
+}
+
+func commandInventorySessions(commands []CommandSummary) []string {
+	sessions := make([]string, 0, len(commands))
+	for _, command := range commands {
+		sessions = append(sessions, command.Session)
+	}
+	return sessions
+}

--- a/components/execd/pkg/runtime/command_status.go
+++ b/components/execd/pkg/runtime/command_status.go
@@ -112,19 +112,19 @@ func (c *Controller) SeekBackgroundCommandOutput(session string, cursor int64) (
 	return data, currentPos, nil
 }
 
-// markCommandFinished updates bookkeeping when a command exits.
-func (c *Controller) markCommandFinished(session string, exitCode int, errMsg string) {
+// markCommandFinished updates bookkeeping when a command exits and returns a
+// value snapshot after releasing Controller.mu.
+func (c *Controller) markCommandFinished(session string, exitCode int, errMsg string) commandTerminalSnapshot {
 	now := time.Now()
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	var kernel *commandKernel
 	if v, ok := c.commandClientMap.Load(session); ok {
 		kernel, _ = v.(*commandKernel)
 	}
 	if kernel == nil {
-		return
+		c.mu.Unlock()
+		return commandTerminalSnapshot{}
 	}
 
 	kernel.exitCode = &exitCode
@@ -135,4 +135,14 @@ func (c *Controller) markCommandFinished(session string, exitCode int, errMsg st
 	// process. Group-wide kill would otherwise amplify the impact of a
 	// stale-PID hit to every process in the unrelated process group.
 	kernel.pid = 0
+	snapshot := commandTerminalSnapshot{
+		session:    session,
+		startedAt:  kernel.startedAt,
+		finishedAt: now,
+		exitCode:   exitCode,
+		errMsg:     errMsg,
+		background: kernel.isBackground,
+	}
+	c.mu.Unlock()
+	return snapshot
 }

--- a/components/execd/pkg/runtime/command_windows.go
+++ b/components/execd/pkg/runtime/command_windows.go
@@ -80,21 +80,27 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 
 	kernel := &commandKernel{
 		pid:          cmd.Process.Pid,
+		stdoutPath:   c.stdoutFileName(session),
+		stderrPath:   c.stderrFileName(session),
+		startedAt:    startAt,
+		running:      true,
 		content:      request.Code,
 		isBackground: false,
 	}
 	c.storeCommandKernel(session, kernel)
+	c.registerCommandKernelRunning(session, kernel)
 
 	err = cmd.Wait()
 	close(done)
 	wg.Wait()
 	if err != nil {
 		var eName, eValue string
+		exitCode := 1
 		var traceback []string
 
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
-			exitCode := exitError.ExitCode()
+			exitCode = exitError.ExitCode()
 			eName = "CommandExecError"
 			eValue = strconv.Itoa(exitCode)
 		} else {
@@ -110,9 +116,13 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 		})
 
 		log.Error("CommandExecError: error running commands: %v", err)
+		snapshot := c.markCommandFinished(session, exitCode, err.Error())
+		c.transitionCommandTerminalSnapshot(snapshot)
 		return nil
 	}
+	snapshot := c.markCommandFinished(session, 0, "")
 	request.Hooks.OnExecuteComplete(time.Since(startAt))
+	c.transitionCommandTerminalSnapshot(snapshot)
 	return nil
 }
 
@@ -166,6 +176,7 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 		isBackground: true,
 	}
 	c.storeCommandKernel(session, kernel)
+	c.registerCommandKernelRunning(session, kernel)
 
 	safego.Go(func() {
 		<-ctx.Done()
@@ -187,10 +198,12 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 			if errors.As(err, &exitError) {
 				exitCode = exitError.ExitCode()
 			}
-			c.markCommandFinished(session, exitCode, err.Error())
+			snapshot := c.markCommandFinished(session, exitCode, err.Error())
+			c.transitionCommandTerminalSnapshot(snapshot)
 			return
 		}
-		c.markCommandFinished(session, 0, "")
+		snapshot := c.markCommandFinished(session, 0, "")
+		c.transitionCommandTerminalSnapshot(snapshot)
 	})
 
 	request.Hooks.OnExecuteComplete(time.Since(startAt))

--- a/components/execd/pkg/runtime/ctrl.go
+++ b/components/execd/pkg/runtime/ctrl.go
@@ -17,10 +17,14 @@ package runtime
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/tidwall/btree"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/alibaba/opensandbox/execd/pkg/jupyter"
@@ -31,6 +35,30 @@ var kernelWaitingBackoff = wait.Backoff{
 	Duration: 500 * time.Millisecond,
 	Factor:   1.5,
 	Jitter:   0.1,
+}
+
+// ErrInvalidCommandCursor reports an invalid command inventory cursor.
+var ErrInvalidCommandCursor = errors.New("invalid cursor")
+
+// CommandInventoryConfig controls retention of completed command summaries.
+type CommandInventoryConfig struct {
+	RecoveryTTL time.Duration
+	MaxTerminal int
+}
+
+var defaultCommandInventoryConfig = CommandInventoryConfig{
+	RecoveryTTL: time.Hour,
+	MaxTerminal: 1000,
+}
+
+// ControllerOption configures a Controller.
+type ControllerOption func(*Controller)
+
+// WithCommandInventory configures command inventory retention.
+func WithCommandInventory(config CommandInventoryConfig) ControllerOption {
+	return func(c *Controller) {
+		c.commandInventoryConfig = config
+	}
 }
 
 // Controller manages code execution across runtimes.
@@ -46,6 +74,16 @@ type Controller struct {
 	isolatedSessionMap      sync.Map // map[sessionID]*isolatedSession
 	db                      *sql.DB
 	dbOnce                  sync.Once
+
+	inventoryMu            sync.Mutex
+	inventoryProcessID     string
+	bySession              map[string]*inventoryEntry
+	runningByStartedAt     *btree.BTreeG[*inventoryEntry]
+	terminalByStartedAt    *btree.BTreeG[*inventoryEntry]
+	terminalByFinishedAt   *btree.BTreeG[*inventoryEntry]
+	commandInventoryConfig CommandInventoryConfig
+	terminalSequence       uint64
+	cleanupOwner           atomic.Bool
 }
 
 type jupyterKernel struct {
@@ -69,11 +107,21 @@ type commandKernel struct {
 }
 
 // NewController creates a runtime controller.
-func NewController(baseURL, token string) *Controller {
-	return &Controller{
-		baseURL: baseURL,
-		token:   token,
+func NewController(baseURL, token string, options ...ControllerOption) *Controller {
+	c := &Controller{
+		baseURL:                baseURL,
+		token:                  token,
+		inventoryProcessID:     uuid.NewString(),
+		bySession:              make(map[string]*inventoryEntry),
+		runningByStartedAt:     btree.NewBTreeGOptions(inventoryEntryStartedLess, btree.Options{NoLocks: true}),
+		terminalByStartedAt:    btree.NewBTreeGOptions(inventoryEntryStartedLess, btree.Options{NoLocks: true}),
+		terminalByFinishedAt:   btree.NewBTreeGOptions(inventoryEntryTerminalFinishedLess, btree.Options{NoLocks: true}),
+		commandInventoryConfig: defaultCommandInventoryConfig,
 	}
+	for _, option := range options {
+		option(c)
+	}
+	return c
 }
 
 // Execute dispatches a request to the correct backend.

--- a/components/execd/pkg/web/controller/codeinterpreting.go
+++ b/components/execd/pkg/web/controller/codeinterpreting.go
@@ -35,7 +35,14 @@ import (
 var codeRunner codeExecutionRunner
 
 func InitCodeRunner() *runtime.Controller {
-	ctrl := runtime.NewController(flag.JupyterServerHost, flag.JupyterServerToken)
+	ctrl := runtime.NewController(
+		flag.JupyterServerHost,
+		flag.JupyterServerToken,
+		runtime.WithCommandInventory(runtime.CommandInventoryConfig{
+			RecoveryTTL: flag.CommandRecoveryTTL,
+			MaxTerminal: flag.CommandRecoveryMaxTerminal,
+		}),
+	)
 	codeRunner = ctrl
 	return ctrl
 }
@@ -50,6 +57,7 @@ type codeExecutionRunner interface {
 	Execute(request *runtime.ExecuteCodeRequest) error
 	GetContext(session string) (runtime.CodeContext, error)
 	GetCommandStatus(session string) (*runtime.CommandStatus, error)
+	ListCommands(request runtime.ListCommandsRequest) (runtime.ListCommandsResponse, error)
 	ListContext(language string) ([]runtime.CodeContext, error)
 	DeleteLanguageContext(language runtime.Language) error
 	DeleteContext(session string) error

--- a/components/execd/pkg/web/controller/codeinterpreting_test.go
+++ b/components/execd/pkg/web/controller/codeinterpreting_test.go
@@ -34,6 +34,7 @@ import (
 type fakeCodeRunner struct {
 	execute          func(request *runtime.ExecuteCodeRequest) error
 	runInBashSession func(_ context.Context, _ *runtime.ExecuteCodeRequest) error
+	listCommands     func(runtime.ListCommandsRequest) (runtime.ListCommandsResponse, error)
 }
 
 func (f *fakeCodeRunner) CreateContext(_ *runtime.CreateContextRequest) (string, error) {
@@ -53,6 +54,13 @@ func (f *fakeCodeRunner) GetContext(_ string) (runtime.CodeContext, error) {
 
 func (f *fakeCodeRunner) GetCommandStatus(_ string) (*runtime.CommandStatus, error) {
 	return nil, nil
+}
+
+func (f *fakeCodeRunner) ListCommands(request runtime.ListCommandsRequest) (runtime.ListCommandsResponse, error) {
+	if f.listCommands != nil {
+		return f.listCommands(request)
+	}
+	return runtime.ListCommandsResponse{}, nil
 }
 
 func (f *fakeCodeRunner) ListContext(_ string) ([]runtime.CodeContext, error) {
@@ -96,6 +104,68 @@ func (f *fakeCodeRunner) CreatePTYSession(_ string, _ string, _ string) (runtime
 func (f *fakeCodeRunner) GetPTYSession(_ string) runtime.PTYSession         { return nil }
 func (f *fakeCodeRunner) DeletePTYSession(_ string) error                   { return nil }
 func (f *fakeCodeRunner) GetPTYSessionStatus(_ string) (bool, int64, error) { return false, 0, nil }
+
+func TestInitCodeRunnerCommandInventoryConfig(t *testing.T) {
+	previousRunner := codeRunner
+	previousTTL := flag.CommandRecoveryTTL
+	previousMaxTerminal := flag.CommandRecoveryMaxTerminal
+	t.Cleanup(func() {
+		codeRunner = previousRunner
+		flag.CommandRecoveryTTL = previousTTL
+		flag.CommandRecoveryMaxTerminal = previousMaxTerminal
+	})
+
+	for _, test := range []struct {
+		name        string
+		ttl         time.Duration
+		maxTerminal int
+		commands    int
+		wantListed  int
+	}{
+		{name: "retains configured terminal inventory", ttl: time.Hour, maxTerminal: 1000, commands: 1, wantListed: 1},
+		{name: "enforces configured terminal cap", ttl: time.Hour, maxTerminal: 1, commands: 2, wantListed: 1},
+		{name: "zero terminal capacity", ttl: time.Hour, maxTerminal: 0, commands: 1},
+		{name: "zero recovery TTL", ttl: 0, maxTerminal: 1000, commands: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			flag.CommandRecoveryTTL = test.ttl
+			flag.CommandRecoveryMaxTerminal = test.maxTerminal
+			runner := InitCodeRunner()
+			sessions := make([]string, 0, test.commands)
+			for range test.commands {
+				var session string
+				err := runner.Execute(&runtime.ExecuteCodeRequest{
+					Language: runtime.Command,
+					Code:     "exit 0",
+					Cwd:      t.TempDir(),
+					Hooks: runtime.ExecuteResultHook{
+						OnExecuteInit:     func(id string) { session = id },
+						OnExecuteStdout:   func(string) {},
+						OnExecuteStderr:   func(string) {},
+						OnExecuteError:    func(*execute.ErrorOutput) {},
+						OnExecuteComplete: func(time.Duration) {},
+					},
+				})
+				require.NoError(t, err)
+				require.NotEmpty(t, session)
+				sessions = append(sessions, session)
+			}
+
+			for _, session := range sessions {
+				status, err := runner.GetCommandStatus(session)
+				require.NoError(t, err)
+				require.False(t, status.Running)
+			}
+
+			page, err := runner.ListCommands(runtime.ListCommandsRequest{})
+			require.NoError(t, err)
+			require.Len(t, page.Commands, test.wantListed)
+			if test.commands == 1 && test.wantListed == 1 {
+				require.Equal(t, sessions[0], page.Commands[0].Session)
+			}
+		})
+	}
+}
 
 func TestBuildExecuteCodeRequestDefaultsToCommand(t *testing.T) {
 	ctrl := &CodeInterpretingController{}

--- a/components/execd/pkg/web/controller/command.go
+++ b/components/execd/pkg/web/controller/command.go
@@ -16,9 +16,12 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,6 +31,148 @@ import (
 	"github.com/alibaba/opensandbox/execd/pkg/telemetry"
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
 )
+
+const (
+	defaultCommandInventoryLimit = 50
+	maxCommandInventoryLimit     = 100
+)
+
+var (
+	errInvalidCommandInventoryQuery  = errors.New("invalid query parameter")
+	errInvalidCommandInventoryCursor = errors.New("invalid cursor")
+)
+
+// ListCommands returns a page of command inventory summaries.
+func (c *CodeInterpretingController) ListCommands() {
+	c.ctx.Header("Cache-Control", "no-store")
+
+	request, err := parseListCommandsQuery(c.ctx.Request.URL.RawQuery)
+	if err != nil {
+		c.RespondError(http.StatusBadRequest, model.ErrorCodeInvalidQuery, err.Error())
+		return
+	}
+
+	response, err := codeRunner.ListCommands(request)
+	if err != nil {
+		if errors.Is(err, runtime.ErrInvalidCommandCursor) {
+			c.RespondError(http.StatusBadRequest, model.ErrorCodeInvalidQuery, "invalid cursor")
+			return
+		}
+		c.RespondError(
+			http.StatusInternalServerError,
+			model.ErrorCodeRuntimeError,
+			fmt.Sprintf("error listing commands. %v", err),
+		)
+		return
+	}
+
+	commands := make([]any, 0, len(response.Commands))
+	for _, command := range response.Commands {
+		if command.Running {
+			commands = append(commands, model.RunningCommandSummary{
+				Session:    command.Session,
+				Running:    true,
+				Background: command.Background,
+				StartedAt:  command.StartedAt,
+			})
+			continue
+		}
+		commands = append(commands, model.TerminalCommandSummary{
+			Session:    command.Session,
+			Running:    false,
+			Background: command.Background,
+			StartedAt:  command.StartedAt,
+			FinishedAt: command.FinishedAt,
+			ExitCode:   command.ExitCode,
+			Error:      command.Error,
+		})
+	}
+
+	c.RespondSuccess(model.ListCommandsResponse{
+		Commands: commands,
+		Pagination: model.CommandInventoryPagination{
+			Limit:      response.Pagination.Limit,
+			NextCursor: response.Pagination.NextCursor,
+		},
+	})
+}
+
+func parseListCommandsQuery(rawQuery string) (runtime.ListCommandsRequest, error) {
+	request := runtime.ListCommandsRequest{Limit: defaultCommandInventoryLimit}
+	if rawQuery == "" {
+		return request, nil
+	}
+
+	components := strings.Split(rawQuery, "&")
+	seen := make(map[string]bool, 3)
+	invalidQuery := false
+	emptyCursor := false
+	for _, component := range components {
+		if component == "" {
+			invalidQuery = true
+			continue
+		}
+		rawKey, rawValue, hasValue := strings.Cut(component, "=")
+		key, keyErr := url.QueryUnescape(rawKey)
+		value, valueErr := url.QueryUnescape(rawValue)
+		if keyErr != nil || valueErr != nil {
+			invalidQuery = true
+			continue
+		}
+		if key == "cursor" && (!hasValue || strings.TrimSpace(value) == "") {
+			emptyCursor = true
+			continue
+		}
+		if key != "running" && key != "limit" && key != "cursor" || !hasValue || seen[key] {
+			invalidQuery = true
+			continue
+		}
+		seen[key] = true
+		if strings.TrimSpace(value) == "" {
+			invalidQuery = true
+			continue
+		}
+
+		switch key {
+		case "running":
+			running, err := strconv.ParseBool(value)
+			if err != nil || (value != "true" && value != "false") {
+				invalidQuery = true
+				continue
+			}
+			request.Running = &running
+		case "limit":
+			if !isDecimal(value) {
+				invalidQuery = true
+				continue
+			}
+			limit, err := strconv.Atoi(value)
+			if err != nil || limit < 1 || limit > maxCommandInventoryLimit {
+				invalidQuery = true
+				continue
+			}
+			request.Limit = limit
+		case "cursor":
+			request.Cursor = value
+		}
+	}
+	if emptyCursor {
+		return runtime.ListCommandsRequest{}, errInvalidCommandInventoryCursor
+	}
+	if invalidQuery {
+		return runtime.ListCommandsRequest{}, errInvalidCommandInventoryQuery
+	}
+	return request, nil
+}
+
+func isDecimal(value string) bool {
+	for i := range len(value) {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return value != ""
+}
 
 // RunCommand executes a shell command and streams the output via SSE.
 func (c *CodeInterpretingController) RunCommand() {

--- a/components/execd/pkg/web/controller/command_inventory_test.go
+++ b/components/execd/pkg/web/controller/command_inventory_test.go
@@ -1,0 +1,219 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/alibaba/opensandbox/execd/pkg/runtime"
+	"github.com/alibaba/opensandbox/execd/pkg/web/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListCommands(t *testing.T) {
+	t.Run("maps query and response", func(t *testing.T) {
+		previousRunner := codeRunner
+		startedAt := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+		finishedAt := startedAt.Add(time.Minute)
+		exitCode := 17
+		cursor := "next-cursor"
+		codeRunner = &fakeCodeRunner{
+			listCommands: func(request runtime.ListCommandsRequest) (runtime.ListCommandsResponse, error) {
+				require.NotNil(t, request.Running)
+				require.False(t, *request.Running)
+				require.Equal(t, 25, request.Limit)
+				require.Equal(t, "opaque-cursor", request.Cursor)
+				return runtime.ListCommandsResponse{
+					Commands: []runtime.CommandSummary{
+						{Session: "running", Running: true, Background: true, StartedAt: startedAt},
+						{Session: "terminal", Background: false, StartedAt: startedAt, FinishedAt: &finishedAt, ExitCode: &exitCode, Error: "failed"},
+					},
+					Pagination: runtime.CommandPagination{Limit: 25, NextCursor: &cursor},
+				}, nil
+			},
+		}
+		t.Cleanup(func() { codeRunner = previousRunner })
+
+		ctx, w := newTestContext(http.MethodGet, "/command?running=false&limit=25&cursor=opaque-cursor", nil)
+		NewCodeInterpretingController(ctx).ListCommands()
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+		var response map[string]any
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		commands := response["commands"].([]any)
+		running := commands[0].(map[string]any)
+		require.NotContains(t, running, "finished_at")
+		require.NotContains(t, running, "exit_code")
+		terminal := commands[1].(map[string]any)
+		require.Equal(t, "terminal", terminal["session"])
+		require.Equal(t, float64(exitCode), terminal["exit_code"])
+		require.Contains(t, terminal, "finished_at")
+		pagination := response["pagination"].(map[string]any)
+		require.Equal(t, "next-cursor", pagination["nextCursor"])
+	})
+
+	t.Run("maps running filters and default limit", func(t *testing.T) {
+		for _, test := range []struct {
+			name    string
+			path    string
+			running *bool
+		}{
+			{name: "omitted selects all", path: "/command"},
+			{name: "true selects running", path: "/command?running=true", running: boolPointer(true)},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				previousRunner := codeRunner
+				codeRunner = &fakeCodeRunner{
+					listCommands: func(request runtime.ListCommandsRequest) (runtime.ListCommandsResponse, error) {
+						require.Equal(t, test.running, request.Running)
+						require.Equal(t, 50, request.Limit)
+						require.Empty(t, request.Cursor)
+						return runtime.ListCommandsResponse{Commands: []runtime.CommandSummary{}, Pagination: runtime.CommandPagination{Limit: 50}}, nil
+					},
+				}
+				t.Cleanup(func() { codeRunner = previousRunner })
+
+				ctx, w := newTestContext(http.MethodGet, test.path, nil)
+				NewCodeInterpretingController(ctx).ListCommands()
+
+				require.Equal(t, http.StatusOK, w.Code)
+			})
+		}
+	})
+
+	t.Run("terminal null fields remain explicit", func(t *testing.T) {
+		previousRunner := codeRunner
+		codeRunner = &fakeCodeRunner{
+			listCommands: func(runtime.ListCommandsRequest) (runtime.ListCommandsResponse, error) {
+				return runtime.ListCommandsResponse{
+					Commands:   []runtime.CommandSummary{{Session: "terminal", Running: false}},
+					Pagination: runtime.CommandPagination{Limit: 50},
+				}, nil
+			},
+		}
+		t.Cleanup(func() { codeRunner = previousRunner })
+
+		ctx, w := newTestContext(http.MethodGet, "/command", nil)
+		NewCodeInterpretingController(ctx).ListCommands()
+
+		var response map[string]any
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		terminal := response["commands"].([]any)[0].(map[string]any)
+		require.Contains(t, terminal, "finished_at")
+		require.Nil(t, terminal["finished_at"])
+		require.Contains(t, terminal, "exit_code")
+		require.Nil(t, terminal["exit_code"])
+	})
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
+func TestCommandInventoryHTTP(t *testing.T) {
+	t.Run("invalid limit does not cache response", func(t *testing.T) {
+		ctx, w := newTestContext(http.MethodGet, "/command?limit=0", nil)
+		NewCodeInterpretingController(ctx).ListCommands()
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+	})
+
+	t.Run("invalid query", func(t *testing.T) {
+		for _, test := range []struct {
+			name    string
+			path    string
+			message string
+		}{
+			{name: "unknown", path: "/command?unknown=value", message: "invalid query parameter"},
+			{name: "duplicate limit", path: "/command?limit=1&limit=2", message: "invalid query parameter"},
+			{name: "duplicate running", path: "/command?running=true&running=false", message: "invalid query parameter"},
+			{name: "duplicate cursor", path: "/command?cursor=one&cursor=two", message: "invalid query parameter"},
+			{name: "empty running", path: "/command?running=", message: "invalid query parameter"},
+			{name: "empty limit", path: "/command?limit=", message: "invalid query parameter"},
+			{name: "percent decoded blank running", path: "/command?running=%20", message: "invalid query parameter"},
+			{name: "invalid running", path: "/command?running=TRUE", message: "invalid query parameter"},
+			{name: "zero limit", path: "/command?limit=0", message: "invalid query parameter"},
+			{name: "large limit", path: "/command?limit=101", message: "invalid query parameter"},
+			{name: "leading empty component", path: "/command?&running=true", message: "invalid query parameter"},
+			{name: "trailing empty component", path: "/command?running=true&", message: "invalid query parameter"},
+			{name: "empty components", path: "/command?&&", message: "invalid query parameter"},
+			{name: "interior empty component", path: "/command?running=true&&limit=25", message: "invalid query parameter"},
+			{name: "malformed percent escape", path: "/command?running=%zz", message: "invalid query parameter"},
+			{name: "empty cursor", path: "/command?cursor=", message: "invalid cursor"},
+			{name: "cursor without equals", path: "/command?cursor", message: "invalid cursor"},
+			{name: "empty cursor takes precedence", path: "/command?cursor=&running=", message: "invalid cursor"},
+			{name: "empty cursor takes precedence when later", path: "/command?running=&cursor=", message: "invalid cursor"},
+			{name: "empty cursor takes precedence over empty component", path: "/command?&&cursor=", message: "invalid cursor"},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				ctx, w := newTestContext(http.MethodGet, test.path, nil)
+				NewCodeInterpretingController(ctx).ListCommands()
+
+				require.Equal(t, http.StatusBadRequest, w.Code)
+				require.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+				var response model.ErrorResponse
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+				require.Equal(t, model.ErrorCodeInvalidQuery, response.Code)
+				require.Equal(t, test.message, response.Message)
+			})
+		}
+	})
+
+	t.Run("invalid runtime cursor is opaque", func(t *testing.T) {
+		previousRunner := codeRunner
+		codeRunner = &fakeCodeRunner{
+			listCommands: func(runtime.ListCommandsRequest) (runtime.ListCommandsResponse, error) {
+				return runtime.ListCommandsResponse{}, fmt.Errorf("cursor token secret: %w", runtime.ErrInvalidCommandCursor)
+			},
+		}
+		t.Cleanup(func() { codeRunner = previousRunner })
+
+		ctx, w := newTestContext(http.MethodGet, "/command?cursor=opaque", nil)
+		NewCodeInterpretingController(ctx).ListCommands()
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+		var response model.ErrorResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		require.Equal(t, model.ErrorCodeInvalidQuery, response.Code)
+		require.Equal(t, "invalid cursor", response.Message)
+	})
+
+	t.Run("runtime errors remain runtime errors", func(t *testing.T) {
+		previousRunner := codeRunner
+		codeRunner = &fakeCodeRunner{
+			listCommands: func(runtime.ListCommandsRequest) (runtime.ListCommandsResponse, error) {
+				return runtime.ListCommandsResponse{}, errors.New("command inventory invariant: corrupted index")
+			},
+		}
+		t.Cleanup(func() { codeRunner = previousRunner })
+
+		ctx, w := newTestContext(http.MethodGet, "/command", nil)
+		NewCodeInterpretingController(ctx).ListCommands()
+
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+		require.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+		var response model.ErrorResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		require.Equal(t, model.ErrorCodeRuntimeError, response.Code)
+	})
+}

--- a/components/execd/pkg/web/model/command.go
+++ b/components/execd/pkg/web/model/command.go
@@ -26,3 +26,34 @@ type CommandStatusResponse struct {
 	StartedAt  time.Time  `json:"started_at,omitempty"`
 	FinishedAt *time.Time `json:"finished_at,omitempty"`
 }
+
+// ListCommandsResponse represents a page of command inventory summaries.
+type ListCommandsResponse struct {
+	Commands   []any                      `json:"commands"`
+	Pagination CommandInventoryPagination `json:"pagination"`
+}
+
+// CommandInventoryPagination describes command inventory page traversal.
+type CommandInventoryPagination struct {
+	Limit      int     `json:"limit"`
+	NextCursor *string `json:"nextCursor,omitempty"`
+}
+
+// RunningCommandSummary represents a command that is still running.
+type RunningCommandSummary struct {
+	Session    string    `json:"session"`
+	Running    bool      `json:"running"`
+	Background bool      `json:"background"`
+	StartedAt  time.Time `json:"started_at"`
+}
+
+// TerminalCommandSummary represents a command that has completed.
+type TerminalCommandSummary struct {
+	Session    string     `json:"session"`
+	Running    bool       `json:"running"`
+	Background bool       `json:"background"`
+	StartedAt  time.Time  `json:"started_at"`
+	FinishedAt *time.Time `json:"finished_at"`
+	ExitCode   *int       `json:"exit_code"`
+	Error      string     `json:"error,omitempty"`
+}

--- a/components/execd/pkg/web/model/error.go
+++ b/components/execd/pkg/web/model/error.go
@@ -18,6 +18,7 @@ type ErrorCode string
 
 const (
 	ErrorCodeInvalidRequest      ErrorCode = "INVALID_REQUEST_BODY"
+	ErrorCodeInvalidQuery        ErrorCode = "INVALID_QUERY"
 	ErrorCodeMissingQuery        ErrorCode = "MISSING_QUERY"
 	ErrorCodeRuntimeError        ErrorCode = "RUNTIME_ERROR"
 	ErrorCodeInvalidFile         ErrorCode = "INVALID_FILE"

--- a/components/execd/pkg/web/router.go
+++ b/components/execd/pkg/web/router.go
@@ -74,6 +74,7 @@ func NewRouter(accessToken string) *gin.Engine {
 	{
 		command.POST("", withCode(func(c *controller.CodeInterpretingController) { c.RunCommand() }))
 		command.DELETE("", withCode(func(c *controller.CodeInterpretingController) { c.InterruptCommand() }))
+		command.GET("", withCode(func(c *controller.CodeInterpretingController) { c.ListCommands() }))
 		command.GET("/status/:id", withCode(func(c *controller.CodeInterpretingController) { c.GetCommandStatus() }))
 		command.GET("/:id/logs", withCode(func(c *controller.CodeInterpretingController) { c.GetBackgroundCommandOutput() }))
 	}
@@ -157,6 +158,9 @@ func accessTokenMiddleware(token string) gin.HandlerFunc {
 
 		requestedToken := ctx.GetHeader(model.ApiAccessTokenHeader)
 		if requestedToken == "" || requestedToken != token {
+			if ctx.Request.Method == http.MethodGet && ctx.Request.URL.Path == "/command" {
+				ctx.Header("Cache-Control", "no-store")
+			}
 			ctx.AbortWithStatusJSON(http.StatusUnauthorized, map[string]any{
 				"error": "Unauthorized: invalid or missing header " + model.ApiAccessTokenHeader,
 			})

--- a/components/execd/pkg/web/router_test.go
+++ b/components/execd/pkg/web/router_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alibaba/opensandbox/execd/pkg/web/controller"
+	"github.com/alibaba/opensandbox/execd/pkg/web/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRouterCommandInventory(t *testing.T) {
+	controller.InitCodeRunner()
+	router := NewRouter("")
+	req := httptest.NewRequest(http.MethodGet, "/command", nil)
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, req)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "no-store", response.Header().Get("Cache-Control"))
+}
+
+func TestNewRouterCommandRoutesRemainRegistered(t *testing.T) {
+	router := NewRouter("")
+
+	for _, test := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "post command", method: http.MethodPost, path: "/command"},
+		{name: "delete command", method: http.MethodDelete, path: "/command"},
+		{name: "get command status", method: http.MethodGet, path: "/command/status/:id"},
+		{name: "get command logs", method: http.MethodGet, path: "/command/:id/logs"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			found := false
+			for _, route := range router.Routes() {
+				if route.Method == test.method && route.Path == test.path {
+					found = true
+					break
+				}
+			}
+			require.True(t, found, "%s %s must remain registered", test.method, test.path)
+		})
+	}
+}
+
+func TestNewRouterAccessToken(t *testing.T) {
+	controller.InitCodeRunner()
+	router := NewRouter("expected-token")
+
+	t.Run("command inventory requires configured token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/command", nil)
+		response := httptest.NewRecorder()
+
+		router.ServeHTTP(response, req)
+
+		require.Equal(t, http.StatusUnauthorized, response.Code)
+		require.Equal(t, "no-store", response.Header().Get("Cache-Control"))
+	})
+
+	t.Run("command inventory permits configured token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/command", nil)
+		req.Header.Set(model.ApiAccessTokenHeader, "expected-token")
+		response := httptest.NewRecorder()
+
+		router.ServeHTTP(response, req)
+
+		require.Equal(t, http.StatusOK, response.Code)
+	})
+}

--- a/components/execd/tests/smoke.sh
+++ b/components/execd/tests/smoke.sh
@@ -14,11 +14,115 @@
 # limitations under the License.
 
 
-set -euxo pipefail
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: ./tests/smoke.sh [--inventory-cap|--inventory-expiry]
+
+Starts isolated local Jupyter and execd processes, waits for /ping, runs the
+API smoke once, then stops both processes. The inventory modes require the
+matching EXECD_COMMAND_RECOVERY_* settings documented in this script.
+EOF
+}
+
+mode=""
+case "${1:-}" in
+	"") ;;
+	--inventory-cap) mode="cap" ;;
+	--inventory-expiry) mode="expiry" ;;
+	-h|--help) usage; exit 0 ;;
+	*) usage >&2; exit 2 ;;
+esac
+
+case "$mode" in
+	cap)
+		[[ "${EXECD_COMMAND_RECOVERY_TTL:-}" == "1h" && "${EXECD_COMMAND_RECOVERY_MAX_TERMINAL:-}" == "2" ]] || {
+			echo "--inventory-cap requires EXECD_COMMAND_RECOVERY_TTL=1h EXECD_COMMAND_RECOVERY_MAX_TERMINAL=2" >&2
+			exit 2
+		}
+		;;
+	expiry)
+		[[ "${EXECD_COMMAND_RECOVERY_TTL:-}" == "2s" && "${EXECD_COMMAND_RECOVERY_MAX_TERMINAL:-}" == "1000" ]] || {
+			echo "--inventory-expiry requires EXECD_COMMAND_RECOVERY_TTL=2s EXECD_COMMAND_RECOVERY_MAX_TERMINAL=1000" >&2
+			exit 2
+		}
+		;;
+esac
+
+JUPYTER_PID=""
+EXECD_PID=""
+
+cleanup() {
+	local pid
+	for pid in "$EXECD_PID" "$JUPYTER_PID"; do
+		if [[ -n "$pid" ]]; then
+			kill "$pid" 2>/dev/null || true
+			wait "$pid" 2>/dev/null || true
+		fi
+	done
+}
+trap cleanup EXIT INT TERM
+
+require_alive() {
+	local pid="$1"
+	local name="$2"
+	if ! kill -0 "$pid" 2>/dev/null; then
+		echo "$name process exited unexpectedly (pid=$pid)" >&2
+		return 1
+	fi
+}
+
+curl_ready() {
+	curl --fail --silent --show-error --connect-timeout 1 --max-time 2 "$@" >/dev/null
+}
+
+wait_for_jupyter() {
+	local deadline=$((SECONDS + 30))
+	until curl_ready -H "Authorization: token ${JUPYTER_TOKEN}" "http://127.0.0.1:${JUPYTER_PORT}/api"; do
+		require_alive "$JUPYTER_PID" "Jupyter" || return 1
+		if (( SECONDS >= deadline )); then
+			echo "Jupyter did not become ready at /api before the 30s deadline" >&2
+			return 1
+		fi
+		sleep 0.2
+	done
+	require_alive "$JUPYTER_PID" "Jupyter"
+}
+
+wait_for_execd() {
+	local deadline=$((SECONDS + 30))
+	while true; do
+		# Check both owned processes before and after the request. This rejects a
+		# successful /ping response from an unrelated listener if our execd failed
+		# to bind 44772 or exited during startup.
+		require_alive "$JUPYTER_PID" "Jupyter" || return 1
+		require_alive "$EXECD_PID" "execd" || return 1
+		if curl_ready "http://127.0.0.1:44772/ping"; then
+			require_alive "$JUPYTER_PID" "Jupyter" || return 1
+			require_alive "$EXECD_PID" "execd" || return 1
+			return 0
+		fi
+		if (( SECONDS >= deadline )); then
+			echo "execd did not become healthy at /ping before the 30s deadline" >&2
+			return 1
+		fi
+		sleep 0.2
+	done
+}
 
 source tests/jupyter.sh
 install_jupyter
+JUPYTER_PID=$!
+require_alive "$JUPYTER_PID" "Jupyter"
+wait_for_jupyter
 
 export EXECD_API_GRACE_SHUTDOWN=500ms
 export EXECD_LOG_FILE=execd.log
-./bin/execd -jupyter-host=http://127.0.0.1:${JUPYTER_PORT} --jupyter-token=${JUPYTER_TOKEN} --log-level=7 >startup.log 2>&1 &
+./bin/execd --jupyter-host="http://127.0.0.1:${JUPYTER_PORT}" --jupyter-token="$JUPYTER_TOKEN" --log-level=7 >startup.log 2>&1 &
+EXECD_PID=$!
+require_alive "$EXECD_PID" "execd"
+wait_for_execd
+
+python3 -m unittest discover -s tests -p 'test_smoke_api_inventory.py'
+SMOKE_INVENTORY_MODE="$mode" python3 tests/smoke_api.py

--- a/components/execd/tests/smoke_api.py
+++ b/components/execd/tests/smoke_api.py
@@ -49,28 +49,243 @@ def expect(cond: bool, msg: str):
         raise SystemExit(msg)
 
 
+def iter_sse_events(lines):
+    for line in lines:
+        if not line:
+            continue
+        try:
+            if line.startswith(b"data:"):
+                event = json.loads(line[len(b"data:") :].decode())
+            else:
+                # controller emits raw JSON lines without SSE 'data:' prefix
+                event = json.loads(line.decode())
+        except Exception:
+            continue
+        if isinstance(event, dict):
+            yield event
+
+
+def wait_for_command_barrier(events, *, background: bool, succeeds: bool) -> str:
+    command_id = None
+    expected = "execution_complete" if background or succeeds else "error"
+    for event in events:
+        event_type = event.get("type")
+        if event_type == "init":
+            command_id = event.get("text")
+            expect(command_id, "missing command id in init event")
+            continue
+        if command_id is None:
+            if event_type in ("execution_complete", "error"):
+                raise SystemExit("command terminated before init")
+            continue
+        if event_type == expected:
+            return command_id
+        if event_type in ("execution_complete", "error"):
+            raise SystemExit(f"unexpected command event after init: {event_type}")
+    raise SystemExit("command stream ended before readiness barrier")
+
+
 def sse_get_command_id() -> str:
     url = f"{BASE_URL}/command"
-    payload = {"command": "echo smoke-command && sleep 1", "background": True}
+    if os.name == "nt":
+        command = "echo smoke-command & ping -n 2 127.0.0.1 >nul"
+    else:
+        command = "echo smoke-command && sleep 1"
+    payload = {"command": command, "background": True}
     with session.post(url, json=payload, stream=True, timeout=15) as resp:
         expect(resp.status_code == 200, f"SSE start failed: {resp.status_code} {resp.text}")
-        for line in resp.iter_lines():
-            if not line or not line.startswith(b"data:"):
-                # controller emits raw JSON lines without SSE 'data:' prefix
-                try:
-                    data = json.loads(line.decode())
-                except Exception:
-                    continue
-            else:
-                data = json.loads(line[len(b"data:") :].decode())
-            if data.get("type") == "init":
-                cmd_id = data.get("text")
-                expect(cmd_id, "missing command id in init event")
-                return cmd_id
-    raise SystemExit("Failed to obtain command id from SSE")
+        return wait_for_command_barrier(
+            iter_sse_events(resp.iter_lines()), background=True, succeeds=True
+        )
 
 
-def wait_status(cmd_id: str, timeout: float = 15.0) -> dict:
+def command_for(success: bool, label: str) -> str:
+    if os.name == "nt":
+        code = "0" if success else "17"
+        return f"echo {label} & exit /b {code}"
+    code = "0" if success else "17"
+    return f"printf '{label}\\n'; exit {code}"
+
+
+def start_command(command: str, background: bool, succeeds: bool) -> str:
+    url = f"{BASE_URL}/command"
+    payload = {"command": command, "background": background}
+    with session.post(url, json=payload, stream=True, timeout=15) as resp:
+        expect(resp.status_code == 200, f"command start failed: {resp.status_code} {resp.text}")
+        return wait_for_command_barrier(
+            iter_sse_events(resp.iter_lines()), background=background, succeeds=succeeds
+        )
+
+
+def list_commands(timeout: float = 10) -> list[dict]:
+    response = session.get(f"{BASE_URL}/command", timeout=timeout)
+    expect(response.status_code == 200, f"command list failed: {response.status_code} {response.text}")
+    payload = response.json()
+    commands = payload.get("commands")
+    expect(isinstance(commands, list), f"command list missing commands array: {payload}")
+    return commands
+
+
+INVENTORY_CONDITION_TIMEOUT = 5.0
+INVENTORY_CONDITION_INTERVAL = 0.05
+
+
+def wait_for_inventory_condition(
+    predicate,
+    *,
+    description: str,
+    timeout: float = INVENTORY_CONDITION_TIMEOUT,
+) -> list[dict]:
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise SystemExit(
+                f"inventory condition not reached before {timeout:g}s deadline: {description}"
+            )
+        commands = list_commands(timeout=min(10.0, remaining))
+        if predicate(commands):
+            return commands
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise SystemExit(
+                f"inventory condition not reached before {timeout:g}s deadline: {description}"
+            )
+        time.sleep(min(INVENTORY_CONDITION_INTERVAL, remaining))
+
+
+def expect_terminal_delete_legacy_error(command_id: str):
+    response = session.delete(f"{BASE_URL}/command", params={"id": command_id}, timeout=10)
+    expect(response.status_code == 500, f"terminal DELETE changed legacy status: {response.status_code} {response.text}")
+    expect("not running" in response.text, f"terminal DELETE changed legacy error: {response.text}")
+
+
+def expect_known_session_compatibility(command_id: str, background: bool, expected_label: str | None = None):
+    status = wait_status(command_id)
+    expect(not status.get("running", True), f"terminal status still running: {status}")
+    logs = session.get(f"{BASE_URL}/command/{command_id}/logs", params={"cursor": 0}, timeout=10)
+    if background:
+        expect(logs.status_code == 200, f"known background logs unavailable: {logs.status_code} {logs.text}")
+        if expected_label:
+            expect(expected_label in logs.text, f"known background logs lost expected output {expected_label!r}: {logs.text!r}")
+    else:
+        expect(logs.status_code == 400, f"foreground logs must be rejected: {logs.status_code} {logs.text}")
+        expect("not running in background" in logs.text, f"foreground logs error changed: {logs.text}")
+    expect_terminal_delete_legacy_error(command_id)
+
+
+def command_lifecycle_regression():
+    commands = []
+    for background in (False, True):
+        for success in (True, False):
+            label = f"inventory-{'bg' if background else 'fg'}-{'ok' if success else 'fail'}"
+            command_id = start_command(command_for(success, label), background, success)
+            status = wait_status(command_id)
+            expect(not status.get("running", True), f"{label} did not become terminal: {status}")
+            expected_exit = 0 if success else 17
+            expect(status.get("exit_code") == expected_exit, f"{label} exit code mismatch: {status}")
+            commands.append((command_id, background, label))
+
+    listed = {entry.get("session") for entry in list_commands()}
+    for command_id, background, label in commands:
+        expect(command_id in listed, f"terminal command absent from inventory: {command_id}")
+        expect_known_session_compatibility(command_id, background, label)
+
+
+def inventory_cap_regression():
+    sessions = []
+    for index in range(3):
+        label = f"inventory-cap-{index}"
+        command_id = start_command(command_for(True, label), True, True)
+        wait_status(command_id)
+        sessions.append((command_id, label))
+    earliest_id, earliest_label = sessions[0]
+    second_id, _ = sessions[1]
+    third_id, _ = sessions[2]
+
+    def cap_evicted(entries: list[dict]) -> bool:
+        listed_sessions = {entry.get("session") for entry in entries}
+        return (
+            earliest_id not in listed_sessions
+            and second_id in listed_sessions
+            and third_id in listed_sessions
+        )
+
+    listed = {
+        entry.get("session")
+        for entry in wait_for_inventory_condition(
+            cap_evicted,
+            description=(
+                f"earliest terminal summary {earliest_id} was not evicted while "
+                f"{second_id} and {third_id} remained visible"
+            ),
+        )
+    }
+    expect(earliest_id not in listed, f"cap did not evict earliest terminal summary: {earliest_id}")
+    expect(second_id in listed, f"cap unexpectedly removed second terminal summary: {second_id}")
+    expect(third_id in listed, f"cap unexpectedly removed third terminal summary: {third_id}")
+    expect_known_session_compatibility(earliest_id, True, earliest_label)
+
+
+def command_for_inventory_observation(label: str) -> str:
+    if os.name == "nt":
+        return f"echo {label} & ping -n 2 127.0.0.1 >nul"
+    return f"printf '{label}\\n' && sleep 1"
+
+
+def start_background_command_for_inventory_observation(command: str) -> str:
+    url = f"{BASE_URL}/command"
+    payload = {"command": command, "background": True}
+    with session.post(url, json=payload, stream=True, timeout=15) as resp:
+        expect(resp.status_code == 200, f"command start failed: {resp.status_code} {resp.text}")
+        for event in iter_sse_events(resp.iter_lines()):
+            if event.get("type") != "init":
+                continue
+            command_id = event.get("text")
+            expect(command_id, "missing command id in init event")
+            return command_id
+    raise SystemExit("command stream ended before inventory observation barrier")
+
+
+def inventory_expiry_regression():
+    label = "inventory-expiry"
+    command_id = start_background_command_for_inventory_observation(
+        command_for_inventory_observation(label)
+    )
+    wait_for_inventory_condition(
+        lambda entries: any(
+            entry.get("session") == command_id and entry.get("running") is True
+            for entry in entries
+        ),
+        description=f"running command summary {command_id} was not visible",
+    )
+    deadline = time.monotonic() + 5
+    seen_terminal_summary = False
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        expect(remaining > 0, f"terminal summary did not expire before 5s deadline: {command_id}")
+        # Bound each request by the remaining deadline so a slow list endpoint
+        # cannot extend this regression beyond its declared five seconds.
+        entries = list_commands(timeout=min(10, remaining))
+        if any(
+            entry.get("session") == command_id and entry.get("running") is False
+            for entry in entries
+        ):
+            seen_terminal_summary = True
+        elif seen_terminal_summary and not any(
+            entry.get("session") == command_id for entry in entries
+        ):
+            expect_known_session_compatibility(command_id, True, label)
+            return
+        time.sleep(0.05)
+    if not seen_terminal_summary:
+        raise SystemExit(
+            f"terminal summary was not visible before expiry check deadline: {command_id}"
+        )
+    raise SystemExit(f"terminal summary did not expire before 5s deadline: {command_id}")
+
+
+def wait_status(cmd_id: str, timeout: float = 15.0, poll_interval: float = 0.3) -> dict:
     url = f"{BASE_URL}/command/status/{cmd_id}"
     deadline = time.time() + timeout
     last = None
@@ -80,7 +295,7 @@ def wait_status(cmd_id: str, timeout: float = 15.0) -> dict:
         last = r.json()
         if not last.get("running", True):
             return last
-        time.sleep(0.3)
+        time.sleep(poll_interval)
     return last
 
 
@@ -314,6 +529,19 @@ def main():
 
     run_command_blank_lines()
     print("[+] run_command preserves blank lines")
+
+    inventory_mode = os.environ.get("SMOKE_INVENTORY_MODE", "")
+    if inventory_mode == "":
+        command_lifecycle_regression()
+        print("[+] command inventory lifecycle compatibility ok")
+    elif inventory_mode == "cap":
+        inventory_cap_regression()
+        print("[+] command inventory cap eviction compatibility ok")
+    elif inventory_mode == "expiry":
+        inventory_expiry_regression()
+        print("[+] command inventory TTL expiry compatibility ok")
+    else:
+        raise SystemExit(f"unknown SMOKE_INVENTORY_MODE: {inventory_mode}")
 
     cmd_id = sse_get_command_id()
     print(f"[+] command id: {cmd_id}")

--- a/components/execd/tests/test_smoke_api_inventory.py
+++ b/components/execd/tests/test_smoke_api_inventory.py
@@ -1,0 +1,219 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+import smoke_api
+
+
+class CommandStartIDBarrierTest(unittest.TestCase):
+    def test_background_returns_id_after_execution_complete(self):
+        command_id = smoke_api.wait_for_command_barrier(
+            [{"type": "init", "text": "id"}, {"type": "execution_complete"}],
+            background=True,
+            succeeds=True,
+        )
+
+        self.assertEqual(command_id, "id")
+
+
+class WaitForInventoryConditionTest(unittest.TestCase):
+    @patch("smoke_api.time.sleep")
+    @patch("smoke_api.time.monotonic", side_effect=[0.0, 0.0])
+    @patch("smoke_api.list_commands", return_value=[{"session": "later"}])
+    def test_inventory_condition_returns_first_matching_snapshot(
+        self, list_commands, monotonic, sleep
+    ):
+        commands = smoke_api.wait_for_inventory_condition(
+            lambda entries: entries[0]["session"] == "later",
+            description="later command is visible",
+        )
+
+        self.assertEqual(commands, [{"session": "later"}])
+        list_commands.assert_called_once_with(timeout=5.0)
+        sleep.assert_not_called()
+
+    @patch("smoke_api.time.sleep")
+    @patch("smoke_api.time.monotonic", side_effect=[0.0, 0.0, 0.0, 0.05])
+    @patch("smoke_api.list_commands", side_effect=[[], [{"session": "evicted"}]])
+    def test_inventory_condition_rechecks_after_bounded_sleep(
+        self, list_commands, monotonic, sleep
+    ):
+        commands = smoke_api.wait_for_inventory_condition(
+            lambda entries: bool(entries),
+            description="eviction completed",
+        )
+
+        self.assertEqual(commands, [{"session": "evicted"}])
+        self.assertEqual(list_commands.call_count, 2)
+        sleep.assert_called_once_with(0.05)
+
+    @patch("smoke_api.time.sleep")
+    @patch("smoke_api.time.monotonic", side_effect=[0.0, 0.0, 0.0, 0.05])
+    @patch("smoke_api.list_commands", return_value=[])
+    def test_inventory_condition_stops_at_deadline_without_extra_request_or_sleep(
+        self, list_commands, monotonic, sleep
+    ):
+        with self.assertRaisesRegex(SystemExit, "eviction completed"):
+            smoke_api.wait_for_inventory_condition(
+                lambda entries: False,
+                description="eviction completed",
+                timeout=0.05,
+            )
+
+        list_commands.assert_called_once_with(timeout=0.05)
+        sleep.assert_called_once_with(0.05)
+
+    @patch("smoke_api.time.sleep")
+    @patch("smoke_api.time.monotonic", return_value=0.0)
+    @patch(
+        "smoke_api.list_commands",
+        side_effect=SystemExit("command list failed: 500"),
+    )
+    def test_inventory_condition_does_not_retry_list_failure(
+        self, list_commands, monotonic, sleep
+    ):
+        with self.assertRaisesRegex(SystemExit, "command list failed: 500"):
+            smoke_api.wait_for_inventory_condition(
+                lambda entries: False,
+                description="eviction completed",
+            )
+
+        list_commands.assert_called_once_with(timeout=5.0)
+        sleep.assert_not_called()
+
+    @patch("smoke_api.time.sleep")
+    @patch("smoke_api.time.monotonic", return_value=0.0)
+    @patch("smoke_api.list_commands", side_effect=RuntimeError("transport failed"))
+    def test_inventory_condition_does_not_retry_transport_failure(
+        self, list_commands, monotonic, sleep
+    ):
+        with self.assertRaisesRegex(RuntimeError, "transport failed"):
+            smoke_api.wait_for_inventory_condition(
+                lambda entries: False,
+                description="eviction completed",
+            )
+
+        list_commands.assert_called_once_with(timeout=5.0)
+        sleep.assert_not_called()
+
+    @patch("smoke_api.time.sleep")
+    @patch(
+        "smoke_api.time.monotonic",
+        side_effect=[0.0, 0.0, 0.0, 0.05, 0.05, 0.10],
+    )
+    @patch(
+        "smoke_api.list_commands",
+        side_effect=[
+            [],
+            [{"session": "first"}],
+            [{"session": "second"}, {"session": "third"}],
+        ],
+    )
+    @patch("smoke_api.expect_known_session_compatibility")
+    @patch("smoke_api.wait_status")
+    @patch("smoke_api.start_command", side_effect=["first", "second", "third"])
+    def test_inventory_cap_requires_remaining_terminal_summaries_before_compatibility(
+        self,
+        start_command,
+        wait_status,
+        expect_compatibility,
+        list_commands,
+        monotonic,
+        sleep,
+    ):
+        condition_returned = False
+        original_wait_for_inventory_condition = smoke_api.wait_for_inventory_condition
+
+        def wait_for_cap_condition(*args, **kwargs):
+            nonlocal condition_returned
+            commands = original_wait_for_inventory_condition(*args, **kwargs)
+            condition_returned = True
+            return commands
+
+        def assert_compatibility_after_cap_condition(*args):
+            self.assertTrue(condition_returned)
+
+        expect_compatibility.side_effect = assert_compatibility_after_cap_condition
+        with patch(
+            "smoke_api.wait_for_inventory_condition",
+            side_effect=wait_for_cap_condition,
+        ):
+            smoke_api.inventory_cap_regression()
+
+        self.assertEqual(list_commands.call_count, 3)
+        self.assertEqual(sleep.call_count, 2)
+        self.assertEqual(sleep.call_args_list, [((0.05,),), ((0.05,),)])
+        expect_compatibility.assert_called_once_with(
+            "first", True, "inventory-cap-0"
+        )
+
+    @patch("smoke_api.time.sleep")
+    @patch("smoke_api.time.monotonic", return_value=0.0)
+    @patch("smoke_api.list_commands")
+    @patch("smoke_api.expect_known_session_compatibility")
+    @patch("smoke_api.wait_status")
+    @patch(
+        "smoke_api.start_background_command_for_inventory_observation",
+        return_value="expiry",
+    )
+    def test_inventory_expiry_calls_compatibility_after_terminal_observation_and_eviction(
+        self,
+        start_background_command,
+        wait_status,
+        expect_compatibility,
+        list_commands,
+        monotonic,
+        sleep,
+    ):
+        observations = []
+        snapshots = iter(
+            [
+                [{"session": "expiry", "running": True}],
+                [{"session": "expiry", "running": False}],
+                [],
+            ]
+        )
+
+        def list_inventory(*, timeout):
+            entries = next(snapshots)
+            if entries and entries[0]["running"]:
+                observations.append("running")
+            elif entries:
+                observations.append("terminal")
+            else:
+                observations.append("absent")
+            return entries
+
+        def assert_compatibility_after_inventory_eviction(*args):
+            observations.append("compatibility")
+            self.assertEqual(
+                observations,
+                ["running", "terminal", "absent", "compatibility"],
+            )
+
+        list_commands.side_effect = list_inventory
+        expect_compatibility.side_effect = assert_compatibility_after_inventory_eviction
+        smoke_api.inventory_expiry_regression()
+
+        self.assertEqual(list_commands.call_count, 3)
+        sleep.assert_called_once_with(0.05)
+        start_background_command.assert_called_once_with(
+            smoke_api.command_for_inventory_observation("inventory-expiry")
+        )
+        wait_status.assert_not_called()
+        expect_compatibility.assert_called_once_with(
+            "expiry", True, "inventory-expiry"
+        )

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -88,6 +88,7 @@ Defines interfaces for executing code, commands, and file operations within sand
 **Command Execution:**
 - `POST /command` - Execute shell command (streaming output)
 - `DELETE /command` - Interrupt command execution
+- `GET /command` - List running and recently completed command summaries with pagination
 - `GET /command/status/{id}` - Get foreground/background command status
 - `GET /command/{id}/logs` - Fetch accumulated stdout/stderr for a background command
 

--- a/docs/components/execd.md
+++ b/docs/components/execd.md
@@ -36,9 +36,32 @@ isolated-session capability probing and creation fail closed.
 
 ### 2) Start Jupyter Server
 
+execd requires a Jupyter Server that is reachable at the address passed to
+`--jupyter-host`. In a source checkout, source the repository helper and invoke
+its `install_jupyter` function:
+
 ```bash
-./tests/jupyter.sh
+. ./tests/jupyter.sh
+install_jupyter
 ```
+
+Alternatively, install Jupyter if necessary, then start it with the token you
+will pass to execd:
+
+```bash
+python3 -m pip install jupyter
+jupyter server \
+  --ip=127.0.0.1 \
+  --port=54321 \
+  --no-browser \
+  --ServerApp.token=your-jupyter-token
+```
+
+The helper sets `JUPYTER_PORT=54321` and
+`JUPYTER_TOKEN=opensandboxexecdintegrationtest`, then starts a Jupyter Notebook
+process in the background. Use those values for the execd connection when
+following the helper path. Keep the standalone Jupyter Server process running
+while using execd.
 
 ### 3) Run execd
 
@@ -54,6 +77,33 @@ isolated-session capability probing and creation fail closed.
 ```bash
 curl -v http://localhost:44772/ping
 ```
+
+### Local Smoke Test (Command Inventory Regression)
+
+`components/execd/tests/smoke.sh` starts dedicated local Jupyter and execd instances, waits for them to become ready, and then runs API smoke tests. It verifies command-inventory default compatibility, cap eviction only after the earliest terminal summary is absent while the second and third remain visible, and TTL expiry only after the command was publicly observed before terminal retention begins. Build execd in `components/execd`, then run one of these three modes:
+
+```bash
+# Default command-inventory lifecycle compatibility
+./tests/smoke.sh
+
+# Completed-summary cap: must use exactly TTL=1h and cap=2
+EXECD_COMMAND_RECOVERY_TTL=1h EXECD_COMMAND_RECOVERY_MAX_TERMINAL=2 ./tests/smoke.sh --inventory-cap
+
+# Completed-summary TTL expiry: must use exactly TTL=2s and cap=1000
+EXECD_COMMAND_RECOVERY_TTL=2s EXECD_COMMAND_RECOVERY_MAX_TERMINAL=1000 ./tests/smoke.sh --inventory-expiry
+```
+
+To deterministically validate the inventory cap/expiry observation helpers without starting an additional service, run:
+
+```bash
+python3 -m unittest discover -s tests -p 'test_smoke_api_inventory.py'
+```
+
+Prerequisites are Bash, `curl`, Python, Python `requests`, a built `./bin/execd`, and a usable `jupyter notebook`. Ports `127.0.0.1:54321` and `127.0.0.1:44772` must be free.
+
+The script sets a fixed 30-second readiness deadline for Jupyter `/api` and execd `/ping`, and checks that the `JUPYTER_PID` and `EXECD_PID` it started remain alive before and after requests to avoid accidentally using an existing listener. On success, failure, or interruption, its exit trap automatically stops and waits for both child processes. On success, it prints `[+] smoke tests PASS` and exits with code `0`.
+
+On failure, first check the terminal for dependency, argument, or 30-second timeout messages. Then check `startup.log` (execd startup failures) and `execd.log` (execd runtime logs) in the current directory. If a port is occupied, stop the process using it or retry in an isolated environment.
 
 ## API
 
@@ -71,6 +121,52 @@ minimal images that do not include Bash. This applies to PTY sessions, the
 Bash session API (which keeps its existing name for compatibility), and
 isolated sessions. Commands submitted to a fallback session must use syntax
 supported by that image's `sh` implementation.
+
+### Command Inventory `GET /command`
+
+`GET /command` returns a **summary inventory** of commands known to the current instance, for observing running and recently completed commands. It does not return command content or logs. Optional query parameters are:
+
+- `running=true` returns only running commands; `running=false` returns only completed commands; omit it to return both.
+- `limit` is `1` to `100` per page, with a default of `50`.
+- `cursor` continues to the next page.
+
+A cursor is opaque and bound to the requested filter. It is valid only for the lifetime of the Execd controller instance that issued it. After an Execd restart, controller replacement, or request routing to another instance, omit the cursor and restart from the first page. Inventory pagination is weakly consistent; retained summaries do not replace legacy status/log APIs.
+
+The response contains `commands` and `pagination` (`limit` and optional `nextCursor`). Each summary includes `session`, `running`, `background`, and `started_at`; completed entries also include `finished_at`, `exit_code`, and optional `error`. Ordering and pagination are weakly consistent: if commands start, complete, or disappear because of retention during a read, results across pages are not guaranteed to be an exact snapshot or a complete recoverable history.
+
+The inventory enumerates only summaries visible in this execd instance's memory. Callers with that instance's access token can enumerate it, so the token must be protected at the instance boundary. Inventory eviction does not clear existing session status, background logs, or command content; these legacy interfaces continue to follow their respective known-session lifecycles. This feature adds no inventory metrics.
+
+#### SDK entry points
+
+- Python async:
+
+  ```python
+  inventory = sandbox.command_inventory
+  if inventory is not None:
+      await inventory.list_commands(...)
+  ```
+
+- Python sync:
+
+  ```python
+  inventory = sandbox_sync.command_inventory
+  if inventory is not None:
+      inventory.list_commands(...)
+  ```
+
+- JavaScript: `sandbox.commands.listCommands?.(...)`
+- Kotlin: `sandbox.commands().listCommands(...)`
+- C#: `sandbox.CommandInventory?.ListCommandsAsync(...)`
+- Go: `sandbox.ListCommands(ctx, req)` or `ExecdClient.ListCommands(ctx, req)`
+
+`running`, `limit`, and `cursor` are the common query inputs. Python and C# inventory access may be unavailable with legacy/custom adapters, so check the capability before calling it. JavaScript legacy/custom `ExecdCommands` implementations may omit `listCommands`, so use the optional method invocation shown above. Blank request cursors normalize to omission; present blank response cursors are rejected by SDKs.
+
+| Method and Path | Purpose |
+|---|---|
+| `GET /command` | Read the command summary inventory with pagination. |
+| `GET /command/status/:id` | Read the detailed status of a known session. |
+| `GET /command/:id/logs` | Read background command logs; foreground commands are rejected. |
+| `DELETE /command?id=:id` | Interrupt a running command; completed sessions retain the existing not-running error semantics. |
 
 ## Isolated Sessions
 
@@ -156,6 +252,8 @@ override it.
 | `--graceful-shutdown-timeout` | `1s` | SSE tail-drain wait window before closing. |
 | `--jupyter-idle-poll-interval` | `100ms` | Poll interval after Jupyter reports idle. |
 | `--isolation-config` | `""` | Path to the isolation TOML config (see below). |
+| `--command-recovery-ttl` | `1h` | Retention duration for completed command summaries. |
+| `--command-recovery-max-terminal` | `1000` | Maximum number of completed command summaries to retain (maximum `10000`). |
 
 ### Environment Variables
 
@@ -167,12 +265,16 @@ override it.
 | `EXECD_API_GRACE_SHUTDOWN` | Same as `--graceful-shutdown-timeout`. |
 | `EXECD_JUPYTER_IDLE_POLL_INTERVAL` | Same as `--jupyter-idle-poll-interval`. |
 | `EXECD_ISOLATION_CONFIG` | Same as `--isolation-config`. |
+| `EXECD_COMMAND_RECOVERY_TTL` | Retention duration for completed command summaries; default `1h`. |
+| `EXECD_COMMAND_RECOVERY_MAX_TERMINAL` | Maximum number of completed command summaries; default `1000`, maximum `10000`. |
 | `EXECD_CLONE3_COMPAT` | Linux clone3 compatibility switch (see below). |
 | `EXECD_LOG_FILE` | Optional log output file path; default is stdout. |
 | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Preferred OTLP metrics endpoint. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Fallback OTLP endpoint when metrics-specific endpoint is unset. |
 | `OPENSANDBOX_ID` | Optional `sandbox_id` metric/resource attribute. |
 | `OPENSANDBOX_EXECD_METRICS_EXTRA_ATTRS` | Optional extra metric attrs (`k=v,k2=v2`). |
+
+Command-summary retention configuration is read from environment variables first, then overridden by CLI flags of the same name. `EXECD_COMMAND_RECOVERY_TTL=0` or `--command-recovery-ttl=0`, and `EXECD_COMMAND_RECOVERY_MAX_TERMINAL=0` or `--command-recovery-max-terminal=0`, all mean that only running commands are listed and no completed-summary entries are retained. Empty or unparseable values, a negative TTL, a negative cap, or a cap above `10000` emit a clear invalid-configuration diagnostic at startup and prevent the process from starting; correct the configuration before starting again.
 
 ### Isolation Config File
 

--- a/docs/sdks/csharp.md
+++ b/docs/sdks/csharp.md
@@ -66,6 +66,31 @@ catch (SandboxException ex)
 
 ## Usage Examples
 
+### Command Inventory
+
+Use the optional `sandbox.CommandInventory` capability to list command
+summaries. Set `running` to `true` or `false` to select a state, or omit it for
+both. Preserve a returned cursor exactly and the exact initial `running` filter
+on each subsequent page or receive `INVALID_QUERY`. The cursor works only while
+requests reach the same execd controller; after a restart or routing change,
+begin again without a cursor.
+
+```csharp
+if (sandbox.CommandInventory is { } inventory)
+{
+    var page = await inventory.ListCommandsAsync(running: false, limit: 50);
+    if (page.Pagination.NextCursor is { } nextCursor)
+    {
+        var nextPage = await inventory.ListCommandsAsync(
+            running: false,
+            cursor: nextCursor);
+    }
+}
+```
+
+`CommandInventory` can be `null` when a legacy or custom adapter does not
+provide this additive capability.
+
 ### 1. Lifecycle Management
 
 Manage the sandbox lifecycle, including renewal, pausing, and resuming.

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -94,6 +94,37 @@ err := exec.RunCommand(ctx, opensandbox.RunCommandRequest{
 })
 ```
 
+### Command inventory
+
+Use `sandbox.ListCommands` (or `ExecdClient.ListCommands` for a direct execd
+client) to list command summaries. Set `Running` to a pointer to `true` or
+`false` to filter by state; leave it `nil` for both. `Cursor` is opaque, bound
+to the exact initial `Running` filter, and valid only for the lifetime of the
+execd controller that returned it. Preserve the filter on each subsequent page
+or receive `INVALID_QUERY`; restart without a cursor after a restart or routing
+change.
+
+```go
+running := false
+page, err := sandbox.ListCommands(ctx, opensandbox.ListCommandsRequest{
+    Running: &running,
+    Limit:   50,
+})
+if err != nil {
+    log.Fatal(err)
+}
+if page.Pagination.NextCursor != nil {
+    nextPage, err := sandbox.ListCommands(ctx, opensandbox.ListCommandsRequest{
+        Running: &running,
+        Cursor: *page.Pagination.NextCursor,
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    _ = nextPage
+}
+```
+
 ### Check egress policy
 
 ```go

--- a/docs/sdks/javascript.md
+++ b/docs/sdks/javascript.md
@@ -72,6 +72,28 @@ try {
 
 ## Usage Examples
 
+### Command Inventory
+
+Call the optional `sandbox.commands.listCommands` entry point to list command
+summaries. The `running` option selects running (`true`) or completed (`false`)
+commands; omit it for both. Treat `nextCursor` as opaque and bound to the exact
+initial `running` filter. Preserve that filter on each subsequent page or
+receive `INVALID_QUERY`; use it only while requests reach the same execd
+controller. After a restart or routing change, begin again without a cursor.
+
+```ts
+const page = await sandbox.commands.listCommands?.({ running: false, limit: 50 });
+if (page?.pagination.nextCursor) {
+  const nextPage = await sandbox.commands.listCommands?.({
+    running: false,
+    cursor: page.pagination.nextCursor,
+  });
+}
+```
+
+Legacy or custom `ExecdCommands` implementations can omit this optional method,
+so retain the optional invocation.
+
 ### 1. Lifecycle Management
 
 Manage the sandbox lifecycle, including renewal, pausing, and resuming.

--- a/docs/sdks/kotlin.md
+++ b/docs/sdks/kotlin.md
@@ -79,6 +79,31 @@ public class QuickStart {
 
 ## Usage Examples
 
+### Command Inventory
+
+Use `sandbox.commands().listCommands(...)` to list command summaries. Set
+`running` to `true` or `false` to select a state, or leave it unset for both.
+Pass `page.pagination.nextCursor` unchanged to retrieve the next page; the
+cursor is opaque, bound to the exact initial `running` filter, and works only
+for the lifetime of the execd controller that issued it. Preserve that filter
+on each subsequent page or receive `INVALID_QUERY`. Start again without a
+cursor after a restart or routing change.
+
+```kotlin
+val page = sandbox.commands().listCommands(running = false, limit = 50)
+val nextCursor = page.pagination.nextCursor
+if (nextCursor != null) {
+    val nextPage = sandbox.commands().listCommands(
+        running = false,
+        cursor = nextCursor,
+    )
+}
+```
+
+The default implementation reports unsupported command inventory for legacy
+adapters by throwing `UnsupportedOperationException`; handle that case when an
+application supplies a custom adapter.
+
 ### 1. Lifecycle Management
 
 Manage the sandbox lifecycle, including renewal, pausing, and resuming.

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -255,6 +255,30 @@ For async pools, pass a `redis.asyncio` client to `AsyncRedisPoolStateStore`.
 
 ## Usage Examples
 
+### Command Inventory
+
+Use the optional `sandbox.command_inventory` capability to list command
+summaries. Pass `running=True` or `running=False` to select one state, or omit
+it for both. A cursor is opaque, bound to the exact initial `running` filter,
+and valid only while the issuing execd controller remains active. Preserve the
+filter on each subsequent page or receive `INVALID_QUERY`; after a restart or
+routing change, start again without a cursor.
+
+```python
+inventory = sandbox.command_inventory
+if inventory is not None:
+    page = await inventory.list_commands(running=False, limit=50)
+    if page.pagination.next_cursor is not None:
+        next_page = await inventory.list_commands(
+            running=False,
+            cursor=page.pagination.next_cursor,
+        )
+```
+
+For `SandboxSync`, use `sandbox.command_inventory` and
+`list_commands(...)` without `await`. Legacy or custom adapters can omit this
+capability, so check for `None` before calling it.
+
 ### 1. Lifecycle Management
 
 Manage the sandbox lifecycle, including renewal, pausing, and resuming.

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/CommandsAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/CommandsAdapter.cs
@@ -26,7 +26,7 @@ namespace OpenSandbox.Adapters;
 /// <summary>
 /// Adapter for the execd commands service.
 /// </summary>
-internal sealed class CommandsAdapter : IExecdCommands
+internal sealed class CommandsAdapter : IExecdCommands, IExecdCommandInventory
 {
     private readonly HttpClientWrapper _client;
     private readonly HttpClient _sseHttpClient;
@@ -182,6 +182,36 @@ internal sealed class CommandsAdapter : IExecdCommands
 
         _logger.LogDebug("Fetching command status: {ExecutionId}", executionId);
         return _client.GetAsync<CommandStatus>($"/command/status/{Uri.EscapeDataString(executionId)}", cancellationToken: cancellationToken);
+    }
+
+    public Task<ListCommandsPage> ListCommandsAsync(
+        bool? running = null,
+        int limit = 50,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (limit is < 1 or > 100)
+        {
+            throw new InvalidArgumentException("limit must be between 1 and 100");
+        }
+
+        var hasCursor = !string.IsNullOrWhiteSpace(cursor);
+        _logger.LogDebug("Listing command inventory (running={Running}, limit={Limit}, hasCursor={HasCursor})", running, limit, hasCursor);
+        var queryParams = new Dictionary<string, string?>();
+        if (running.HasValue)
+        {
+            queryParams["running"] = running.Value ? "true" : "false";
+        }
+        if (limit != 50)
+        {
+            queryParams["limit"] = limit.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+        if (hasCursor)
+        {
+            queryParams["cursor"] = cursor;
+        }
+
+        return _client.GetAsync<ListCommandsPage>("/command", queryParams, cancellationToken);
     }
 
     public async Task<CommandLogs> GetBackgroundCommandLogsAsync(

--- a/sdks/sandbox/csharp/src/OpenSandbox/Factory/DefaultAdapterFactory.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Factory/DefaultAdapterFactory.cs
@@ -90,6 +90,7 @@ public sealed class DefaultAdapterFactory : IAdapterFactory
         return new ExecdStack
         {
             Commands = commands,
+            CommandInventory = commands,
             Files = files,
             Health = health,
             Metrics = metrics,

--- a/sdks/sandbox/csharp/src/OpenSandbox/Factory/IAdapterFactory.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Factory/IAdapterFactory.cs
@@ -99,6 +99,12 @@ public class ExecdStack
     public required IExecdCommands Commands { get; init; }
 
     /// <summary>
+    /// Gets the optional additive command inventory service.
+    /// Existing custom factories may omit this capability.
+    /// </summary>
+    public IExecdCommandInventory? CommandInventory { get; init; }
+
+    /// <summary>
     /// Gets the files service.
     /// </summary>
     public required ISandboxFiles Files { get; init; }

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/CommandInventory.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/CommandInventory.cs
@@ -1,0 +1,397 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenSandbox.Models;
+
+/// <summary>
+/// A command inventory summary.
+/// </summary>
+public abstract class CommandSummary
+{
+    /// <summary>Gets the command identity, equal to the legacy command status ID.</summary>
+    public required string Session { get; init; }
+
+    /// <summary>Gets whether the command is still running.</summary>
+    public abstract bool Running { get; }
+
+    /// <summary>Gets whether the command runs in the background.</summary>
+    public required bool Background { get; init; }
+
+    /// <summary>
+    /// Gets when the command started. The wire format accepts RFC3339Nano fractions through
+    /// nine digits; this <see cref="DateTimeOffset"/> representation truncates fractions beyond
+    /// its seven-digit precision.
+    /// </summary>
+    public required DateTimeOffset StartedAt { get; init; }
+}
+
+/// <summary>
+/// A command inventory summary for a command that is still running.
+/// </summary>
+public sealed class RunningCommandSummary : CommandSummary
+{
+    /// <inheritdoc />
+    public override bool Running => true;
+}
+
+/// <summary>
+/// A command inventory summary for a command that has finished.
+/// </summary>
+public sealed class TerminalCommandSummary : CommandSummary
+{
+    /// <inheritdoc />
+    public override bool Running => false;
+
+    /// <summary>
+    /// Gets when the command finished. The wire format accepts RFC3339Nano fractions through
+    /// nine digits; this <see cref="DateTimeOffset"/> representation truncates fractions beyond
+    /// its seven-digit precision.
+    /// </summary>
+    public required DateTimeOffset FinishedAt { get; init; }
+
+    /// <summary>Gets the exit code, which is present on the wire and may be null.</summary>
+    public int? ExitCode { get; init; }
+
+    /// <summary>Gets the optional terminal error message.</summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Pagination metadata for a command inventory page.
+/// </summary>
+public sealed class CommandPagination
+{
+    /// <summary>Gets the page limit used by the server.</summary>
+    public required int Limit { get; init; }
+
+    /// <summary>Gets the opaque cursor for the next page, or null for the final page.</summary>
+    public string? NextCursor { get; init; }
+}
+
+/// <summary>
+/// A weakly consistent page of command inventory entries.
+/// </summary>
+[JsonConverter(typeof(ListCommandsPageJsonConverter))]
+public sealed class ListCommandsPage
+{
+    /// <summary>Gets the command summaries in this page.</summary>
+    public required IReadOnlyList<CommandSummary> Commands { get; init; }
+
+    /// <summary>Gets the pagination metadata.</summary>
+    public required CommandPagination Pagination { get; init; }
+}
+
+internal sealed class ListCommandsPageJsonConverter : JsonConverter<ListCommandsPage>
+{
+    private static readonly HashSet<string> RunningProperties = new(StringComparer.Ordinal)
+    {
+        "session", "running", "background", "started_at"
+    };
+
+    private static readonly HashSet<string> TerminalProperties = new(StringComparer.Ordinal)
+    {
+        "session", "running", "background", "started_at", "finished_at", "exit_code", "error"
+    };
+
+    public override ListCommandsPage Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var document = JsonDocument.ParseValue(ref reader);
+        var root = document.RootElement;
+        RequireObject(root, "command inventory page");
+
+        var commandsElement = RequireProperty(root, "commands", "command inventory page");
+        if (commandsElement.ValueKind != JsonValueKind.Array)
+        {
+            throw Invalid("command inventory page commands must be an array");
+        }
+
+        var commands = new List<CommandSummary>();
+        foreach (var element in commandsElement.EnumerateArray())
+        {
+            commands.Add(ParseSummary(element));
+        }
+
+        return new ListCommandsPage
+        {
+            Commands = commands,
+            Pagination = ParsePagination(RequireProperty(root, "pagination", "command inventory page"))
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, ListCommandsPage value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("commands");
+        writer.WriteStartArray();
+        foreach (var command in value.Commands)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("session", command.Session);
+            writer.WriteBoolean("running", command.Running);
+            writer.WriteBoolean("background", command.Background);
+            writer.WriteString("started_at", command.StartedAt);
+            if (command is TerminalCommandSummary terminal)
+            {
+                writer.WriteString("finished_at", terminal.FinishedAt);
+                writer.WritePropertyName("exit_code");
+                if (terminal.ExitCode.HasValue)
+                {
+                    writer.WriteNumberValue(terminal.ExitCode.Value);
+                }
+                else
+                {
+                    writer.WriteNullValue();
+                }
+
+                if (terminal.Error is not null)
+                {
+                    writer.WriteString("error", terminal.Error);
+                }
+            }
+
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+        writer.WritePropertyName("pagination");
+        writer.WriteStartObject();
+        writer.WriteNumber("limit", value.Pagination.Limit);
+        if (value.Pagination.NextCursor is not null)
+        {
+            writer.WriteString("nextCursor", value.Pagination.NextCursor);
+        }
+
+        writer.WriteEndObject();
+        writer.WriteEndObject();
+    }
+
+    private static CommandPagination ParsePagination(JsonElement element)
+    {
+        RequireObject(element, "command inventory pagination");
+        var limit = RequireProperty(element, "limit", "command inventory pagination");
+        if (limit.ValueKind != JsonValueKind.Number || !limit.TryGetInt32(out var limitValue) || limitValue is < 1 or > 100)
+        {
+            throw Invalid("command inventory pagination limit must be an integer between 1 and 100");
+        }
+
+        string? nextCursor = null;
+        if (element.TryGetProperty("nextCursor", out var cursor))
+        {
+            nextCursor = RequireString(cursor, "command inventory pagination nextCursor");
+            if (string.IsNullOrWhiteSpace(nextCursor))
+            {
+                throw Invalid("command inventory pagination nextCursor must not be blank");
+            }
+        }
+
+        return new CommandPagination { Limit = limitValue, NextCursor = nextCursor };
+    }
+
+    private static CommandSummary ParseSummary(JsonElement element)
+    {
+        RequireObject(element, "command summary");
+        var running = RequireProperty(element, "running", "command summary");
+        if (running.ValueKind is not JsonValueKind.True and not JsonValueKind.False)
+        {
+            throw Invalid("command summary running must be a boolean");
+        }
+
+        var isRunning = running.GetBoolean();
+        RequireOnlyProperties(element, isRunning ? RunningProperties : TerminalProperties, "command summary");
+        var session = RequireString(RequireProperty(element, "session", "command summary"), "command summary session");
+        var background = RequireBoolean(RequireProperty(element, "background", "command summary"), "command summary background");
+        var startedAt = RequireDateTime(RequireProperty(element, "started_at", "command summary"), "command summary started_at");
+
+        if (isRunning)
+        {
+            return new RunningCommandSummary
+            {
+                Session = session,
+                Background = background,
+                StartedAt = startedAt
+            };
+        }
+
+        var exitCode = RequireProperty(element, "exit_code", "terminal command summary");
+        if (exitCode.ValueKind is not JsonValueKind.Null and not JsonValueKind.Number)
+        {
+            throw Invalid("terminal command summary exit_code must be an integer or null");
+        }
+
+        int? exitCodeValue = null;
+        if (exitCode.ValueKind == JsonValueKind.Number)
+        {
+            if (!exitCode.TryGetInt32(out var parsedExitCode))
+            {
+                throw Invalid("terminal command summary exit_code must be an integer or null");
+            }
+
+            exitCodeValue = parsedExitCode;
+        }
+
+        string? error = null;
+        if (element.TryGetProperty("error", out var errorElement))
+        {
+            error = RequireString(errorElement, "terminal command summary error");
+        }
+
+        return new TerminalCommandSummary
+        {
+            Session = session,
+            Background = background,
+            StartedAt = startedAt,
+            FinishedAt = RequireDateTime(RequireProperty(element, "finished_at", "terminal command summary"), "terminal command summary finished_at"),
+            ExitCode = exitCodeValue,
+            Error = error
+        };
+    }
+
+    private static void RequireObject(JsonElement element, string name)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            throw Invalid($"{name} must be an object");
+        }
+    }
+
+    private static void RequireOnlyProperties(JsonElement element, ISet<string> allowedProperties, string name)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var property in element.EnumerateObject())
+        {
+            if (!allowedProperties.Contains(property.Name) || !seen.Add(property.Name))
+            {
+                throw Invalid($"{name} contains an unsupported property: {property.Name}");
+            }
+        }
+    }
+
+    private static JsonElement RequireProperty(JsonElement element, string propertyName, string name)
+    {
+        return element.TryGetProperty(propertyName, out var property)
+            ? property
+            : throw Invalid($"{name} is missing required property: {propertyName}");
+    }
+
+    private static string RequireString(JsonElement element, string name)
+    {
+        if (element.ValueKind != JsonValueKind.String)
+        {
+            throw Invalid($"{name} must be a string");
+        }
+
+        return element.GetString()!;
+    }
+
+    private static bool RequireBoolean(JsonElement element, string name)
+    {
+        if (element.ValueKind is not JsonValueKind.True and not JsonValueKind.False)
+        {
+            throw Invalid($"{name} must be a boolean");
+        }
+
+        return element.GetBoolean();
+    }
+
+    private static DateTimeOffset RequireDateTime(JsonElement element, string name)
+    {
+        var value = RequireString(element, name);
+        if (!TryNormalizeRfc3339Nano(value, out var normalized))
+        {
+            throw Invalid($"{name} must be an RFC3339 date-time");
+        }
+
+        if (!DateTimeOffset.TryParseExact(
+                normalized,
+                new[] { "yyyy-MM-dd'T'HH:mm:ssK", "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK" },
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None,
+                out var parsed))
+        {
+            throw Invalid($"{name} must be an RFC3339 date-time");
+        }
+
+        return parsed;
+    }
+
+    private static bool TryNormalizeRfc3339Nano(string value, out string normalized)
+    {
+        normalized = value;
+        if (value.Length < 20 || value[4] != '-' || value[7] != '-' || value[10] != 'T' ||
+            value[13] != ':' || value[16] != ':')
+        {
+            return false;
+        }
+
+        if (!AllAsciiDigits(value, 0, 4) || !AllAsciiDigits(value, 5, 2) ||
+            !AllAsciiDigits(value, 8, 2) || !AllAsciiDigits(value, 11, 2) ||
+            !AllAsciiDigits(value, 14, 2) || !AllAsciiDigits(value, 17, 2))
+        {
+            return false;
+        }
+
+        var position = 19;
+        if (position < value.Length && value[position] == '.')
+        {
+            var fractionStart = ++position;
+            while (position < value.Length && value[position] is >= '0' and <= '9')
+            {
+                position++;
+            }
+
+            var fractionLength = position - fractionStart;
+            if (fractionLength is < 1 or > 9)
+            {
+                return false;
+            }
+
+            if (fractionLength > 7)
+            {
+                normalized = value.Remove(fractionStart + 7, fractionLength - 7);
+            }
+        }
+
+        if (position == value.Length - 1 && value[position] == 'Z')
+        {
+            return true;
+        }
+
+        if (position + 6 != value.Length || (value[position] != '+' && value[position] != '-') ||
+            value[position + 3] != ':' || !AllAsciiDigits(value, position + 1, 2) ||
+            !AllAsciiDigits(value, position + 4, 2))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool AllAsciiDigits(string value, int start, int length)
+    {
+        for (var index = start; index < start + length; index++)
+        {
+            if (value[index] is < '0' or > '9')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static JsonException Invalid(string message) => new(message);
+}

--- a/sdks/sandbox/csharp/src/OpenSandbox/Sandbox.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Sandbox.cs
@@ -52,6 +52,11 @@ public sealed class Sandbox : IAsyncDisposable
     public IExecdCommands Commands { get; }
 
     /// <summary>
+    /// Gets the additive command inventory capability when provided by the adapter factory.
+    /// </summary>
+    public IExecdCommandInventory? CommandInventory { get; }
+
+    /// <summary>
     /// Gets the filesystem service.
     /// </summary>
     public ISandboxFiles Files { get; }
@@ -97,6 +102,7 @@ public sealed class Sandbox : IAsyncDisposable
         HttpClientProvider httpClientProvider,
         ISandboxes sandboxes,
         IExecdCommands commands,
+        IExecdCommandInventory? commandInventory,
         ISandboxFiles files,
         IExecdHealth health,
         IExecdMetrics metrics,
@@ -114,6 +120,7 @@ public sealed class Sandbox : IAsyncDisposable
         _logger = _loggerFactory.CreateLogger("OpenSandbox.Sandbox");
         _sandboxes = sandboxes;
         Commands = commands;
+        CommandInventory = commandInventory ?? commands as IExecdCommandInventory;
         Files = files;
         Health = health;
         Metrics = metrics;
@@ -268,6 +275,7 @@ public sealed class Sandbox : IAsyncDisposable
                 httpClientProvider,
                 sandboxes,
                 execdStack.Commands,
+                execdStack.CommandInventory,
                 execdStack.Files,
                 execdStack.Health,
                 execdStack.Metrics,
@@ -410,6 +418,7 @@ public sealed class Sandbox : IAsyncDisposable
                 httpClientProvider,
                 sandboxes,
                 execdStack.Commands,
+                execdStack.CommandInventory,
                 execdStack.Files,
                 execdStack.Health,
                 execdStack.Metrics,

--- a/sdks/sandbox/csharp/src/OpenSandbox/Services/IExecdCommandInventory.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Services/IExecdCommandInventory.cs
@@ -1,0 +1,39 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using OpenSandbox.Models;
+
+namespace OpenSandbox.Services;
+
+/// <summary>
+/// Provides weakly consistent command inventory discovery for a sandbox.
+/// </summary>
+public interface IExecdCommandInventory
+{
+    /// <summary>
+    /// Lists a page of running and terminal command summaries.
+    /// </summary>
+    /// <param name="running">Filters to running or terminal commands; omit for both.</param>
+    /// <param name="limit">Maximum number of command summaries to return.</param>
+    /// <param name="cursor">An opaque cursor from a prior page.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A weakly consistent command inventory page.</returns>
+    /// <exception cref="Core.InvalidArgumentException">Thrown when <paramref name="limit"/> is outside 1 through 100.</exception>
+    /// <exception cref="Core.SandboxException">Thrown when the execd service request fails.</exception>
+    Task<ListCommandsPage> ListCommandsAsync(
+        bool? running = null,
+        int limit = 50,
+        string? cursor = null,
+        CancellationToken cancellationToken = default);
+}

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/CommandInventoryCapabilityTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/CommandInventoryCapabilityTests.cs
@@ -1,0 +1,678 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using OpenSandbox.Adapters;
+using OpenSandbox.Config;
+using OpenSandbox.Core;
+using OpenSandbox.Factory;
+using OpenSandbox.Internal;
+using OpenSandbox.Models;
+using OpenSandbox.Services;
+using Xunit;
+
+namespace OpenSandbox.Tests;
+
+public class CommandInventoryCapabilityTests
+{
+    [Fact]
+    public async Task ConnectAsync_ShouldKeepLegacyCustomCommandsStubCompatible_WhenFactoryDoesNotProvideInventory()
+    {
+        var commands = new LegacyCommandsStub();
+        var factory = new LegacyCommandsAdapterFactory(commands);
+
+        await using var sandbox = await Sandbox.ConnectAsync(new SandboxConnectOptions
+        {
+            SandboxId = "sbx-command-inventory",
+            ConnectionConfig = new ConnectionConfig(new ConnectionConfigOptions
+            {
+                Domain = "localhost:8080"
+            }),
+            AdapterFactory = factory,
+            SkipHealthCheck = true
+        });
+
+        sandbox.Commands.Should().BeSameAs(commands);
+        sandbox.CommandInventory.Should().BeNull();
+        factory.CreateExecdStackCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_ShouldUseInventoryCapabilityImplementedByCommandsWhenStackCapabilityIsOmitted()
+    {
+        var commands = new CommandsAndInventoryStub();
+        var factory = new LegacyCommandsAdapterFactory(commands);
+
+        await using var sandbox = await Sandbox.ConnectAsync(new SandboxConnectOptions
+        {
+            SandboxId = "sbx-command-inventory-fallback",
+            ConnectionConfig = new ConnectionConfig(new ConnectionConfigOptions
+            {
+                Domain = "localhost:8080"
+            }),
+            AdapterFactory = factory,
+            SkipHealthCheck = true
+        });
+
+        sandbox.Commands.Should().BeSameAs(commands);
+        sandbox.CommandInventory.Should().BeSameAs(commands);
+    }
+
+    [Fact]
+    public void DefaultAdapterFactory_ShouldExposeCommandInventoryCapability()
+    {
+        var connectionConfig = new ConnectionConfig(new ConnectionConfigOptions { Domain = "localhost:8080" });
+        using var provider = new HttpClientProvider(connectionConfig, NullLoggerFactory.Instance);
+        var factory = DefaultAdapterFactory.Create();
+
+        var stack = factory.CreateExecdStack(new CreateExecdStackOptions
+        {
+            ConnectionConfig = connectionConfig,
+            ExecdBaseUrl = "http://execd.local",
+            HttpClientProvider = provider,
+            LoggerFactory = NullLoggerFactory.Instance
+        });
+
+        stack.CommandInventory.Should().NotBeNull();
+        stack.CommandInventory.Should().BeSameAs(stack.Commands);
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldGetCommandEndpointWithoutQueryByDefault()
+    {
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            request.Method.Should().Be(HttpMethod.Get);
+            request.RequestUri!.AbsolutePath.Should().Be("/command");
+            request.RequestUri.Query.Should().BeEmpty();
+            return JsonResponse(RunningPageJson());
+        });
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var page = await inventory.ListCommandsAsync();
+
+        page.Commands.Should().ContainSingle().Which.Should().BeOfType<RunningCommandSummary>();
+        handler.RequestUris.Should().ContainSingle().Which.Should().Be("http://execd.local/command");
+    }
+
+    [Theory]
+    [InlineData(true, "?running=true")]
+    [InlineData(false, "?running=false")]
+    public async Task ListCommandsAsync_ShouldEncodeRunningFilter(bool running, string expectedQuery)
+    {
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            request.RequestUri!.Query.Should().Be(expectedQuery);
+            return JsonResponse(RunningPageJson());
+        });
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        await inventory.ListCommandsAsync(running);
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldEncodeOpaqueCursorWithoutInterpretingIt()
+    {
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            request.RequestUri!.Query.Should().Be("?cursor=opaque%2B%2F%3Dtoken%3Fvalue");
+            return JsonResponse(RunningPageJson());
+        });
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        await inventory.ListCommandsAsync(cursor: "opaque+/=token?value");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" \t ")]
+    public async Task ListCommandsAsync_ShouldOmitBlankCursor(string cursor)
+    {
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            request.RequestUri!.Query.Should().BeEmpty();
+            return JsonResponse(RunningPageJson());
+        });
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        await inventory.ListCommandsAsync(cursor: cursor);
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldIncludeNonDefaultLimit()
+    {
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            request.RequestUri!.Query.Should().Be("?limit=25");
+            return JsonResponse(RunningPageJson());
+        });
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        await inventory.ListCommandsAsync(limit: 25);
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldPropagateCancellationToken()
+    {
+        CancellationToken received = default;
+        var handler = new StubHttpMessageHandler((_, cancellationToken) =>
+        {
+            received = cancellationToken;
+            return JsonResponse(RunningPageJson());
+        });
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+        using var cancellation = new CancellationTokenSource();
+
+        await inventory.ListCommandsAsync(cancellationToken: cancellation.Token);
+
+        received.Should().Be(cancellation.Token);
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldPreserveHttpClientWrapperInvalidQueryErrorMapping()
+    {
+        var handler = new StubHttpMessageHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("""
+                    { "code": "INVALID_QUERY", "message": "invalid cursor" }
+                    """, Encoding.UTF8, "application/json")
+            };
+            response.Headers.Add("x-request-id", "request-inventory-400");
+            return Task.FromResult(response);
+        });
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var act = () => inventory.ListCommandsAsync(cursor: "invalid");
+
+        var exception = await act.Should().ThrowAsync<SandboxApiException>();
+        exception.Which.StatusCode.Should().Be(400);
+        exception.Which.Error.Code.Should().Be("INVALID_QUERY");
+        exception.Which.Message.Should().Be("invalid cursor");
+        exception.Which.RequestId.Should().Be("request-inventory-400");
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldAllowEnvelopeAndPaginationExtensions()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse("""
+            {
+              "commands": [{
+                "session": "cmd-running",
+                "running": true,
+                "background": true,
+                "started_at": "2026-07-24T10:00:00Z"
+              }],
+              "pagination": {
+                "limit": 50,
+                "inventory_extension": { "enabled": true }
+              },
+              "page_extension": ["future"]
+            }
+            """));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var page = await inventory.ListCommandsAsync();
+
+        page.Commands.Should().ContainSingle();
+        page.Pagination.Limit.Should().Be(50);
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldDeserializeMixedPageAndPreserveNonemptyCursor()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse("""
+            {
+              "commands": [
+                {
+                  "session": "cmd-running",
+                  "running": true,
+                  "background": true,
+                  "started_at": "2026-07-24T10:00:00Z"
+                },
+                {
+                  "session": "cmd-terminal",
+                  "running": false,
+                  "background": false,
+                  "started_at": "2026-07-24T10:00:00Z",
+                  "finished_at": "2026-07-24T10:01:00Z",
+                  "exit_code": 7
+                }
+              ],
+              "pagination": { "limit": 2, "nextCursor": "opaque+/=cursor" }
+            }
+            """));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var page = await inventory.ListCommandsAsync();
+
+        page.Commands.Should().HaveCount(2);
+        page.Commands[0].Should().BeOfType<RunningCommandSummary>();
+        page.Commands[1].Should().BeOfType<TerminalCommandSummary>();
+        page.Pagination.NextCursor.Should().Be("opaque+/=cursor");
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldPreserveNonemptyNextCursor()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse("""
+            {
+              "commands": [],
+              "pagination": { "limit": 50, "nextCursor": "opaque+/=cursor" }
+            }
+            """));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var page = await inventory.ListCommandsAsync();
+
+        page.Pagination.NextCursor.Should().Be("opaque+/=cursor");
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldRejectNullNextCursor()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse("""
+            {
+              "commands": [],
+              "pagination": { "limit": 50, "nextCursor": null }
+            }
+            """));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var act = () => inventory.ListCommandsAsync();
+
+        await act.Should().ThrowAsync<SandboxApiException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ListCommandsAsync_ShouldRejectBlankNextCursor(string nextCursor)
+    {
+        var serializedNextCursor = JsonSerializer.Serialize(nextCursor);
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse($"""
+            {{
+              "commands": [],
+              "pagination": {{ "limit": 50, "nextCursor": {serializedNextCursor} }}
+            }}
+            """));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var act = () => inventory.ListCommandsAsync();
+
+        await act.Should().ThrowAsync<SandboxApiException>();
+    }
+
+    [Theory]
+    [InlineData("{\"commands\":null,\"pagination\":{\"limit\":50}}")]
+    [InlineData("{\"commands\":[],\"pagination\":null}")]
+    [InlineData("{\"pagination\":{\"limit\":50}}")]
+    [InlineData("{\"commands\":[],\"pagination\":{\"limit\":null}}")]
+    [InlineData("{\"commands\":[],\"pagination\":{\"limit\":\"50\"}}")]
+    public async Task ListCommandsAsync_ShouldRejectMissingNullAndWrongTypeKnownEnvelopeFields(string page)
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse(page));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var act = () => inventory.ListCommandsAsync();
+
+        await act.Should().ThrowAsync<SandboxApiException>();
+    }
+
+    [Fact]
+    public void ListCommandsPage_ShouldSerializeAsValidResponseShape()
+    {
+        var page = new ListCommandsPage
+        {
+            Commands =
+            [
+                new RunningCommandSummary
+                {
+                    Session = "cmd-running",
+                    Background = true,
+                    StartedAt = DateTimeOffset.Parse("2026-07-24T10:00:00Z")
+                },
+                new TerminalCommandSummary
+                {
+                    Session = "cmd-terminal",
+                    Background = false,
+                    StartedAt = DateTimeOffset.Parse("2026-07-24T10:00:00Z"),
+                    FinishedAt = DateTimeOffset.Parse("2026-07-24T10:01:00Z"),
+                    ExitCode = null,
+                    Error = "interrupted"
+                }
+            ],
+            Pagination = new CommandPagination { Limit = 2, NextCursor = "next" }
+        };
+
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(page));
+
+        document.RootElement.GetProperty("commands")[0].GetProperty("running").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("commands")[1].GetProperty("exit_code").ValueKind.Should().Be(JsonValueKind.Null);
+        document.RootElement.GetProperty("pagination").GetProperty("nextCursor").GetString().Should().Be("next");
+    }
+
+    [Theory]
+    [InlineData("{\"running\":false,\"background\":false,\"started_at\":\"2026-07-24T10:00:00Z\",\"finished_at\":\"2026-07-24T10:01:00Z\",\"exit_code\":0}")]
+    [InlineData("{\"session\":\"cmd-terminal\",\"running\":false,\"background\":false,\"started_at\":\"2026-07-24T10:00:00Z\",\"exit_code\":0}")]
+    [InlineData("{\"session\":\"cmd-terminal\",\"running\":false,\"background\":false,\"started_at\":\"2026-07-24T10:00:00Z\",\"finished_at\":\"2026-07-24T10:01:00Z\"}")]
+    [InlineData("{\"session\":null,\"running\":true,\"background\":true,\"started_at\":\"2026-07-24T10:00:00Z\"}")]
+    [InlineData("{\"session\":\"cmd\",\"running\":true,\"background\":\"true\",\"started_at\":\"2026-07-24T10:00:00Z\"}")]
+    [InlineData("{\"session\":\"cmd\",\"running\":\"true\",\"background\":true,\"started_at\":\"2026-07-24T10:00:00Z\"}")]
+    [InlineData("{\"session\":\"cmd\",\"session\":\"duplicate\",\"running\":true,\"background\":true,\"started_at\":\"2026-07-24T10:00:00Z\"}")]
+    [InlineData("{\"session\":\"cmd\",\"running\":true,\"background\":true,\"started_at\":\"not-a-date\"}")]
+    [InlineData("{\"session\":\"cmd\",\"running\":true,\"background\":true,\"started_at\":\"2026-07-24\"}")]
+    [InlineData("{\"session\":\"cmd\",\"running\":true,\"background\":true,\"started_at\":\"07/24/2026 10:00:00\"}")]
+    [InlineData("{\"session\":\"cmd\",\"running\":true,\"background\":true,\"started_at\":\"2026-07-24T10:00:00.Z\"}")]
+    [InlineData("{\"session\":\"cmd\",\"running\":true,\"background\":true,\"started_at\":\"2026-07-24T10:00:00.1234567890Z\"}")]
+    [InlineData("{\"session\":\"cmd\",\"running\":true,\"background\":true,\"started_at\":\"2026-07-24T10:00:00.12+0800\"}")]
+    public async Task ListCommandsAsync_ShouldRejectMissingNullDuplicateAndMalformedCommonFields(string summary)
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse(PageWithSummary(summary)));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var act = () => inventory.ListCommandsAsync();
+
+        await act.Should().ThrowAsync<SandboxApiException>();
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldDeserializeRunningSummaryWithoutTerminalFields()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse(RunningPageJson()));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var page = await inventory.ListCommandsAsync();
+
+        var summary = page.Commands.Should().ContainSingle().Which.Should().BeOfType<RunningCommandSummary>().Subject;
+        summary.Session.Should().Be("cmd-running");
+        summary.Background.Should().BeTrue();
+        summary.StartedAt.Should().Be(DateTimeOffset.Parse("2026-07-24T10:00:00Z"));
+    }
+
+    [Theory]
+    [InlineData("2026-07-24T10:00:00.1Z")]
+    [InlineData("2026-07-24T10:00:00.1234567Z")]
+    [InlineData("2026-07-24T10:00:00.12345678Z")]
+    [InlineData("2026-07-24T10:00:00.123456789Z")]
+    [InlineData("2026-07-24T10:00:00.123456789+08:00")]
+    public async Task ListCommandsAsync_ShouldAcceptRfc3339NanoTimestamps(string startedAt)
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse(PageWithSummary($"""
+            {{
+              "session": "cmd-running",
+              "running": true,
+              "background": true,
+              "started_at": "{startedAt}"
+            }}
+            """)));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var page = await inventory.ListCommandsAsync();
+
+        page.Commands.Should().ContainSingle().Which.Should().BeOfType<RunningCommandSummary>();
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldTruncateRfc3339NanoToDateTimeOffsetPrecision()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse(PageWithSummary("""
+            {
+              "session": "cmd-running",
+              "running": true,
+              "background": true,
+              "started_at": "2026-07-24T10:00:00.123456789Z"
+            }
+            """)));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var page = await inventory.ListCommandsAsync();
+
+        var summary = page.Commands.Should().ContainSingle().Which.Should().BeOfType<RunningCommandSummary>().Subject;
+        summary.StartedAt.Should().Be(new DateTimeOffset(2026, 7, 24, 10, 0, 0, TimeSpan.Zero).AddTicks(1234567));
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldDeserializeTerminalSummaryWithPresentNullExitCode()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse(TerminalPageJson()));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var page = await inventory.ListCommandsAsync();
+
+        var summary = page.Commands.Should().ContainSingle().Which.Should().BeOfType<TerminalCommandSummary>().Subject;
+        summary.FinishedAt.Should().Be(DateTimeOffset.Parse("2026-07-24T10:01:00Z"));
+        summary.ExitCode.Should().BeNull();
+        summary.Error.Should().Be("interrupted");
+    }
+
+    [Fact]
+    public async Task ListCommandsAsync_ShouldTreatOmittedNextCursorAsFinalPage()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse(RunningPageJson()));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var page = await inventory.ListCommandsAsync();
+
+        page.Pagination.Limit.Should().Be(50);
+        page.Pagination.NextCursor.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"session\":\"cmd-running\",\"running\":true,\"background\":true,\"started_at\":\"2026-07-24T10:00:00Z\",\"finished_at\":\"2026-07-24T10:01:00Z\"}")]
+    [InlineData("{\"session\":\"cmd-terminal\",\"running\":false,\"background\":false,\"started_at\":\"2026-07-24T10:00:00Z\",\"finished_at\":\"2026-07-24T10:01:00Z\",\"exit_code\":null,\"error\":123}")]
+    [InlineData("{\"session\":\"cmd-running\",\"running\":true,\"background\":true,\"started_at\":\"2026-07-24T10:00:00Z\",\"unexpected\":true}")]
+    public async Task ListCommandsAsync_ShouldRejectInvalidSummaryWireShape(string summary)
+    {
+        var handler = new StubHttpMessageHandler((_, _) => JsonResponse($"""
+            {{
+              "commands": [{summary}],
+              "pagination": {{ "limit": 50 }}
+            }}
+            """));
+        IExecdCommandInventory inventory = CreateAdapter(handler);
+
+        var act = () => inventory.ListCommandsAsync();
+
+        await act.Should().ThrowAsync<SandboxApiException>();
+    }
+
+    private static CommandsAdapter CreateAdapter(HttpMessageHandler httpHandler)
+    {
+        const string baseUrl = "http://execd.local";
+        var headers = new Dictionary<string, string> { ["X-Test"] = "true" };
+        var client = new HttpClientWrapper(new HttpClient(httpHandler), baseUrl, headers);
+        return new CommandsAdapter(
+            client,
+            new HttpClient(httpHandler),
+            baseUrl,
+            headers,
+            NullLoggerFactory.Instance.CreateLogger("CommandInventoryCapabilityTests"));
+    }
+
+    private static Task<HttpResponseMessage> JsonResponse(string body)
+    {
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        });
+    }
+
+    private static string RunningPageJson() => """
+        {
+          "commands": [
+            {
+              "session": "cmd-running",
+              "running": true,
+              "background": true,
+              "started_at": "2026-07-24T10:00:00Z"
+            }
+          ],
+          "pagination": { "limit": 50 }
+        }
+        """;
+
+    private static string TerminalPageJson() => """
+        {
+          "commands": [
+            {
+              "session": "cmd-terminal",
+              "running": false,
+              "background": false,
+              "started_at": "2026-07-24T10:00:00Z",
+              "finished_at": "2026-07-24T10:01:00Z",
+              "exit_code": null,
+              "error": "interrupted"
+            }
+          ],
+          "pagination": { "limit": 50 }
+        }
+        """;
+
+    private static string PageWithSummary(string summary) => $"""
+        {{
+          "commands": [{summary}],
+          "pagination": {{ "limit": 50 }}
+        }}
+        """;
+
+    private sealed class LegacyCommandsAdapterFactory : IAdapterFactory
+    {
+        private readonly IExecdCommands _commands;
+
+        public LegacyCommandsAdapterFactory(IExecdCommands commands)
+        {
+            _commands = commands;
+        }
+
+        public int CreateExecdStackCallCount { get; private set; }
+
+        public LifecycleStack CreateLifecycleStack(CreateLifecycleStackOptions options)
+        {
+            return new LifecycleStack
+            {
+                Sandboxes = new LegacySandboxesStub()
+            };
+        }
+
+        public ExecdStack CreateExecdStack(CreateExecdStackOptions options)
+        {
+            CreateExecdStackCallCount++;
+            return new ExecdStack
+            {
+                Commands = _commands,
+                Files = Mock.Of<ISandboxFiles>(),
+                Health = Mock.Of<IExecdHealth>(),
+                Metrics = Mock.Of<IExecdMetrics>(),
+                Isolation = Mock.Of<IIsolatedSessions>()
+            };
+        }
+
+        public EgressStack CreateEgressStack(CreateEgressStackOptions options)
+        {
+            return new EgressStack
+            {
+                Egress = Mock.Of<IEgress>()
+            };
+        }
+    }
+
+    private class LegacyCommandsStub : IExecdCommands
+    {
+        public IAsyncEnumerable<ServerStreamEvent> RunStreamAsync(string command, RunCommandOptions? options = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<Execution> RunAsync(string command, RunCommandOptions? options = null, ExecutionHandlers? handlers = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task InterruptAsync(string sessionId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<CommandStatus> GetCommandStatusAsync(string executionId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<CommandLogs> GetBackgroundCommandLogsAsync(string executionId, long? cursor = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<string> CreateSessionAsync(CreateSessionOptions? options = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<Execution> RunInSessionAsync(string sessionId, string command, RunInSessionOptions? options = null, ExecutionHandlers? handlers = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task DeleteSessionAsync(string sessionId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class CommandsAndInventoryStub : LegacyCommandsStub, IExecdCommandInventory
+    {
+        public Task<ListCommandsPage> ListCommandsAsync(
+            bool? running = null,
+            int limit = 50,
+            string? cursor = null,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class LegacySandboxesStub : ISandboxes
+    {
+        public Task<CreateSandboxResponse> CreateSandboxAsync(CreateSandboxRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<SandboxInfo> GetSandboxAsync(string sandboxId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ListSandboxesResponse> ListSandboxesAsync(ListSandboxesParams? @params = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<SandboxInfo> PatchSandboxMetadataAsync(string sandboxId, IReadOnlyDictionary<string, string?> patch, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task DeleteSandboxAsync(string sandboxId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task PauseSandboxAsync(string sandboxId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task ResumeSandboxAsync(string sandboxId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<RenewSandboxExpirationResponse> RenewSandboxExpirationAsync(string sandboxId, RenewSandboxExpirationRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<SnapshotInfo> CreateSnapshotAsync(string sandboxId, CreateSnapshotRequest? request = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<SnapshotInfo> GetSnapshotAsync(string snapshotId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ListSnapshotsResponse> ListSnapshotsAsync(ListSnapshotsParams? @params = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task DeleteSnapshotAsync(string snapshotId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<Endpoint> GetSandboxEndpointAsync(string sandboxId, int port, bool useServerProxy = false, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new Endpoint
+            {
+                EndpointAddress = $"127.0.0.1:{port}",
+                Headers = new Dictionary<string, string>()
+            });
+        }
+
+        public Task<Endpoint> GetSignedSandboxEndpointAsync(string sandboxId, int port, long expires, bool useServerProxy = false, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        public StubHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        public List<string> RequestUris { get; } = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestUris.Add(request.RequestUri?.ToString() ?? string.Empty);
+            return await _handler(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/sdks/sandbox/go/command_inventory_test.go
+++ b/sdks/sandbox/go/command_inventory_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+const commandInventoryResponse = `{
+	"commands": [
+		{"session":"running","running":true,"background":true,"started_at":"2026-07-22T12:00:00Z"},
+		{"session":"terminal","running":false,"background":false,"started_at":"2026-07-22T12:00:00Z","finished_at":"2026-07-22T12:01:00Z","exit_code":null}
+	],
+	"pagination": {"limit":25,"nextCursor":"next-cursor"}
+}`
+
+func TestExecdClientListCommands_Query(t *testing.T) {
+	tests := []struct {
+		name string
+		req  ListCommandsRequest
+		want url.Values
+	}{
+		{name: "default", want: url.Values{}},
+		{name: "running omitted", req: ListCommandsRequest{Limit: 25}, want: url.Values{"limit": {"25"}}},
+		{name: "running true", req: ListCommandsRequest{Running: boolPtr(true)}, want: url.Values{"running": {"true"}}},
+		{name: "running false", req: ListCommandsRequest{Running: boolPtr(false)}, want: url.Values{"running": {"false"}}},
+		{name: "empty cursor is omitted", req: ListCommandsRequest{Cursor: ""}, want: url.Values{}},
+		{name: "whitespace cursor is omitted", req: ListCommandsRequest{Cursor: "  \t "}, want: url.Values{}},
+		{
+			name: "limit and opaque cursor are escaped",
+			req:  ListCommandsRequest{Limit: 25, Cursor: "opaque +/= cursor"},
+			want: url.Values{"limit": {"25"}, "cursor": {"opaque +/= cursor"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("method = %s, want GET", r.Method)
+				}
+				if r.URL.Path != "/command" {
+					t.Errorf("path = %q, want /command", r.URL.Path)
+				}
+				if got := r.URL.Query(); !urlValuesEqual(got, test.want) {
+					t.Errorf("query = %q, want %q", got.Encode(), test.want.Encode())
+				}
+				jsonResponse(w, http.StatusOK, json.RawMessage(commandInventoryResponse))
+			})
+
+			got, err := client.ListCommands(context.Background(), test.req)
+			if err != nil {
+				t.Fatalf("ListCommands() error = %v", err)
+			}
+			if got.Pagination.Limit != 25 {
+				t.Errorf("pagination limit = %d, want 25", got.Pagination.Limit)
+			}
+		})
+	}
+}
+
+func TestListCommandsResponse_RawJSONBranchesAndRoundTrip(t *testing.T) {
+	var response ListCommandsResponse
+	if err := json.Unmarshal([]byte(commandInventoryResponse), &response); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if response.Pagination.NextCursor == nil || *response.Pagination.NextCursor != "next-cursor" {
+		t.Fatalf("next cursor = %v, want next-cursor", response.Pagination.NextCursor)
+	}
+	if response.Commands[1].ExitCode != nil {
+		t.Errorf("terminal exit code = %v, want nil for explicit null", response.Commands[1].ExitCode)
+	}
+
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var raw struct {
+		Commands   []map[string]json.RawMessage `json:"commands"`
+		Pagination map[string]json.RawMessage   `json:"pagination"`
+	}
+	if err := json.Unmarshal(encoded, &raw); err != nil {
+		t.Fatalf("unmarshal round trip = %v", err)
+	}
+	if _, ok := raw.Commands[0]["finished_at"]; ok {
+		t.Error("running command unexpectedly includes finished_at")
+	}
+	if _, ok := raw.Commands[0]["exit_code"]; ok {
+		t.Error("running command unexpectedly includes exit_code")
+	}
+	if got, ok := raw.Commands[1]["finished_at"]; !ok || string(got) != `"2026-07-22T12:01:00Z"` {
+		t.Errorf("terminal finished_at = %s, want timestamp", got)
+	}
+	if got, ok := raw.Commands[1]["exit_code"]; !ok || string(got) != "null" {
+		t.Errorf("terminal exit_code = %s, want explicit null", got)
+	}
+
+	var finalPage ListCommandsResponse
+	if err := json.Unmarshal([]byte(`{"commands":[],"pagination":{"limit":25}}`), &finalPage); err != nil {
+		t.Fatalf("unmarshal final page = %v", err)
+	}
+	if finalPage.Pagination.NextCursor != nil {
+		t.Errorf("final page next cursor = %v, want nil", *finalPage.Pagination.NextCursor)
+	}
+}
+
+func TestListCommandsResponse_RejectsInvalidBranches(t *testing.T) {
+	tests := []string{
+		`{"commands":[{"session":"running","running":true,"background":true,"started_at":"2026-07-22T12:00:00Z","finished_at":null}],"pagination":{"limit":25}}`,
+		`{"commands":[{"session":"terminal","running":false,"background":false,"started_at":"2026-07-22T12:00:00Z","finished_at":null,"exit_code":null,"error":123}],"pagination":{"limit":25}}`,
+		`{"commands":[{"session":"terminal","running":false,"background":false,"started_at":"2026-07-22T12:00:00Z","finished_at":null}],"pagination":{"limit":25}}`,
+		`{"commands":[{"session":"running","running":null,"background":true,"started_at":"2026-07-22T12:00:00Z"}],"pagination":{"limit":25}}`,
+		`{"commands":[{"session":null,"running":true,"background":true,"started_at":"2026-07-22T12:00:00Z"}],"pagination":{"limit":25}}`,
+		`{"commands":[{"session":"running","running":true,"background":null,"started_at":"2026-07-22T12:00:00Z"}],"pagination":{"limit":25}}`,
+		`{"commands":[{"session":"running","running":true,"background":true,"started_at":null}],"pagination":{"limit":25}}`,
+		`{"commands":[{"session":"terminal","running":false,"background":false,"started_at":"2026-07-22T12:00:00Z","finished_at":"2026-07-22T12:01:00Z","exit_code":null,"error":null}],"pagination":{"limit":25}}`,
+		`{"commands":[{"session":"terminal","running":false,"background":false,"started_at":"2026-07-22T12:00:00Z","finished_at":null,"exit_code":null}],"pagination":{"limit":25}}`,
+		`{"commands":[],"pagination":{"limit":25,"nextCursor":null}}`,
+		`{"commands":[],"pagination":{"limit":25,"nextCursor":""}}`,
+		`{"commands":[],"pagination":{"limit":25,"nextCursor":"   "}}`,
+		`{"commands":[],"pagination":{"limit":0}}`,
+		`{"commands":[],"pagination":{"limit":-1}}`,
+		`{"commands":[],"pagination":{"limit":101}}`,
+		`{"commands":[{"session":"running","running":true,"background":true,"started_at":"2026-07-22T12:00:00Z","unknown":true}],"pagination":{"limit":25}}`,
+	}
+	for _, body := range tests {
+		var response ListCommandsResponse
+		if err := json.Unmarshal([]byte(body), &response); err == nil {
+			t.Errorf("Unmarshal(%s) unexpectedly succeeded", body)
+		}
+	}
+}
+
+func TestListCommandsResponse_AcceptsTopLevelAndPaginationExtensions(t *testing.T) {
+	var response ListCommandsResponse
+	err := json.Unmarshal([]byte(`{
+		"commands": [],
+		"pagination": {"limit":25,"futurePaginationField":{"enabled":true}},
+		"futureTopLevelField": true
+	}`), &response)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v, want top-level and pagination extensions accepted", err)
+	}
+	if response.Pagination.Limit != 25 {
+		t.Errorf("pagination limit = %d, want 25", response.Pagination.Limit)
+	}
+}
+
+func TestCommandSummary_MarshalRejectsTerminalWithoutFinishedAt(t *testing.T) {
+	_, err := json.Marshal(CommandSummary{
+		Session:    "terminal",
+		Running:    false,
+		Background: false,
+		ExitCode:   nil,
+	})
+	if err == nil {
+		t.Fatal("Marshal() succeeded, want error for terminal command without finished_at")
+	}
+}
+
+func TestCommandSummary_RequiresNestedBranchFields(t *testing.T) {
+	tests := []string{
+		`{"running":true,"background":true,"started_at":"2026-07-22T12:00:00Z"}`,
+		`{"session":"running","background":true,"started_at":"2026-07-22T12:00:00Z"}`,
+		`{"session":"running","running":true,"started_at":"2026-07-22T12:00:00Z"}`,
+		`{"session":"running","running":true,"background":true}`,
+		`{"session":"terminal","running":false,"background":false,"started_at":"2026-07-22T12:00:00Z","finished_at":"2026-07-22T12:01:00Z"}`,
+		`{"session":"terminal","running":false,"background":false,"started_at":"2026-07-22T12:00:00Z","exit_code":null}`,
+	}
+	for _, body := range tests {
+		var summary CommandSummary
+		if err := json.Unmarshal([]byte(body), &summary); err == nil {
+			t.Errorf("Unmarshal(%s) unexpectedly succeeded", body)
+		}
+	}
+}
+
+func TestExecdClientListCommands_HTTPError(t *testing.T) {
+	_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, http.StatusBadRequest, ErrorResponse{Code: "INVALID_QUERY", Message: "invalid cursor"})
+	})
+	_, err := client.ListCommands(context.Background(), ListCommandsRequest{})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("ListCommands() error = %T %v, want *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", apiErr.StatusCode)
+	}
+}
+
+func TestSandboxListCommands(t *testing.T) {
+	t.Run("forwards to non-nil execd", func(t *testing.T) {
+		_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("running") != "false" {
+				t.Errorf("running = %q, want false", r.URL.Query().Get("running"))
+			}
+			jsonResponse(w, http.StatusOK, json.RawMessage(commandInventoryResponse))
+		})
+		sandbox := &Sandbox{execd: client}
+		response, err := sandbox.ListCommands(context.Background(), ListCommandsRequest{Running: boolPtr(false)})
+		if err != nil {
+			t.Fatalf("Sandbox.ListCommands() error = %v", err)
+		}
+		if len(response.Commands) != 2 {
+			t.Errorf("commands = %d, want 2", len(response.Commands))
+		}
+	})
+
+	t.Run("preserves nil execd legacy error", func(t *testing.T) {
+		_, err := (&Sandbox{}).ListCommands(context.Background(), ListCommandsRequest{})
+		if err == nil || err.Error() != "opensandbox: execd client not initialized" {
+			t.Errorf("error = %v, want legacy execd initialization error", err)
+		}
+	})
+}
+
+func boolPtr(value bool) *bool { return &value }
+
+func urlValuesEqual(got, want url.Values) bool {
+	return got.Encode() == want.Encode()
+}

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 )
 
 // ExecdClient provides access to the OpenSandbox Execd API for code execution,
@@ -133,6 +134,29 @@ func (e *ExecdClient) DeleteSession(ctx context.Context, sessionID string) error
 // RunCommand executes a shell command and streams output events via SSE.
 func (e *ExecdClient) RunCommand(ctx context.Context, req RunCommandRequest, handler EventHandler) error {
 	return e.client.doStreamRequest(ctx, http.MethodPost, "/command", req, handler)
+}
+
+// ListCommands returns a page of command inventory summaries.
+func (e *ExecdClient) ListCommands(ctx context.Context, req ListCommandsRequest) (*ListCommandsResponse, error) {
+	params := url.Values{}
+	if req.Running != nil {
+		params.Set("running", strconv.FormatBool(*req.Running))
+	}
+	if req.Limit != 0 {
+		params.Set("limit", strconv.Itoa(req.Limit))
+	}
+	if strings.TrimSpace(req.Cursor) != "" {
+		params.Set("cursor", req.Cursor)
+	}
+	path := "/command"
+	if encoded := params.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	var result ListCommandsResponse
+	if err := e.client.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // InterruptCommand interrupts the currently running command execution.

--- a/sdks/sandbox/go/sandbox_exec.go
+++ b/sdks/sandbox/go/sandbox_exec.go
@@ -40,6 +40,14 @@ func (s *Sandbox) RunCommandWithOpts(ctx context.Context, req RunCommandRequest,
 	return exec, nil
 }
 
+// ListCommands returns a page of command inventory summaries.
+func (s *Sandbox) ListCommands(ctx context.Context, req ListCommandsRequest) (*ListCommandsResponse, error) {
+	if s.execd == nil {
+		return nil, fmt.Errorf("opensandbox: execd client not initialized")
+	}
+	return s.execd.ListCommands(ctx, req)
+}
+
 // ExecuteCode executes code in a context and streams output via SSE.
 func (s *Sandbox) ExecuteCode(ctx context.Context, req RunCodeRequest, handlers *ExecutionHandlers) (*Execution, error) {
 	if s.execd == nil {

--- a/sdks/sandbox/go/types.go
+++ b/sdks/sandbox/go/types.go
@@ -17,8 +17,10 @@
 package opensandbox
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -528,6 +530,204 @@ type CommandStatusResponse struct {
 	Error      string     `json:"error,omitempty"`
 	StartedAt  time.Time  `json:"started_at"`
 	FinishedAt *time.Time `json:"finished_at,omitempty"`
+}
+
+// ListCommandsRequest selects a page of command inventory summaries. Running
+// is a pointer so callers can distinguish no filter from an explicit false
+// filter. Cursor is an opaque value supplied by the previous response.
+type ListCommandsRequest struct {
+	Running *bool
+	Limit   int
+	Cursor  string
+}
+
+// ListCommandsResponse is a page of command inventory summaries.
+type ListCommandsResponse struct {
+	Commands   []CommandSummary           `json:"commands"`
+	Pagination CommandInventoryPagination `json:"pagination"`
+}
+
+// CommandInventoryPagination describes traversal of command inventory pages.
+type CommandInventoryPagination struct {
+	Limit      int     `json:"limit"`
+	NextCursor *string `json:"nextCursor,omitempty"`
+}
+
+// CommandSummary describes either a running or terminal command. Terminal
+// summaries always include FinishedAt and ExitCode in their JSON representation;
+// nil values represent explicit JSON null values.
+type CommandSummary struct {
+	Session    string
+	Running    bool
+	Background bool
+	StartedAt  time.Time
+	FinishedAt *time.Time
+	ExitCode   *int32
+	Error      string
+}
+
+// UnmarshalJSON decodes the command-summary discriminated union strictly. A
+// running command cannot contain terminal fields; terminal commands must
+// contain them, including when their values are JSON null.
+func (c *CommandSummary) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return fmt.Errorf("opensandbox: decode command summary: %w", err)
+	}
+	if fields == nil {
+		return fmt.Errorf("opensandbox: decode command summary: expected object")
+	}
+
+	runningRaw, ok := fields["running"]
+	if !ok {
+		return fmt.Errorf("opensandbox: decode command summary: missing running")
+	}
+	if isJSONNull(runningRaw) {
+		return fmt.Errorf("opensandbox: decode command summary: running must not be null")
+	}
+	var running bool
+	if err := json.Unmarshal(runningRaw, &running); err != nil {
+		return fmt.Errorf("opensandbox: decode command summary running: %w", err)
+	}
+
+	allowed := map[string]bool{
+		"session": true, "running": true, "background": true, "started_at": true,
+	}
+	if running {
+		for name := range fields {
+			if !allowed[name] {
+				return fmt.Errorf("opensandbox: decode running command summary: unexpected %s", name)
+			}
+		}
+	} else {
+		allowed["finished_at"] = true
+		allowed["exit_code"] = true
+		allowed["error"] = true
+		for name := range fields {
+			if !allowed[name] {
+				return fmt.Errorf("opensandbox: decode terminal command summary: unexpected %s", name)
+			}
+		}
+		if _, ok := fields["finished_at"]; !ok {
+			return fmt.Errorf("opensandbox: decode terminal command summary: missing finished_at")
+		}
+		if _, ok := fields["exit_code"]; !ok {
+			return fmt.Errorf("opensandbox: decode terminal command summary: missing exit_code")
+		}
+	}
+
+	for _, name := range []string{"session", "background", "started_at"} {
+		raw, ok := fields[name]
+		if !ok {
+			return fmt.Errorf("opensandbox: decode command summary: missing %s", name)
+		}
+		if isJSONNull(raw) {
+			return fmt.Errorf("opensandbox: decode command summary: %s must not be null", name)
+		}
+	}
+	if !running {
+		if isJSONNull(fields["finished_at"]) {
+			return fmt.Errorf("opensandbox: decode terminal command summary: finished_at must not be null")
+		}
+		if errorRaw, ok := fields["error"]; ok && isJSONNull(errorRaw) {
+			return fmt.Errorf("opensandbox: decode terminal command summary: error must not be null")
+		}
+	}
+
+	var decoded struct {
+		Session    string     `json:"session"`
+		Running    bool       `json:"running"`
+		Background bool       `json:"background"`
+		StartedAt  time.Time  `json:"started_at"`
+		FinishedAt *time.Time `json:"finished_at"`
+		ExitCode   *int32     `json:"exit_code"`
+		Error      string     `json:"error"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return fmt.Errorf("opensandbox: decode command summary: %w", err)
+	}
+	*c = CommandSummary(decoded)
+	return nil
+}
+
+// MarshalJSON preserves the command-summary union contract. In particular,
+// terminal fields remain present when their values are nil.
+func (c CommandSummary) MarshalJSON() ([]byte, error) {
+	if c.Running {
+		return json.Marshal(struct {
+			Session    string    `json:"session"`
+			Running    bool      `json:"running"`
+			Background bool      `json:"background"`
+			StartedAt  time.Time `json:"started_at"`
+		}{c.Session, c.Running, c.Background, c.StartedAt})
+	}
+	if c.FinishedAt == nil {
+		return nil, fmt.Errorf("opensandbox: marshal terminal command summary: finished_at is required")
+	}
+	return json.Marshal(struct {
+		Session    string     `json:"session"`
+		Running    bool       `json:"running"`
+		Background bool       `json:"background"`
+		StartedAt  time.Time  `json:"started_at"`
+		FinishedAt *time.Time `json:"finished_at"`
+		ExitCode   *int32     `json:"exit_code"`
+		Error      string     `json:"error,omitempty"`
+	}{c.Session, c.Running, c.Background, c.StartedAt, c.FinishedAt, c.ExitCode, c.Error})
+}
+
+// UnmarshalJSON decodes known command inventory fields strictly while ignoring
+// top-level and pagination extensions for forward compatibility.
+func (r *ListCommandsResponse) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return fmt.Errorf("opensandbox: decode command inventory: %w", err)
+	}
+	commandsRaw, ok := fields["commands"]
+	if !ok {
+		return fmt.Errorf("opensandbox: decode command inventory: missing commands")
+	}
+	paginationRaw, ok := fields["pagination"]
+	if !ok {
+		return fmt.Errorf("opensandbox: decode command inventory: missing pagination")
+	}
+	if isJSONNull(commandsRaw) || isJSONNull(paginationRaw) {
+		return fmt.Errorf("opensandbox: decode command inventory: commands and pagination must not be null")
+	}
+	var commands []CommandSummary
+	if err := json.Unmarshal(commandsRaw, &commands); err != nil {
+		return fmt.Errorf("opensandbox: decode command inventory commands: %w", err)
+	}
+	var paginationFields map[string]json.RawMessage
+	if err := json.Unmarshal(paginationRaw, &paginationFields); err != nil {
+		return fmt.Errorf("opensandbox: decode command inventory pagination: %w", err)
+	}
+	limitRaw, ok := paginationFields["limit"]
+	if !ok {
+		return fmt.Errorf("opensandbox: decode command inventory pagination: missing limit")
+	}
+	if isJSONNull(limitRaw) {
+		return fmt.Errorf("opensandbox: decode command inventory pagination: limit must not be null")
+	}
+	if nextCursorRaw, ok := paginationFields["nextCursor"]; ok && isJSONNull(nextCursorRaw) {
+		return fmt.Errorf("opensandbox: decode command inventory pagination: nextCursor must not be null")
+	}
+	var pagination CommandInventoryPagination
+	if err := json.Unmarshal(paginationRaw, &pagination); err != nil {
+		return fmt.Errorf("opensandbox: decode command inventory pagination: %w", err)
+	}
+	if pagination.Limit < 1 || pagination.Limit > 100 {
+		return fmt.Errorf("opensandbox: decode command inventory pagination: limit must be between 1 and 100")
+	}
+	if pagination.NextCursor != nil && strings.TrimSpace(*pagination.NextCursor) == "" {
+		return fmt.Errorf("opensandbox: decode command inventory pagination: nextCursor must not be blank")
+	}
+	r.Commands = commands
+	r.Pagination = pagination
+	return nil
+}
+
+func isJSONNull(data json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(data), []byte("null"))
 }
 
 // CommandLogsResponse contains the stdout/stderr output and cursor for

--- a/sdks/sandbox/javascript/package.json
+++ b/sdks/sandbox/javascript/package.json
@@ -43,7 +43,7 @@
     "build": "pnpm run gen:api && tsup",
     "test": "pnpm run build && node --test tests/*.test.mjs",
     "lint": "eslint src scripts --max-warnings 0",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/sdks/sandbox/javascript/src/adapters/commandsAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/commandsAdapter.ts
@@ -19,6 +19,9 @@ import type { paths as ExecdPaths } from "../api/execd.js";
 import type {
   CommandExecution,
   CommandLogs,
+  CommandSummary,
+  ListCommandsOptions,
+  ListCommandsPage,
   CommandStatus,
   RunCommandOpts,
   ServerStreamEvent,
@@ -109,6 +112,42 @@ function assertNonBlank(value: string, field: string): void {
   }
 }
 
+const runningFields = new Set(["session", "running", "background", "started_at"]);
+const terminalFields = new Set([
+  "session",
+  "running",
+  "background",
+  "started_at",
+  "finished_at",
+  "exit_code",
+  "error",
+]);
+const rfc3339Pattern =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-](\d{2}):(\d{2}))$/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireExactKeys(item: Record<string, unknown>, allowed: Set<string>, branch: string): void {
+  for (const key of Object.keys(item)) {
+    if (!allowed.has(key)) throw new Error(`${branch} command has unknown field: ${key}`);
+  }
+}
+
+function requireInt32OrNull(value: unknown, field: string): number | null {
+  if (value === null) return null;
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < -2147483648 ||
+    value > 2147483647
+  ) {
+    throw new Error(`Invalid ${field}`);
+  }
+  return value;
+}
+
 function parseOptionalDate(value: unknown, field: string): Date | undefined {
   if (value == null) return undefined;
   if (value instanceof Date) return value;
@@ -120,6 +159,141 @@ function parseOptionalDate(value: unknown, field: string): Date | undefined {
     throw new Error(`Invalid ${field}: ${value}`);
   }
   return parsed;
+}
+
+function parseRequiredRfc3339Date(value: unknown, field: string): Date {
+  if (value == null) throw new Error(`Missing ${field}`);
+  return parseRfc3339Date(value, field);
+}
+
+function daysInMonth(year: number, month: number): number {
+  if (month === 2) {
+    return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 29 : 28;
+  }
+  return [4, 6, 9, 11].includes(month) ? 30 : 31;
+}
+
+function parseRfc3339Date(value: unknown, field: string): Date {
+  if (typeof value !== "string") throw new Error(`Invalid ${field}`);
+  const match = rfc3339Pattern.exec(value);
+  if (!match) throw new Error(`Invalid ${field}: ${value}`);
+
+  const [, year, month, day, hour, minute, second, fraction, timezone, offsetHour, offsetMinute] = match;
+  const numericYear = Number(year);
+  const numericMonth = Number(month);
+  const numericDay = Number(day);
+  const numericHour = Number(hour);
+  const numericMinute = Number(minute);
+  const numericSecond = Number(second);
+  const numericOffsetHour = offsetHour == null ? 0 : Number(offsetHour);
+  const numericOffsetMinute = offsetMinute == null ? 0 : Number(offsetMinute);
+  if (
+    numericMonth < 1 ||
+    numericMonth > 12 ||
+    numericDay < 1 ||
+    numericDay > daysInMonth(numericYear, numericMonth) ||
+    numericHour > 23 ||
+    numericMinute > 59 ||
+    numericSecond > 59 ||
+    numericOffsetHour > 23 ||
+    numericOffsetMinute > 59
+  ) {
+    throw new Error(`Invalid ${field}: ${value}`);
+  }
+
+  const milliseconds = fraction == null ? 0 : Number(`${fraction.slice(0, 3).padEnd(3, "0")}`);
+  const offset =
+    timezone.toUpperCase() === "Z"
+      ? 0
+      : (numericOffsetHour * 60 + numericOffsetMinute) * (timezone.startsWith("+") ? 1 : -1);
+  const parsed = new Date(0);
+  parsed.setUTCFullYear(numericYear, numericMonth - 1, numericDay);
+  parsed.setUTCHours(numericHour, numericMinute, numericSecond, milliseconds);
+  parsed.setTime(parsed.getTime() - offset * 60_000);
+  if (Number.isNaN(parsed.getTime())) throw new Error(`Invalid ${field}: ${value}`);
+  return parsed;
+}
+
+function requireString(item: Record<string, unknown>, field: string): string {
+  if (!Object.hasOwn(item, field) || typeof item[field] !== "string") {
+    throw new Error(`Invalid ${field}`);
+  }
+  return item[field];
+}
+
+function toCommandSummary(value: unknown): CommandSummary {
+  if (!isRecord(value)) throw new Error("Invalid command summary");
+  if (!Object.hasOwn(value, "running") || typeof value.running !== "boolean") {
+    throw new Error("Invalid command summary");
+  }
+
+  const branch = value.running ? "running" : "terminal";
+  requireExactKeys(value, value.running ? runningFields : terminalFields, branch);
+  const base = {
+    session: requireString(value, "session"),
+    background: (() => {
+      if (!Object.hasOwn(value, "background") || typeof value.background !== "boolean") {
+        throw new Error("Invalid background");
+      }
+      return value.background;
+    })(),
+    startedAt: (() => {
+      if (!Object.hasOwn(value, "started_at")) throw new Error("Missing started_at");
+      return parseRequiredRfc3339Date(value.started_at, "started_at");
+    })(),
+  };
+
+  if (value.running) return { ...base, running: true };
+  if (!Object.hasOwn(value, "finished_at") || !Object.hasOwn(value, "exit_code")) {
+    throw new Error("Invalid terminal command summary");
+  }
+  const error = value.error;
+  if (Object.hasOwn(value, "error") && typeof error !== "string") {
+    throw new Error("Invalid error");
+  }
+  return {
+    ...base,
+    running: false,
+    finishedAt: parseRequiredRfc3339Date(value.finished_at, "finished_at"),
+    exitCode: requireInt32OrNull(value.exit_code, "exit_code"),
+    ...(typeof error === "string" ? { error } : {}),
+  };
+}
+
+function parseListCommandsPage(value: unknown): ListCommandsPage {
+  if (
+    !isRecord(value) ||
+    !Object.hasOwn(value, "commands") ||
+    !Array.isArray(value.commands) ||
+    !Object.hasOwn(value, "pagination") ||
+    !isRecord(value.pagination)
+  ) {
+    throw new Error("List commands failed: unexpected response shape");
+  }
+  const { pagination } = value;
+  if (
+    !Object.hasOwn(pagination, "limit") ||
+    typeof pagination.limit !== "number" ||
+    !Number.isInteger(pagination.limit) ||
+    pagination.limit < 1 ||
+    pagination.limit > 100
+  ) {
+    throw new Error("Invalid pagination limit");
+  }
+  const nextCursor = pagination.nextCursor;
+  if (Object.hasOwn(pagination, "nextCursor") && typeof nextCursor !== "string") {
+    throw new Error("Invalid nextCursor");
+  }
+  if (typeof nextCursor === "string" && nextCursor.trim() === "") {
+    throw new Error("Invalid nextCursor");
+  }
+  return {
+    commands: value.commands.map(toCommandSummary),
+    pagination: {
+      limit: pagination.limit,
+      ...(typeof nextCursor === "string" ? { nextCursor } : {}),
+    },
+  };
 }
 
 export interface CommandsAdapterOptions {
@@ -263,6 +437,20 @@ export class CommandsAdapter implements ExecdCommands {
       content,
       cursor: Number.isFinite(parsedCursor ?? NaN) ? parsedCursor : undefined,
     };
+  }
+
+  async listCommands(options?: ListCommandsOptions): Promise<ListCommandsPage> {
+    const query: Record<string, boolean | number | string> = {};
+    if (options?.running != null) query.running = options.running;
+    if (options?.limit != null) query.limit = options.limit;
+    if (options?.cursor != null && options.cursor.trim() !== "") {
+      query.cursor = options.cursor;
+    }
+    const { data, error, response } = await this.client.GET("/command", {
+      params: { query },
+    });
+    throwOnOpenApiFetchError({ error, response }, "List commands failed");
+    return parseListCommandsPage(data);
   }
 
   async *runStream(

--- a/sdks/sandbox/javascript/src/api/execd.ts
+++ b/sdks/sandbox/javascript/src/api/execd.ts
@@ -222,7 +222,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * List command inventory
+         * @description Lists command inventory entries. Omitting `running` returns both running and
+         *     terminal commands; `running=true` returns only running commands; and
+         *     `running=false` returns only terminal commands. `limit` defaults to 50 and
+         *     the opaque `cursor` resumes a later page without client-side interpretation.
+         *     A cursor is bound to the exact `running` filter from its first request;
+         *     subsequent requests must preserve that filter or receive `INVALID_QUERY`.
+         *
+         *     The returned `session` is the same command identity exposed as `id` by the
+         *     legacy `GET /command/status/{id}` endpoint. Results are weakly consistent
+         *     and are not a snapshot: commands may transition or disappear between pages.
+         *     Responses must not be cached.
+         */
+        get: operations["listCommands"];
         put?: never;
         /**
          * Execute shell command
@@ -1034,6 +1048,42 @@ export interface components {
              */
             finished_at?: string | null;
         };
+        /** @description A command that is still running. Terminal fields are omitted. */
+        RunningCommandSummary: {
+            /** @description Command identity; equal to the legacy command status `id`. */
+            session: string;
+            /** @constant */
+            running: true;
+            background: boolean;
+            /** Format: date-time */
+            started_at: string;
+        };
+        /** @description A command that has finished. `exit_code` is present and may be null. */
+        TerminalCommandSummary: {
+            /** @description Command identity; equal to the legacy command status `id`. */
+            session: string;
+            /** @constant */
+            running: false;
+            background: boolean;
+            /** Format: date-time */
+            started_at: string;
+            /** Format: date-time */
+            finished_at: string;
+            /** Format: int32 */
+            exit_code: number | null;
+            error?: string;
+        };
+        /** @description A running or terminal command inventory summary. */
+        CommandSummary: components["schemas"]["RunningCommandSummary"] | components["schemas"]["TerminalCommandSummary"];
+        CommandPagination: {
+            limit: number;
+            /** @description Opaque nonblank cursor for the next page; omitted on the final page. */
+            nextCursor?: string;
+        };
+        ListCommandsResponse: {
+            commands: components["schemas"]["CommandSummary"][];
+            pagination: components["schemas"]["CommandPagination"];
+        };
         /** @description Server-sent event for streaming execution output */
         ServerStreamEvent: {
             /**
@@ -1724,6 +1774,51 @@ export interface operations {
             };
             400: components["responses"]["BadRequest"];
             404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    listCommands: {
+        parameters: {
+            query?: {
+                /** @description Omit for all commands; true for running commands; false for terminal commands. */
+                running?: boolean;
+                /** @description Maximum number of commands to return. */
+                limit?: number;
+                /** @description Opaque nonblank pagination cursor returned by a previous response. It is bound to the exact `running` filter from the first request; preserve that filter or receive `INVALID_QUERY`. Omit to select the first page. */
+                cursor?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A weakly consistent page of command summaries. */
+            200: {
+                headers: {
+                    /** @description Always `no-store` because command inventory is not cacheable. */
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListCommandsResponse"];
+                };
+            };
+            /** @description Invalid command inventory query. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "code": "INVALID_QUERY",
+                     *       "message": "invalid cursor"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
             500: components["responses"]["InternalServerError"];
         };
     };

--- a/sdks/sandbox/javascript/src/index.ts
+++ b/sdks/sandbox/javascript/src/index.ts
@@ -98,13 +98,19 @@ export type {
 export type {
   CommandExecution,
   CommandLogs,
+  CommandPagination,
+  CommandSummary,
   CommandStatus,
+  ListCommandsOptions,
+  ListCommandsPage,
+  RunningCommandSummary,
   RunCommandOpts,
   ServerStreamEvent,
   CodeContextRequest,
   SupportedLanguage,
   Metrics,
   SandboxMetrics,
+  TerminalCommandSummary,
   PingResponse,
 } from "./models/execd.js";
 export type { ExecdCommands } from "./services/execdCommands.js";

--- a/sdks/sandbox/javascript/src/models/execd.ts
+++ b/sdks/sandbox/javascript/src/models/execd.ts
@@ -92,6 +92,41 @@ export interface CommandLogs {
   cursor?: number;
 }
 
+export interface ListCommandsOptions {
+  running?: boolean;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface RunningCommandSummary {
+  session: string;
+  running: true;
+  background: boolean;
+  startedAt: Date;
+}
+
+export interface TerminalCommandSummary {
+  session: string;
+  running: false;
+  background: boolean;
+  startedAt: Date;
+  finishedAt: Date;
+  exitCode: number | null;
+  error?: string;
+}
+
+export type CommandSummary = RunningCommandSummary | TerminalCommandSummary;
+
+export interface CommandPagination {
+  limit: number;
+  nextCursor?: string;
+}
+
+export interface ListCommandsPage {
+  commands: CommandSummary[];
+  pagination: CommandPagination;
+}
+
 export type CommandExecution = Execution;
 
 export interface Metrics extends Record<string, unknown> {

--- a/sdks/sandbox/javascript/src/services/execdCommands.ts
+++ b/sdks/sandbox/javascript/src/services/execdCommands.ts
@@ -16,6 +16,8 @@ import type { ExecutionHandlers } from "../models/execution.js";
 import type {
   CommandExecution,
   CommandLogs,
+  ListCommandsOptions,
+  ListCommandsPage,
   CommandStatus,
   RunCommandOpts,
   ServerStreamEvent,
@@ -48,6 +50,9 @@ export interface ExecdCommands {
    * Get background command logs (non-streamed).
    */
   getBackgroundCommandLogs(commandId: string, cursor?: number): Promise<CommandLogs>;
+
+  /** List a weakly consistent page of running and terminal command summaries. */
+  listCommands?(options?: ListCommandsOptions): Promise<ListCommandsPage>;
 
   /**
    * Create a bash session with optional working directory.

--- a/sdks/sandbox/javascript/tests/commands.list.test.mjs
+++ b/sdks/sandbox/javascript/tests/commands.list.test.mjs
@@ -1,0 +1,250 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CommandsAdapter } from "../dist/internal.js";
+
+function createAdapter(data) {
+  return new CommandsAdapter(
+    { GET: async () => ({ data, response: new Response(null, { status: 200 }) }) },
+    { baseUrl: "http://127.0.0.1:8080" },
+  );
+}
+
+function runningSummary(overrides = {}) {
+  return {
+    session: "running-session",
+    running: true,
+    background: true,
+    started_at: "2026-07-22T01:02:03Z",
+    ...overrides,
+  };
+}
+
+function terminalSummary(overrides = {}) {
+  return {
+    session: "terminal-session",
+    running: false,
+    background: false,
+    started_at: "2026-07-22T01:01:03Z",
+    finished_at: "2026-07-22T01:01:04Z",
+    exit_code: 0,
+    ...overrides,
+  };
+}
+
+function page(commands, pagination = { limit: 1 }) {
+  return { commands, pagination };
+}
+
+test("CommandsAdapter.listCommands normalizes blank query cursors and maps mixed summaries", async () => {
+  let request;
+  const client = {
+    GET: async (path, options) => {
+      request = { path, options };
+      return {
+        data: {
+          commands: [
+            {
+              session: "running-session",
+              running: true,
+              background: true,
+              started_at: "2026-07-22T01:02:03Z",
+            },
+            {
+              session: "terminal-session",
+              running: false,
+              background: false,
+              started_at: "2026-07-22T01:01:03Z",
+              finished_at: "2026-07-22T01:01:04Z",
+              exit_code: null,
+              error: "killed",
+            },
+          ],
+          pagination: { limit: 2, nextCursor: "x" },
+        },
+        response: new Response(null, { status: 200 }),
+      };
+    },
+  };
+  const adapter = new CommandsAdapter(client, { baseUrl: "http://127.0.0.1:8080" });
+
+  let page;
+  for (const cursor of ["", " \t "]) {
+    page = await adapter.listCommands({ running: false, limit: 2, cursor });
+    assert.deepEqual(request, {
+      path: "/command",
+      options: { params: { query: { running: false, limit: 2 } } },
+    });
+  }
+
+  assert.equal(page.commands[0].running, true);
+  assert.equal(page.commands[1].running, false);
+  assert.equal(page.commands[1].exitCode, null);
+  assert.equal(page.pagination.nextCursor, "x");
+});
+
+test("CommandsAdapter.listCommands preserves a nonblank opaque query cursor", async () => {
+  const cursor = "  opaque +/=  ";
+  let request;
+  const client = {
+    GET: async (path, options) => {
+      request = { path, options };
+      return {
+        data: { commands: [], pagination: { limit: 1, nextCursor: cursor } },
+        response: new Response(null, { status: 200 }),
+      };
+    },
+  };
+  const adapter = new CommandsAdapter(client, { baseUrl: "http://127.0.0.1:8080" });
+
+  const page = await adapter.listCommands({ cursor });
+
+  assert.equal(request.options.params.query.cursor, cursor);
+  assert.equal(page.pagination.nextCursor, cursor);
+});
+
+test("CommandsAdapter.listCommands omits absent query values and final nextCursor", async () => {
+  let request;
+  const client = {
+    GET: async (path, options) => {
+      request = { path, options };
+      return {
+        data: { commands: [], pagination: { limit: 50 } },
+        response: new Response(null, { status: 200 }),
+      };
+    },
+  };
+  const adapter = new CommandsAdapter(client, { baseUrl: "http://127.0.0.1:8080" });
+
+  const page = await adapter.listCommands();
+
+  assert.deepEqual(request, { path: "/command", options: { params: { query: {} } } });
+  assert.equal(page.pagination.nextCursor, undefined);
+});
+
+test("CommandsAdapter.listCommands rejects blank nextCursor values", async () => {
+  for (const nextCursor of ["", " \t "]) {
+    await assert.rejects(
+      createAdapter(page([], { limit: 50, nextCursor })).listCommands(),
+      /Invalid nextCursor/,
+    );
+  }
+});
+
+test("CommandsAdapter.listCommands rejects a terminal summary without exit_code", async () => {
+  const client = {
+    GET: async () => ({
+      data: {
+        commands: [
+          {
+            session: "terminal-session",
+            running: false,
+            background: false,
+            started_at: "2026-07-22T01:01:03Z",
+            finished_at: "2026-07-22T01:01:04Z",
+          },
+        ],
+        pagination: { limit: 1 },
+      },
+      response: new Response(null, { status: 200 }),
+    }),
+  };
+  const adapter = new CommandsAdapter(client, { baseUrl: "http://127.0.0.1:8080" });
+
+  await assert.rejects(adapter.listCommands(), /Invalid terminal command summary/);
+});
+
+test("CommandsAdapter.listCommands strictly validates command summary branches", async () => {
+  const invalidSummaries = [
+    runningSummary({ running: "true" }),
+    runningSummary({ finished_at: "2026-07-22T01:02:04Z" }),
+    runningSummary({ unexpected: true }),
+    terminalSummary({ error: null }),
+    terminalSummary({ exit_code: undefined }),
+    terminalSummary({ exit_code: "0" }),
+    terminalSummary({ exit_code: 0.5 }),
+    terminalSummary({ exit_code: 2147483648 }),
+    terminalSummary({ started_at: "2026-07-22" }),
+    terminalSummary({ finished_at: "2026-07-22T01:01:04+01:99" }),
+  ];
+
+  for (const summary of invalidSummaries) {
+    await assert.rejects(createAdapter(page([summary])).listCommands());
+  }
+});
+
+test("CommandsAdapter.listCommands accepts RFC3339 offsets and nullable int32 exit codes", async () => {
+  const result = await createAdapter(
+    page([
+      terminalSummary({
+        started_at: "2026-07-22T01:01:03.123456+05:30",
+        finished_at: "2016-12-31t23:59:59z",
+        exit_code: null,
+      }),
+    ]),
+  ).listCommands();
+
+  assert.equal(result.commands[0].exitCode, null);
+  assert.equal(result.commands[0].startedAt.toISOString(), "2026-07-21T19:31:03.123Z");
+  assert.equal(result.commands[0].finishedAt.toISOString(), "2016-12-31T23:59:59.000Z");
+});
+
+test("CommandsAdapter.listCommands preserves RFC3339 years before 0100", async () => {
+  const result = await createAdapter(
+    page([
+      runningSummary({ started_at: "0001-01-01T00:00:00Z" }),
+      terminalSummary({
+        started_at: "0000-02-29T00:00:00Z",
+        finished_at: "0000-02-29T00:00:01Z",
+      }),
+    ], { limit: 2 }),
+  ).listCommands();
+
+  assert.equal(result.commands[0].startedAt.getUTCFullYear(), 1);
+  assert.equal(result.commands[1].startedAt.getUTCFullYear(), 0);
+  assert.equal(result.commands[1].startedAt.getUTCMonth(), 1);
+  assert.equal(result.commands[1].startedAt.getUTCDate(), 29);
+});
+
+test("CommandsAdapter.listCommands rejects leap-second timestamps", async () => {
+  await assert.rejects(
+    createAdapter(page([runningSummary({ started_at: "2016-12-31T23:59:60Z" })])).listCommands(),
+    /Invalid started_at/,
+  );
+});
+
+test("CommandsAdapter.listCommands strictly validates pages while allowing extensions", async () => {
+  const invalidPages = [
+    { commands: [], pagination: { limit: true } },
+    { commands: [], pagination: { limit: 0 } },
+    { commands: [], pagination: { limit: 101 } },
+    { commands: [], pagination: { limit: 1, nextCursor: null } },
+    { commands: [], pagination: { limit: 1, nextCursor: undefined } },
+    { commands: [], pagination: { limit: 1, nextCursor: 1 } },
+  ];
+
+  for (const invalidPage of invalidPages) {
+    await assert.rejects(createAdapter(invalidPage).listCommands());
+  }
+
+  const result = await createAdapter({
+    commands: [],
+    pagination: { limit: 1, page_extension: true },
+    top_level_extension: true,
+  }).listCommands();
+  assert.equal(result.pagination.limit, 1);
+});

--- a/sdks/sandbox/javascript/tests/types/execd-command-inventory.typecheck.ts
+++ b/sdks/sandbox/javascript/tests/types/execd-command-inventory.typecheck.ts
@@ -1,0 +1,44 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { components } from "../../src/api/execd.js";
+import type { ExecdCommands } from "../../src/services/execdCommands.js";
+
+type CommandSummary = components["schemas"]["CommandSummary"];
+
+declare const summary: CommandSummary;
+
+const legacyCommands: ExecdCommands = {
+  runStream: async function* () {},
+  run: async () => ({ logs: { stdout: [], stderr: [] }, result: [] }),
+  interrupt: async () => {},
+  getCommandStatus: async () => ({ id: "id", content: "", running: false }),
+  getBackgroundCommandLogs: async () => ({ content: "" }),
+  createSession: async () => "session",
+  runInSession: async () => ({ logs: { stdout: [], stderr: [] }, result: [] }),
+  deleteSession: async () => {},
+};
+void legacyCommands;
+
+if (summary.running) {
+  const running: true = summary.running;
+  void running;
+} else {
+  const running: false = summary.running;
+  const finishedAt: string = summary.finished_at;
+  const exitCode: number | null = summary.exit_code;
+  void running;
+  void finishedAt;
+  void exitCode;
+}

--- a/sdks/sandbox/javascript/tsconfig.typecheck.json
+++ b/sdks/sandbox/javascript/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "tests/types/**/*.ts"
+  ]
+}

--- a/sdks/sandbox/kotlin/sandbox-api/build.gradle.kts
+++ b/sdks/sandbox/kotlin/sandbox-api/build.gradle.kts
@@ -99,6 +99,15 @@ val generateExecdApi =
     tasks.register<GenerateTask>("generateExecdApi") {
         configureCommonOptions()
 
+        schemaMappings.putAll(
+            mapOf(
+                "CommandSummary" to "JsonObject",
+                "RunningCommandSummary" to "JsonObject",
+                "TerminalCommandSummary" to "JsonObject",
+            ),
+        )
+        importMappings.put("JsonObject", "kotlinx.serialization.json.JsonObject")
+
         inputSpec.set(rootProject.projectDir.parentFile.parentFile.parentFile.resolve("specs/execd-api.yaml").absolutePath)
         outputDir.set(layout.buildDirectory.dir("generated/api/execd").get().asFile.absolutePath)
         packageName.set("com.alibaba.opensandbox.sandbox.api.execd")

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/CommandModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/CommandModels.kt
@@ -49,3 +49,44 @@ class CommandLogs(
     val content: String,
     val cursor: Long?,
 )
+
+/** A command inventory entry. */
+sealed interface CommandSummary {
+    val session: String
+    val running: Boolean
+    val background: Boolean
+    val startedAt: OffsetDateTime
+}
+
+/** A command which has not reached a terminal state. */
+data class RunningCommandSummary(
+    override val session: String,
+    override val background: Boolean,
+    override val startedAt: OffsetDateTime,
+) : CommandSummary {
+    override val running: Boolean = true
+}
+
+/** A command which has reached a terminal state. */
+data class TerminalCommandSummary(
+    override val session: String,
+    override val background: Boolean,
+    override val startedAt: OffsetDateTime,
+    val finishedAt: OffsetDateTime,
+    val exitCode: Int?,
+    val error: String?,
+) : CommandSummary {
+    override val running: Boolean = false
+}
+
+/** Cursor metadata for a command inventory page. */
+data class CommandPagination(
+    val limit: Int,
+    val nextCursor: String?,
+)
+
+/** A weakly consistent page of command inventory entries. */
+data class ListCommandsPage(
+    val commands: List<CommandSummary>,
+    val pagination: CommandPagination,
+)

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Commands.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Commands.kt
@@ -19,6 +19,7 @@ package com.alibaba.opensandbox.sandbox.domain.services
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandLogs
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandStatus
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.Execution
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.ListCommandsPage
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunCommandRequest
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunInSessionRequest
 import java.time.Duration
@@ -83,6 +84,13 @@ interface Commands {
         executionId: String,
         cursor: Long? = null,
     ): CommandLogs
+
+    /** Lists a weakly consistent page of running and terminal command summaries. */
+    fun listCommands(
+        running: Boolean? = null,
+        limit: Int = 50,
+        cursor: String? = null,
+    ): ListCommandsPage = throw UnsupportedOperationException("Command inventory is not supported")
 
     /**
      * Creates a new bash session with optional working directory.

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExecutionConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExecutionConverter.kt
@@ -16,9 +16,20 @@
 
 package com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter
 
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandPagination
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandStatus
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandSummary
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.ListCommandsPage
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunCommandRequest
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunningCommandSummary
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.TerminalCommandSummary
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import java.time.Duration
+import java.time.OffsetDateTime
 import com.alibaba.opensandbox.sandbox.api.models.execd.CommandStatusResponse as ApiCommandStatusResponse
 import com.alibaba.opensandbox.sandbox.api.models.execd.RunCommandRequest as ApiRunCommandRequest
 
@@ -46,7 +57,156 @@ object ExecutionConverter {
             finishedAt = finishedAt,
         )
     }
+
+    /** Converts a raw command summary while enforcing the inventory branch contract. */
+    fun JsonObject.toCommandSummary(): CommandSummary {
+        val running = requiredBoolean("running")
+        if (running) {
+            requireExactKeys(RUNNING_COMMAND_KEYS, "running command")
+            val session = requiredString("session")
+            val background = requiredBoolean("background")
+            val startedAt = requiredRfc3339("started_at")
+            return RunningCommandSummary(session, background, startedAt)
+        }
+        requireTerminalKeys()
+        val session = requiredString("session")
+        val background = requiredBoolean("background")
+        val startedAt = requiredRfc3339("started_at")
+        val finishedAt = requiredRfc3339("finished_at")
+        val exitCode = requiredNullableInt("exit_code")
+        return TerminalCommandSummary(
+            session,
+            background,
+            startedAt,
+            finishedAt,
+            exitCode,
+            optionalString("error"),
+        )
+    }
+
+    private fun JsonObject.requiredString(name: String): String =
+        get(name).requirePrimitive(name).let { primitive ->
+            require(primitive.isString) { "Command field $name must be a string" }
+            primitive.content
+        }
+
+    private fun JsonObject.requiredBoolean(name: String): Boolean =
+        get(name).requirePrimitive(name).let { primitive ->
+            require(!primitive.isString && (primitive.content == "true" || primitive.content == "false")) {
+                "Command field $name must be a boolean"
+            }
+            primitive.content.toBoolean()
+        }
+
+    private fun JsonObject.optionalString(name: String): String? {
+        if (name !in this) return null
+        return requiredString(name)
+    }
+
+    private fun JsonObject.requiredNullableInt(name: String): Int? {
+        val element = get(name) ?: throw IllegalArgumentException("Missing required command field: $name")
+        if (element is JsonNull) return null
+        val primitive = element.requirePrimitive(name)
+        require(!primitive.isString && INTEGER_LITERAL_PATTERN.matches(primitive.content)) {
+            "Command field $name must be an int32"
+        }
+        return primitive.content.toLongOrNull()
+            ?.takeIf { it in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong() }
+            ?.toInt()
+            ?: throw IllegalArgumentException("Command field $name must be an int32")
+    }
+
+    private fun JsonObject.requiredRfc3339(name: String): OffsetDateTime {
+        val value = requiredString(name)
+        require(RFC3339_PATTERN.matches(value)) { "Command field $name must be an RFC3339 timestamp" }
+        return try {
+            OffsetDateTime.parse(value)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Command field $name must be an RFC3339 timestamp", e)
+        }
+    }
+
+    private fun JsonObject.requireExactKeys(
+        allowedKeys: Set<String>,
+        branch: String,
+    ) {
+        require(keys == allowedKeys) { "$branch has invalid fields" }
+    }
+
+    private fun JsonObject.requireTerminalKeys() {
+        require(TERMINAL_REQUIRED_COMMAND_KEYS.all { it in this } && keys.all { it in TERMINAL_ALLOWED_COMMAND_KEYS }) {
+            "terminal command has invalid fields"
+        }
+    }
+
+    private fun kotlinx.serialization.json.JsonElement?.requirePrimitive(name: String): JsonPrimitive {
+        if (this == null) throw IllegalArgumentException("Missing required command field: $name")
+        if (this is JsonNull || this !is JsonPrimitive) {
+            throw IllegalArgumentException("Command field $name must be a primitive")
+        }
+        return this
+    }
+
+    private val RUNNING_COMMAND_KEYS = setOf("session", "running", "background", "started_at")
+    private val TERMINAL_REQUIRED_COMMAND_KEYS =
+        setOf("session", "running", "background", "started_at", "finished_at", "exit_code")
+    private val TERMINAL_ALLOWED_COMMAND_KEYS = TERMINAL_REQUIRED_COMMAND_KEYS + "error"
+    private val RFC3339_PATTERN =
+        Regex("[0-9]{4}-[0-9]{2}-[0-9]{2}[Tt][0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]+)?(?:[Zz]|[+-](?:[01][0-9]|2[0-3]):[0-5][0-9])")
 }
+
+internal fun parseListCommandsPage(payload: String): ListCommandsPage {
+    val page = parseCommandInventoryObject(commandInventoryJson.parseToJsonElement(payload), "response")
+    val commands =
+        page["commands"] as? JsonArray
+            ?: throw IllegalArgumentException("response.commands must be an array")
+    val pagination = parseCommandInventoryObject(page["pagination"], "pagination")
+    val limit = pagination["limit"].requireInventoryInt("pagination.limit")
+    require(limit in 1..100) { "pagination.limit must be between 1 and 100" }
+    val nextCursor =
+        if ("nextCursor" in pagination) {
+            pagination["nextCursor"].requireInventoryString("pagination.nextCursor")
+        } else {
+            null
+        }
+    require(nextCursor == null || nextCursor.isNotBlank()) {
+        "pagination.nextCursor must not be blank"
+    }
+    return ListCommandsPage(
+        commands = commands.map { ExecutionConverter.run { parseCommandInventoryObject(it, "command").toCommandSummary() } },
+        pagination = CommandPagination(limit, nextCursor),
+    )
+}
+
+private fun parseCommandInventoryObject(
+    element: kotlinx.serialization.json.JsonElement?,
+    name: String,
+): JsonObject = element as? JsonObject ?: throw IllegalArgumentException("$name must be an object")
+
+private fun kotlinx.serialization.json.JsonElement?.requireInventoryString(name: String): String {
+    val primitive =
+        this as? JsonPrimitive
+            ?: throw IllegalArgumentException("$name must be a string")
+    require(primitive.isString) { "$name must be a string" }
+    return primitive.content
+}
+
+private fun kotlinx.serialization.json.JsonElement?.requireInventoryInt(name: String): Int {
+    val primitive =
+        this as? JsonPrimitive
+            ?: throw IllegalArgumentException("$name must be an integer")
+    require(!primitive.isString && INTEGER_LITERAL_PATTERN.matches(primitive.content)) {
+        "$name must be an integer"
+    }
+    return primitive.content.toIntOrNull() ?: throw IllegalArgumentException("$name must be an integer")
+}
+
+private val commandInventoryJson =
+    Json {
+        isLenient = false
+    }
+
+private val INTEGER_LITERAL_PATTERN = Regex("-?(0|[1-9][0-9]*)")
 
 internal fun Duration.toCommandTimeoutMillis(): Long {
     require(!isNegative) { "Timeout must be non-negative, got: $this" }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapter.kt
@@ -33,6 +33,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandLog
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandStatus
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.Execution
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.ExecutionHandlers
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.ListCommandsPage
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunCommandRequest
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunInSessionRequest
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxEndpoint
@@ -41,6 +42,7 @@ import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.Executi
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.ExecutionConverter.toCommandStatus
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.ExecutionEventDispatcher
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.jsonParser
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseListCommandsPage
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseSandboxError
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toCommandTimeoutMillis
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
@@ -168,6 +170,48 @@ internal class CommandsAdapter(
             CommandLogs(content = content, cursor = nextCursor)
         } catch (e: Exception) {
             logger.error("Failed to get command logs", e)
+            throw e.toSandboxException()
+        }
+    }
+
+    override fun listCommands(
+        running: Boolean?,
+        limit: Int,
+        cursor: String?,
+    ): ListCommandsPage {
+        return try {
+            val urlBuilder =
+                execdBaseUrl
+                    .toHttpUrlOrNull()!!
+                    .newBuilder()
+                    .addPathSegment("command")
+            if (running != null) {
+                urlBuilder.addQueryParameter("running", running.toString())
+            }
+            urlBuilder.addQueryParameter("limit", limit.toString())
+            cursor?.takeIf { it.isNotBlank() }?.let {
+                urlBuilder.addQueryParameter("cursor", it)
+            }
+            val request =
+                Request.Builder()
+                    .url(urlBuilder.build())
+                    .get()
+                    .headers(execdEndpoint.headers.toHeaders())
+                    .build()
+            execdApiClient.newCall(request).execute().use { response ->
+                val responseBody = response.body?.string().orEmpty()
+                if (!response.isSuccessful) {
+                    throw SandboxApiException(
+                        message = "Failed to list commands. Status code: ${response.code}, Body: $responseBody",
+                        statusCode = response.code,
+                        error = parseSandboxError(responseBody) ?: SandboxError(UNEXPECTED_RESPONSE),
+                        requestId = response.header("X-Request-ID"),
+                    )
+                }
+                parseListCommandsPage(responseBody)
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to list commands", e)
             throw e.toSandboxException()
         }
     }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapterTest.kt
@@ -17,16 +17,26 @@
 package com.alibaba.opensandbox.sandbox.infrastructure.adapters.service
 
 import com.alibaba.opensandbox.sandbox.HttpClientProvider
+import com.alibaba.opensandbox.sandbox.api.models.execd.ListCommandsResponse
 import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
 import com.alibaba.opensandbox.sandbox.domain.exceptions.InvalidArgumentException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
 import com.alibaba.opensandbox.sandbox.domain.models.execd.SECURE_ACCESS_HEADER
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandLogs
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandStatus
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.Execution
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.ExecutionHandlers
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunCommandRequest
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunInSessionRequest
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunningCommandSummary
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.TerminalCommandSummary
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxEndpoint
+import com.alibaba.opensandbox.sandbox.domain.services.Commands
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.ExecutionConverter.toCommandSummary
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseListCommandsPage
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toCommandTimeoutMillis
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
@@ -49,6 +59,11 @@ class CommandsAdapterTest {
     private lateinit var mockWebServer: MockWebServer
     private lateinit var commandsAdapter: CommandsAdapter
     private lateinit var httpClientProvider: HttpClientProvider
+
+    @Suppress("UNUSED_PARAMETER", "UNUSED_VARIABLE")
+    private fun assertGeneratedListCommandsResponseUsesJsonObjects(response: ListCommandsResponse) {
+        val commands: List<JsonObject> = response.commands
+    }
 
     @BeforeEach
     fun setUp() {
@@ -74,6 +89,36 @@ class CommandsAdapterTest {
     fun tearDown() {
         mockWebServer.shutdown()
         httpClientProvider.close()
+    }
+
+    @Test
+    fun `legacy Commands implementations use the inventory default`() {
+        val legacy =
+            object : Commands {
+                override fun run(request: RunCommandRequest): Execution = unsupported()
+
+                override fun interrupt(executionId: String) = unsupported()
+
+                override fun getCommandStatus(executionId: String): CommandStatus = unsupported()
+
+                override fun getBackgroundCommandLogs(
+                    executionId: String,
+                    cursor: Long?,
+                ): CommandLogs = unsupported()
+
+                override fun createSession(workingDirectory: String?): String = unsupported()
+
+                override fun runInSession(
+                    sessionId: String,
+                    request: RunInSessionRequest,
+                ): Execution = unsupported()
+
+                override fun deleteSession(sessionId: String) = unsupported()
+            }
+
+        val exception = assertThrows<UnsupportedOperationException> { legacy.listCommands() }
+
+        assertEquals("Command inventory is not supported", exception.message)
     }
 
     @Test
@@ -422,4 +467,308 @@ data: {"type":"execution_complete","execution_time":100,"timestamp":167253120100
         val ex = assertThrows(InvalidArgumentException::class.java) { commandsAdapter.deleteSession(" ") }
         assertEquals("session_id cannot be empty", ex.message)
     }
+
+    @Test
+    fun `listCommands maps query and mixed command summaries`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    {
+                      "commands": [
+                        {
+                          "session": "running-session",
+                          "running": true,
+                          "background": true,
+                          "started_at": "2026-07-22T01:02:03Z"
+                        },
+                        {
+                          "session": "terminal-session",
+                          "running": false,
+                          "background": false,
+                          "started_at": "2026-07-22T01:01:03Z",
+                          "finished_at": "2026-07-22T01:01:04Z",
+                          "exit_code": null,
+                          "error": "killed"
+                        }
+                      ],
+                      "pagination": {"limit": 2, "nextCursor": "x"}
+                    }
+                    """.trimIndent(),
+                ),
+        )
+
+        val cursor = "  opaque +/=  "
+        val page = commandsAdapter.listCommands(running = false, limit = 2, cursor = cursor)
+
+        assertTrue(page.commands[0] is RunningCommandSummary)
+        assertTrue(page.commands[1] is TerminalCommandSummary)
+        assertEquals(null, (page.commands[1] as TerminalCommandSummary).exitCode)
+        assertEquals("x", page.pagination.nextCursor)
+        val recordedRequest = mockWebServer.takeRequest()
+        assertEquals(cursor, recordedRequest.requestUrl?.queryParameter("cursor"))
+    }
+
+    @Test
+    fun `listCommands normalizes empty and whitespace cursors to omission`() {
+        listOf("", " \t ").forEach {
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody("""{"commands":[],"pagination":{"limit":50}}"""),
+            )
+            commandsAdapter.listCommands(cursor = it)
+            assertEquals("/command?limit=50", mockWebServer.takeRequest().path)
+        }
+    }
+
+    @Test
+    fun `listCommands preserves boundary spaces in a nonblank next cursor`() {
+        val cursor = "  opaque +/=  "
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"commands":[],"pagination":{"limit":50,"nextCursor":"$cursor"}}"""),
+        )
+
+        val page = commandsAdapter.listCommands()
+
+        assertEquals(cursor, page.pagination.nextCursor)
+    }
+
+    @Test
+    fun `listCommands preserves omitted final cursor`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"commands":[],"pagination":{"limit":50}}"""),
+        )
+
+        val page = commandsAdapter.listCommands()
+
+        assertTrue(page.commands.isEmpty())
+        assertEquals(null, page.pagination.nextCursor)
+        assertEquals("/command?limit=50", mockWebServer.takeRequest().path)
+    }
+
+    @Test
+    fun `raw command inventory parser rejects blank next cursors`() {
+        listOf("", "   ").forEach { cursor ->
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    parseListCommandsPage(
+                        """{"commands":[],"pagination":{"limit":50,"nextCursor":"$cursor"}}""",
+                    )
+                }
+            assertEquals("pagination.nextCursor must not be blank", exception.message)
+        }
+    }
+
+    @Test
+    fun `listCommands accepts terminal success without error`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    {
+                      "commands": [
+                        {
+                          "session": "terminal-session",
+                          "running": false,
+                          "background": false,
+                          "started_at": "2026-07-22T01:01:03Z",
+                          "finished_at": "2026-07-22T01:01:04Z",
+                          "exit_code": 0
+                        }
+                      ],
+                      "pagination": {"limit": 50}
+                    }
+                    """.trimIndent(),
+                ),
+        )
+
+        val page = commandsAdapter.listCommands()
+
+        val command = page.commands.single() as TerminalCommandSummary
+        assertEquals(0, command.exitCode)
+        assertEquals(null, command.error)
+    }
+
+    @Test
+    fun `raw command inventory parser accepts envelope and pagination extensions`() {
+        val page =
+            parseListCommandsPage(
+                """{"commands":[],"pagination":{"limit":50,"future":"value"},"future":true}""",
+            )
+
+        assertTrue(page.commands.isEmpty())
+        assertEquals(50, page.pagination.limit)
+        assertEquals(null, page.pagination.nextCursor)
+    }
+
+    @Test
+    fun `listCommands sends endpoint headers through raw request`() {
+        val endpointProvider =
+            HttpClientProvider(
+                ConnectionConfig.builder()
+                    .domain("${mockWebServer.hostName}:${mockWebServer.port}")
+                    .protocol("http")
+                    .build(),
+            )
+        try {
+            val adapter =
+                CommandsAdapter(
+                    endpointProvider,
+                    SandboxEndpoint(
+                        "${mockWebServer.hostName}:${mockWebServer.port}",
+                        mapOf(
+                            SECURE_ACCESS_HEADER to "secure-token",
+                            "OpenSandbox-Ingress-To" to "sandbox-44772",
+                        ),
+                    ),
+                )
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody("""{"commands":[],"pagination":{"limit":50}}"""),
+            )
+
+            adapter.listCommands()
+
+            val request = mockWebServer.takeRequest()
+            assertEquals("/command?limit=50", request.path)
+            assertEquals("GET", request.method)
+            assertEquals("secure-token", request.getHeader(SECURE_ACCESS_HEADER))
+            assertEquals("sandbox-44772", request.getHeader("OpenSandbox-Ingress-To"))
+        } finally {
+            endpointProvider.close()
+        }
+    }
+
+    @Test
+    fun `terminal command summary rejects omitted exit code`() {
+        val summary =
+            Json.parseToJsonElement(
+                """
+                {
+                  "session": "terminal-session",
+                  "running": false,
+                  "background": false,
+                  "started_at": "2026-07-22T01:01:03Z",
+                  "finished_at": "2026-07-22T01:01:04Z"
+                }
+                """.trimIndent(),
+            ).jsonObject
+
+        assertThrows<IllegalArgumentException> { summary.toCommandSummary() }
+    }
+
+    @Test
+    fun `listCommands maps non-success responses to sandbox api exceptions`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .addHeader("X-Request-ID", "req-command-list")
+                .setBody("""{"code":"INVALID_QUERY","message":"invalid cursor"}"""),
+        )
+
+        val exception = assertThrows<SandboxApiException> { commandsAdapter.listCommands() }
+
+        assertEquals(400, exception.statusCode)
+        assertEquals("INVALID_QUERY", exception.error.code)
+        assertEquals("invalid cursor", exception.error.message)
+        assertEquals("req-command-list", exception.requestId)
+    }
+
+    @Test
+    fun `command summary converter accepts boolean running values`() {
+        val running =
+            Json.parseToJsonElement(
+                """
+                {
+                  "session": "running-session",
+                  "running": true,
+                  "background": true,
+                  "started_at": "2026-07-22T01:02:03Z"
+                }
+                """.trimIndent(),
+            ).jsonObject
+        val terminal =
+            Json.parseToJsonElement(
+                """
+                {
+                  "session": "terminal-session",
+                  "running": false,
+                  "background": false,
+                  "started_at": "2026-07-22T01:01:03Z",
+                  "finished_at": "2026-07-22T01:01:04Z",
+                  "exit_code": 0,
+                  "error": ""
+                }
+                """.trimIndent(),
+            ).jsonObject
+
+        assertTrue(running.toCommandSummary() is RunningCommandSummary)
+        assertTrue(terminal.toCommandSummary() is TerminalCommandSummary)
+    }
+
+    @Test
+    fun `raw command inventory parser rejects malformed contract values`() {
+        val running =
+            """
+            {
+              "session": "running-session",
+              "running": true,
+              "background": true,
+              "started_at": "2026-07-22T01:02:03Z"
+            }
+            """.trimIndent()
+        val terminal =
+            """
+            {
+              "session": "terminal-session",
+              "running": false,
+              "background": false,
+              "started_at": "2026-07-22T01:01:03Z",
+              "finished_at": "2026-07-22T01:01:04Z",
+              "exit_code":0,
+              "error": "failed"
+            }
+            """.trimIndent()
+        val cases =
+            listOf(
+                "quoted boolean" to running.replace("true", "\"true\""),
+                "unknown branch key" to running.dropLast(1) + ",\"unknown\":true}",
+                "terminal field on running" to running.dropLast(1) + ",\"exit_code\":0}",
+                "numeric session" to running.replace("\"running-session\"", "1"),
+                "numeric error" to terminal.replace("\"failed\"", "1"),
+                "null error" to terminal.replace("\"failed\"", "null"),
+                "missing exit code" to terminal.replace("\"exit_code\":0,", ""),
+                "quoted exit code" to terminal.replace("\"exit_code\":0", "\"exit_code\":\"0\""),
+                "fractional exit code" to terminal.replace("\"exit_code\":0", "\"exit_code\":0.5"),
+                "large exit code" to terminal.replace("\"exit_code\":0", "\"exit_code\":2147483648"),
+                "small exit code" to terminal.replace("\"exit_code\":0", "\"exit_code\":-2147483649"),
+                "invalid timestamp" to running.replace("2026-07-22", "2026-02-30"),
+                "invalid pagination limit" to """{"commands":[],"pagination":{"limit":101}}""",
+                "null next cursor" to """{"commands":[],"pagination":{"limit":50,"nextCursor":null}}""",
+                "numeric next cursor" to """{"commands":[],"pagination":{"limit":50,"nextCursor":1}}""",
+                "unquoted object keys" to """{commands:[],pagination:{limit:50}}""",
+                "array envelope" to "[]",
+                "array pagination" to """{"commands":[],"pagination":[]}""",
+            )
+
+        cases.forEach { (name, command) ->
+            val payload =
+                if (command.startsWith("{")) {
+                    if (command.contains("\"commands\"")) command else """{"commands":[$command],"pagination":{"limit":50}}"""
+                } else {
+                    command
+                }
+            assertThrows<IllegalArgumentException>(name) { parseListCommandsPage(payload) }
+        }
+    }
+
+    private fun unsupported(): Nothing = throw AssertionError("not invoked")
 }

--- a/sdks/sandbox/python/scripts/generate_api.py
+++ b/sdks/sandbox/python/scripts/generate_api.py
@@ -23,9 +23,12 @@ using openapi-python-client, which generates httpx-based async clients
 that support custom httpx.AsyncClient injection.
 """
 
+import argparse
 import shutil
 import subprocess
 import sys
+import tempfile
+import uuid
 from pathlib import Path
 
 APACHE_2_LICENSE_HEADER = """#\n# Copyright 2026 Alibaba Group Holding Ltd.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n\n"""
@@ -303,6 +306,69 @@ def add_license_headers(root: Path) -> None:
     )
 
 
+def replace_execd_directory(staged_package: Path, output_path: Path) -> None:
+    """Promote staged execd output and restore the prior output on failure."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    backup = output_path.parent / f".{output_path.name}-backup-{uuid.uuid4().hex}"
+    moved_old_output = False
+
+    try:
+        if output_path.exists():
+            output_path.rename(backup)
+            moved_old_output = True
+        staged_package.rename(output_path)
+    except Exception:
+        if moved_old_output and backup.exists() and not output_path.exists():
+            try:
+                backup.rename(output_path)
+            except Exception as rollback_error:
+                raise RuntimeError(
+                    f"rollback output remains at {backup}"
+                ) from rollback_error
+        raise
+    else:
+        if backup.exists():
+            shutil.rmtree(backup)
+
+
+def generate_execd_target() -> None:
+    """Safely generate and atomically replace only the execd API client."""
+    spec_path = Path("../../../specs/execd-api.yaml").resolve()
+    config_path = Path("scripts/openapi_execd_config.yaml")
+    output_path = Path("src/opensandbox/api/execd")
+
+    if not spec_path.is_file():
+        raise FileNotFoundError(f"execd OpenAPI spec not found at {spec_path}")
+    if not config_path.is_file():
+        raise FileNotFoundError(f"execd generator config not found at {config_path}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        dir=output_path.parent, prefix=".execd-generation-"
+    ) as temporary_dir:
+        generated_root = Path(temporary_dir) / "output"
+        run_command(
+            [
+                "openapi-python-client",
+                "generate",
+                "--path",
+                str(spec_path),
+                "--output-path",
+                str(generated_root),
+                "--config",
+                str(config_path),
+                "--overwrite",
+            ],
+            "Generating execd API client",
+        )
+        staged_package = generated_root / "opensandbox_api_execd"
+        if not staged_package.is_dir():
+            raise RuntimeError("execd generator did not produce opensandbox_api_execd")
+
+        add_license_headers(staged_package)
+        replace_execd_directory(staged_package, output_path)
+
+
 
 def post_process_generated_code() -> None:
     """Post-process the generated code to ensure proper package structure."""
@@ -326,8 +392,22 @@ def post_process_generated_code() -> None:
     add_license_headers(Path("src/opensandbox/api"))
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse the optional isolated execd generation target."""
+    parser = argparse.ArgumentParser(
+        description="Generate OpenSandbox Python SDK API clients."
+    )
+    parser.add_argument(
+        "--target",
+        choices=("execd",),
+        help="Generate only execd safely without global post-processing.",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
     """Main function to generate all API clients."""
+    args = parse_args()
     print("🚀 OpenSandbox Python SDK API Generator")
     print("=" * 50)
     print("Using openapi-python-client for httpx-based async clients")
@@ -345,6 +425,11 @@ def main() -> None:
         print("Please install it with: pip install openapi-python-client")
         print("Or: uv add --dev openapi-python-client")
         sys.exit(1)
+
+    if args.target == "execd":
+        generate_execd_target()
+        print("\n✅ Execd API client generation completed!")
+        return
 
     # Create API directories
     Path("src/opensandbox/api").mkdir(parents=True, exist_ok=True)

--- a/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
@@ -40,16 +40,23 @@ from opensandbox.adapters.converter.execution_event_dispatcher import (
 )
 from opensandbox.adapters.converter.response_handler import (
     build_api_exception_from_httpx,
+    extract_request_id,
     handle_api_error,
 )
 from opensandbox.config import ConnectionConfig
-from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
+from opensandbox.exceptions import (
+    InvalidArgumentException,
+    SandboxApiException,
+    SandboxError,
+)
 from opensandbox.models.execd import (
     CommandLogs,
     CommandStatus,
     Execution,
     ExecutionHandlers,
+    ListCommandsPage,
     RunCommandOpts,
+    parse_list_commands_page,
 )
 from opensandbox.models.sandboxes import SandboxEndpoint
 from opensandbox.services.command import Commands
@@ -348,6 +355,42 @@ class CommandsAdapter(Commands):
             return CommandLogs(content=content, cursor=next_cursor)
         except Exception as e:
             logger.error("Failed to get command logs", exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    async def list_commands(
+        self,
+        running: bool | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> ListCommandsPage:
+        """List command inventory through the generated execd operation."""
+        try:
+            from opensandbox.api.execd.api.command import list_commands
+            from opensandbox.api.execd.types import UNSET
+
+            request_kwargs = list_commands._get_kwargs(
+                running=running if running is not None else UNSET,
+                limit=limit,
+                cursor=cursor if cursor is not None and cursor.strip() else UNSET,
+            )
+            client = await self._get_client()
+            response = await client.get_async_httpx_client().request(**request_kwargs)
+            response.raise_for_status()
+            try:
+                return parse_list_commands_page(json.loads(response.content))
+            except ValueError as e:
+                logger.error("Invalid command inventory response", exc_info=e)
+                raise SandboxApiException(
+                    message="Invalid command inventory response",
+                    status_code=200,
+                    request_id=extract_request_id(response.headers),
+                    error=SandboxError(SandboxError.UNEXPECTED_RESPONSE, str(e)),
+                    cause=e,
+                ) from e
+        except SandboxApiException:
+            raise
+        except Exception as e:
+            logger.error("Failed to list commands", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def create_session(self, *, working_directory: str | None = None) -> str:

--- a/sdks/sandbox/python/src/opensandbox/api/execd/api/command/list_commands.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/api/command/list_commands.py
@@ -1,0 +1,264 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.list_commands_response import ListCommandsResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    running: bool | Unset = UNSET,
+    limit: int | Unset = 50,
+    cursor: str | Unset = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["running"] = running
+
+    params["limit"] = limit
+
+    params["cursor"] = cursor
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/command",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | ListCommandsResponse | None:
+    if response.status_code == 200:
+        response_200 = ListCommandsResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 500:
+        response_500 = ErrorResponse.from_dict(response.json())
+
+        return response_500
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | ListCommandsResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    running: bool | Unset = UNSET,
+    limit: int | Unset = 50,
+    cursor: str | Unset = UNSET,
+) -> Response[ErrorResponse | ListCommandsResponse]:
+    """List command inventory
+
+     Lists command inventory entries. Omitting `running` returns both running and
+    terminal commands; `running=true` returns only running commands; and
+    `running=false` returns only terminal commands. `limit` defaults to 50 and
+    the opaque `cursor` resumes a later page without client-side interpretation.
+    A cursor is bound to the exact `running` filter from its first request;
+    subsequent requests must preserve that filter or receive `INVALID_QUERY`.
+
+    The returned `session` is the same command identity exposed as `id` by the
+    legacy `GET /command/status/{id}` endpoint. Results are weakly consistent
+    and are not a snapshot: commands may transition or disappear between pages.
+    Responses must not be cached.
+
+    Args:
+        running (bool | Unset):
+        limit (int | Unset):  Default: 50.
+        cursor (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | ListCommandsResponse]
+    """
+
+    kwargs = _get_kwargs(
+        running=running,
+        limit=limit,
+        cursor=cursor,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    running: bool | Unset = UNSET,
+    limit: int | Unset = 50,
+    cursor: str | Unset = UNSET,
+) -> ErrorResponse | ListCommandsResponse | None:
+    """List command inventory
+
+     Lists command inventory entries. Omitting `running` returns both running and
+    terminal commands; `running=true` returns only running commands; and
+    `running=false` returns only terminal commands. `limit` defaults to 50 and
+    the opaque `cursor` resumes a later page without client-side interpretation.
+    A cursor is bound to the exact `running` filter from its first request;
+    subsequent requests must preserve that filter or receive `INVALID_QUERY`.
+
+    The returned `session` is the same command identity exposed as `id` by the
+    legacy `GET /command/status/{id}` endpoint. Results are weakly consistent
+    and are not a snapshot: commands may transition or disappear between pages.
+    Responses must not be cached.
+
+    Args:
+        running (bool | Unset):
+        limit (int | Unset):  Default: 50.
+        cursor (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | ListCommandsResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        running=running,
+        limit=limit,
+        cursor=cursor,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    running: bool | Unset = UNSET,
+    limit: int | Unset = 50,
+    cursor: str | Unset = UNSET,
+) -> Response[ErrorResponse | ListCommandsResponse]:
+    """List command inventory
+
+     Lists command inventory entries. Omitting `running` returns both running and
+    terminal commands; `running=true` returns only running commands; and
+    `running=false` returns only terminal commands. `limit` defaults to 50 and
+    the opaque `cursor` resumes a later page without client-side interpretation.
+    A cursor is bound to the exact `running` filter from its first request;
+    subsequent requests must preserve that filter or receive `INVALID_QUERY`.
+
+    The returned `session` is the same command identity exposed as `id` by the
+    legacy `GET /command/status/{id}` endpoint. Results are weakly consistent
+    and are not a snapshot: commands may transition or disappear between pages.
+    Responses must not be cached.
+
+    Args:
+        running (bool | Unset):
+        limit (int | Unset):  Default: 50.
+        cursor (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | ListCommandsResponse]
+    """
+
+    kwargs = _get_kwargs(
+        running=running,
+        limit=limit,
+        cursor=cursor,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    running: bool | Unset = UNSET,
+    limit: int | Unset = 50,
+    cursor: str | Unset = UNSET,
+) -> ErrorResponse | ListCommandsResponse | None:
+    """List command inventory
+
+     Lists command inventory entries. Omitting `running` returns both running and
+    terminal commands; `running=true` returns only running commands; and
+    `running=false` returns only terminal commands. `limit` defaults to 50 and
+    the opaque `cursor` resumes a later page without client-side interpretation.
+    A cursor is bound to the exact `running` filter from its first request;
+    subsequent requests must preserve that filter or receive `INVALID_QUERY`.
+
+    The returned `session` is the same command identity exposed as `id` by the
+    legacy `GET /command/status/{id}` endpoint. Results are weakly consistent
+    and are not a snapshot: commands may transition or disappear between pages.
+    Responses must not be cached.
+
+    Args:
+        running (bool | Unset):
+        limit (int | Unset):  Default: 50.
+        cursor (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | ListCommandsResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            running=running,
+            limit=limit,
+            cursor=cursor,
+        )
+    ).parsed

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
@@ -21,6 +21,7 @@ from .capabilities_response import CapabilitiesResponse
 from .chmod_files_body import ChmodFilesBody
 from .code_context import CodeContext
 from .code_context_request import CodeContextRequest
+from .command_pagination import CommandPagination
 from .command_status_response import CommandStatusResponse
 from .create_isolated_session_request import CreateIsolatedSessionRequest
 from .create_isolated_session_request_profile import CreateIsolatedSessionRequestProfile
@@ -47,6 +48,7 @@ from .isolated_session_summary_status import IsolatedSessionSummaryStatus
 from .isolated_upload_file_body import IsolatedUploadFileBody
 from .isolated_workspace_spec import IsolatedWorkspaceSpec
 from .isolated_workspace_spec_mode import IsolatedWorkspaceSpecMode
+from .list_commands_response import ListCommandsResponse
 from .list_isolated_sessions_response import ListIsolatedSessionsResponse
 from .make_dirs_body import MakeDirsBody
 from .metrics import Metrics
@@ -60,6 +62,7 @@ from .run_code_request import RunCodeRequest
 from .run_command_request import RunCommandRequest
 from .run_command_request_envs import RunCommandRequestEnvs
 from .run_in_session_request import RunInSessionRequest
+from .running_command_summary import RunningCommandSummary
 from .server_stream_event import ServerStreamEvent
 from .server_stream_event_error import ServerStreamEventError
 from .server_stream_event_results import ServerStreamEventResults
@@ -68,6 +71,7 @@ from .session_state import SessionState
 from .session_state_profile import SessionStateProfile
 from .session_state_status import SessionStateStatus
 from .session_state_uid_mode import SessionStateUidMode
+from .terminal_command_summary import TerminalCommandSummary
 from .upload_file_body import UploadFileBody
 
 __all__ = (
@@ -76,6 +80,7 @@ __all__ = (
     "ChmodFilesBody",
     "CodeContext",
     "CodeContextRequest",
+    "CommandPagination",
     "CommandStatusResponse",
     "CreateIsolatedSessionRequest",
     "CreateIsolatedSessionRequestProfile",
@@ -102,6 +107,7 @@ __all__ = (
     "IsolatedUploadFileBody",
     "IsolatedWorkspaceSpec",
     "IsolatedWorkspaceSpecMode",
+    "ListCommandsResponse",
     "ListIsolatedSessionsResponse",
     "MakeDirsBody",
     "Metrics",
@@ -115,6 +121,7 @@ __all__ = (
     "RunCommandRequest",
     "RunCommandRequestEnvs",
     "RunInSessionRequest",
+    "RunningCommandSummary",
     "ServerStreamEvent",
     "ServerStreamEventError",
     "ServerStreamEventResults",
@@ -123,5 +130,6 @@ __all__ = (
     "SessionStateProfile",
     "SessionStateStatus",
     "SessionStateUidMode",
+    "TerminalCommandSummary",
     "UploadFileBody",
 )

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/command_pagination.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/command_pagination.py
@@ -1,0 +1,88 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CommandPagination")
+
+
+@_attrs_define
+class CommandPagination:
+    """
+    Attributes:
+        limit (int):
+        next_cursor (str | Unset): Opaque nonblank cursor for the next page; omitted on the final page.
+    """
+
+    limit: int
+    next_cursor: str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        limit = self.limit
+
+        next_cursor = self.next_cursor
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "limit": limit,
+            }
+        )
+        if next_cursor is not UNSET:
+            field_dict["nextCursor"] = next_cursor
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        limit = d.pop("limit")
+
+        next_cursor = d.pop("nextCursor", UNSET)
+
+        command_pagination = cls(
+            limit=limit,
+            next_cursor=next_cursor,
+        )
+
+        command_pagination.additional_properties = d
+        return command_pagination
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/list_commands_response.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/list_commands_response.py
@@ -1,0 +1,126 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.command_pagination import CommandPagination
+    from ..models.running_command_summary import RunningCommandSummary
+    from ..models.terminal_command_summary import TerminalCommandSummary
+
+
+T = TypeVar("T", bound="ListCommandsResponse")
+
+
+@_attrs_define
+class ListCommandsResponse:
+    """
+    Attributes:
+        commands (list[RunningCommandSummary | TerminalCommandSummary]):
+        pagination (CommandPagination):
+    """
+
+    commands: list[RunningCommandSummary | TerminalCommandSummary]
+    pagination: CommandPagination
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.running_command_summary import RunningCommandSummary
+
+        commands = []
+        for commands_item_data in self.commands:
+            commands_item: dict[str, Any]
+            if isinstance(commands_item_data, RunningCommandSummary):
+                commands_item = commands_item_data.to_dict()
+            else:
+                commands_item = commands_item_data.to_dict()
+
+            commands.append(commands_item)
+
+        pagination = self.pagination.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "commands": commands,
+                "pagination": pagination,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.command_pagination import CommandPagination
+        from ..models.running_command_summary import RunningCommandSummary
+        from ..models.terminal_command_summary import TerminalCommandSummary
+
+        d = dict(src_dict)
+        commands = []
+        _commands = d.pop("commands")
+        for commands_item_data in _commands:
+
+            def _parse_commands_item(data: object) -> RunningCommandSummary | TerminalCommandSummary:
+                try:
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    componentsschemas_command_summary_type_0 = RunningCommandSummary.from_dict(data)
+
+                    return componentsschemas_command_summary_type_0
+                except (TypeError, ValueError, AttributeError, KeyError):
+                    pass
+                if not isinstance(data, dict):
+                    raise TypeError()
+                componentsschemas_command_summary_type_1 = TerminalCommandSummary.from_dict(data)
+
+                return componentsschemas_command_summary_type_1
+
+            commands_item = _parse_commands_item(commands_item_data)
+
+            commands.append(commands_item)
+
+        pagination = CommandPagination.from_dict(d.pop("pagination"))
+
+        list_commands_response = cls(
+            commands=commands,
+            pagination=pagination,
+        )
+
+        list_commands_response.additional_properties = d
+        return list_commands_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/running_command_summary.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/running_command_summary.py
@@ -1,0 +1,87 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, Literal, TypeVar, cast
+
+from attrs import define as _attrs_define
+from dateutil.parser import isoparse
+
+T = TypeVar("T", bound="RunningCommandSummary")
+
+
+@_attrs_define
+class RunningCommandSummary:
+    """A command that is still running. Terminal fields are omitted.
+
+    Attributes:
+        session (str): Command identity; equal to the legacy command status `id`.
+        running (Literal[True]):
+        background (bool):
+        started_at (datetime.datetime):
+    """
+
+    session: str
+    running: Literal[True]
+    background: bool
+    started_at: datetime.datetime
+
+    def to_dict(self) -> dict[str, Any]:
+        session = self.session
+
+        running = self.running
+
+        background = self.background
+
+        started_at = self.started_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "session": session,
+                "running": running,
+                "background": background,
+                "started_at": started_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session = d.pop("session")
+
+        running = cast(Literal[True], d.pop("running"))
+        if running != True:
+            raise ValueError(f"running must match const True, got '{running}'")
+
+        background = d.pop("background")
+
+        started_at = isoparse(d.pop("started_at"))
+
+        running_command_summary = cls(
+            session=session,
+            running=running,
+            background=background,
+            started_at=started_at,
+        )
+
+        return running_command_summary

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/terminal_command_summary.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/terminal_command_summary.py
@@ -1,0 +1,120 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, Literal, TypeVar, cast
+
+from attrs import define as _attrs_define
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TerminalCommandSummary")
+
+
+@_attrs_define
+class TerminalCommandSummary:
+    """A command that has finished. `exit_code` is present and may be null.
+
+    Attributes:
+        session (str): Command identity; equal to the legacy command status `id`.
+        running (Literal[False]):
+        background (bool):
+        started_at (datetime.datetime):
+        finished_at (datetime.datetime):
+        exit_code (int | None):
+        error (str | Unset):
+    """
+
+    session: str
+    running: Literal[False]
+    background: bool
+    started_at: datetime.datetime
+    finished_at: datetime.datetime
+    exit_code: int | None
+    error: str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        session = self.session
+
+        running = self.running
+
+        background = self.background
+
+        started_at = self.started_at.isoformat()
+
+        finished_at = self.finished_at.isoformat()
+
+        exit_code: int | None
+        exit_code = self.exit_code
+
+        error = self.error
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "session": session,
+                "running": running,
+                "background": background,
+                "started_at": started_at,
+                "finished_at": finished_at,
+                "exit_code": exit_code,
+            }
+        )
+        if error is not UNSET:
+            field_dict["error"] = error
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session = d.pop("session")
+
+        running = cast(Literal[False], d.pop("running"))
+        if running != False:
+            raise ValueError(f"running must match const False, got '{running}'")
+
+        background = d.pop("background")
+
+        started_at = isoparse(d.pop("started_at"))
+
+        finished_at = isoparse(d.pop("finished_at"))
+
+        def _parse_exit_code(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
+
+        exit_code = _parse_exit_code(d.pop("exit_code"))
+
+        error = d.pop("error", UNSET)
+
+        terminal_command_summary = cls(
+            session=session,
+            running=running,
+            background=background,
+            started_at=started_at,
+            finished_at=finished_at,
+            exit_code=exit_code,
+            error=error,
+        )
+
+        return terminal_command_summary

--- a/sdks/sandbox/python/src/opensandbox/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/models/__init__.py
@@ -22,14 +22,19 @@ Core Pydantic models for sandbox operations.
 from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.execd import (
     CommandLogs,
+    CommandPagination,
     CommandStatus,
+    CommandSummary,
     Execution,
     ExecutionComplete,
     ExecutionError,
     ExecutionInit,
     ExecutionLogs,
     ExecutionResult,
+    ListCommandsPage,
     OutputMessage,
+    RunningCommandSummary,
+    TerminalCommandSummary,
 )
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
@@ -100,6 +105,11 @@ __all__ = [
     "ExecutionInit",
     "CommandStatus",
     "CommandLogs",
+    "RunningCommandSummary",
+    "TerminalCommandSummary",
+    "CommandSummary",
+    "CommandPagination",
+    "ListCommandsPage",
     # Isolated session models
     "BindMount",
     "CreateIsolatedSessionRequest",

--- a/sdks/sandbox/python/src/opensandbox/models/execd.py
+++ b/sdks/sandbox/python/src/opensandbox/models/execd.py
@@ -19,9 +19,10 @@ Execution-related data models.
 Models for code execution, results, and output handling.
 """
 
+import re
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -347,4 +348,203 @@ class CommandLogs(BaseModel):
     cursor: int | None = Field(
         default=None,
         description="Latest tail cursor for incremental reads",
+    )
+
+
+class RunningCommandSummary(BaseModel):
+    """A command inventory entry that is still running."""
+
+    session: str
+    running: Literal[True]
+    background: bool
+    started_at: datetime
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, strict=True)
+
+
+class TerminalCommandSummary(BaseModel):
+    """A completed command inventory entry with explicit terminal fields."""
+
+    session: str
+    running: Literal[False]
+    background: bool
+    started_at: datetime
+    finished_at: datetime
+    exit_code: int | None
+    error: str | None = None
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, strict=True)
+
+
+CommandSummary: TypeAlias = RunningCommandSummary | TerminalCommandSummary
+
+
+class CommandPagination(BaseModel):
+    """Pagination metadata for a command inventory page."""
+
+    limit: int
+    next_cursor: str | None = Field(default=None, alias="nextCursor")
+
+    @model_validator(mode="after")
+    def validate_next_cursor(self) -> "CommandPagination":
+        """Reject present cursors that violate the nonblank wire contract."""
+        if self.next_cursor is not None and not self.next_cursor.strip():
+            raise ValueError("pagination.nextCursor must not be blank")
+        return self
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, strict=True)
+
+
+class ListCommandsPage(BaseModel):
+    """A weakly consistent page of command inventory entries."""
+
+    commands: list[CommandSummary]
+    pagination: CommandPagination
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, strict=True)
+
+
+def _require_object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field} must be an object")
+    return value
+
+
+def _require_string(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    return value
+
+
+def _require_boolean(value: Any, field: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{field} must be a boolean")
+    return value
+
+
+def _require_integer(value: Any, field: str) -> int:
+    if type(value) is not int:
+        raise ValueError(f"{field} must be an integer")
+    return value
+
+
+_INT32_MIN = -2_147_483_648
+_INT32_MAX = 2_147_483_647
+
+
+_RFC3339_TIMESTAMP = re.compile(
+    r"^[0-9]{4}-[0-9]{2}-[0-9]{2}"
+    r"[Tt]"
+    r"[0-9]{2}:[0-9]{2}:[0-9]{2}"
+    r"(?:\.[0-9]+)?"
+    r"(?:[Zz]|[+-](?:[01][0-9]|2[0-3]):[0-5][0-9])$"
+)
+
+
+def _parse_rfc3339(value: Any, field: str) -> datetime:
+    timestamp = _require_string(value, field)
+    if _RFC3339_TIMESTAMP.fullmatch(timestamp) is None:
+        raise ValueError(f"{field} must be an RFC3339 timestamp")
+    normalized = timestamp[:10] + "T" + timestamp[11:]
+    if normalized.endswith(("Z", "z")):
+        normalized = normalized[:-1] + "+00:00"
+    fraction = re.search(r"\.(\d+)(?=[+-])", normalized)
+    if fraction is not None:
+        normalized = (
+            normalized[: fraction.start(1)]
+            + fraction.group(1)[:6].ljust(6, "0")
+            + normalized[fraction.end(1) :]
+        )
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an RFC3339 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{field} must be an RFC3339 timestamp")
+    return parsed
+
+
+def _parse_command_summary(value: Any) -> CommandSummary:
+    command = _require_object(value, "command")
+    running = _require_boolean(command.get("running"), "command.running")
+
+    if running:
+        allowed_fields = {"session", "running", "background", "started_at"}
+        if extra_fields := command.keys() - allowed_fields:
+            raise ValueError(
+                f"running command has unknown fields: {', '.join(sorted(extra_fields))}"
+            )
+        try:
+            return RunningCommandSummary(
+                session=_require_string(command["session"], "command.session"),
+                running=True,
+                background=_require_boolean(
+                    command["background"], "command.background"
+                ),
+                started_at=_parse_rfc3339(command["started_at"], "command.started_at"),
+            )
+        except KeyError as exc:
+            raise ValueError(f"running command missing {exc.args[0]}") from exc
+
+    allowed_fields = {
+        "session",
+        "running",
+        "background",
+        "started_at",
+        "finished_at",
+        "exit_code",
+        "error",
+    }
+    if extra_fields := command.keys() - allowed_fields:
+        raise ValueError(
+            f"terminal command has unknown fields: {', '.join(sorted(extra_fields))}"
+        )
+    try:
+        exit_code = command["exit_code"]
+        if exit_code is not None:
+            exit_code = _require_integer(exit_code, "command.exit_code")
+            if not _INT32_MIN <= exit_code <= _INT32_MAX:
+                raise ValueError("command.exit_code must be an int32")
+        error = command.get("error")
+        if "error" in command:
+            error = _require_string(error, "command.error")
+        return TerminalCommandSummary(
+            session=_require_string(command["session"], "command.session"),
+            running=False,
+            background=_require_boolean(command["background"], "command.background"),
+            started_at=_parse_rfc3339(command["started_at"], "command.started_at"),
+            finished_at=_parse_rfc3339(
+                command["finished_at"], "command.finished_at"
+            ),
+            exit_code=exit_code,
+            error=error,
+        )
+    except KeyError as exc:
+        raise ValueError(f"terminal command missing {exc.args[0]}") from exc
+
+
+def parse_list_commands_page(payload: Any) -> ListCommandsPage:
+    """Parse a command inventory response with strict branch validation.
+
+    Generated OpenAPI models intentionally preserve forward-compatible envelope
+    fields, but do not enforce the command-summary discriminator contract.
+    """
+    response = _require_object(payload, "response")
+    commands_value = response.get("commands")
+    if not isinstance(commands_value, list):
+        raise ValueError("commands must be a list")
+    pagination = _require_object(response.get("pagination"), "pagination")
+    try:
+        limit = _require_integer(pagination["limit"], "pagination.limit")
+    except KeyError as exc:
+        raise ValueError("pagination missing limit") from exc
+    if not 1 <= limit <= 100:
+        raise ValueError("pagination.limit must be between 1 and 100")
+    next_cursor = pagination.get("nextCursor")
+    if "nextCursor" in pagination:
+        next_cursor = _require_string(next_cursor, "pagination.nextCursor")
+
+    return ListCommandsPage(
+        commands=[_parse_command_summary(command) for command in commands_value],
+        pagination=CommandPagination(limit=limit, nextCursor=next_cursor),
     )

--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -22,7 +22,7 @@ import logging
 import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, cast
 
 from opensandbox.adapters.factory import AdapterFactory
 from opensandbox.config import ConnectionConfig
@@ -50,6 +50,7 @@ from opensandbox.models.sandboxes import (
     Volume,
 )
 from opensandbox.services import (
+    CommandInventory,
     Commands,
     CredentialVault,
     Diagnostics,
@@ -169,6 +170,14 @@ class Sandbox:
         Allows running shell commands, capturing output, and managing processes.
         """
         return self._command_service
+
+    @property
+    def command_inventory(self) -> CommandInventory | None:
+        """Provides optional access to command inventory operations."""
+        candidate = self._command_service
+        if not callable(getattr(candidate, "list_commands", None)):
+            return None
+        return cast(CommandInventory, candidate)
 
     @property
     def metrics(self) -> Metrics:

--- a/sdks/sandbox/python/src/opensandbox/services/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/services/__init__.py
@@ -19,7 +19,7 @@ OpenSandbox service interfaces.
 Protocol definitions for sandbox services.
 """
 
-from opensandbox.services.command import Commands
+from opensandbox.services.command import CommandInventory, Commands
 from opensandbox.services.diagnostics import Diagnostics
 from opensandbox.services.egress import CredentialVault, Egress
 from opensandbox.services.filesystem import Filesystem
@@ -30,6 +30,7 @@ from opensandbox.services.sandbox import Sandboxes
 
 __all__ = [
     "Commands",
+    "CommandInventory",
     "CredentialVault",
     "Diagnostics",
     "Egress",

--- a/sdks/sandbox/python/src/opensandbox/services/command.py
+++ b/sdks/sandbox/python/src/opensandbox/services/command.py
@@ -27,6 +27,7 @@ from opensandbox.models.execd import (
     CommandStatus,
     Execution,
     ExecutionHandlers,
+    ListCommandsPage,
     RunCommandOpts,
 )
 
@@ -166,4 +167,17 @@ class Commands(Protocol):
         Raises:
             SandboxException: if the operation fails.
         """
+        ...
+
+
+class CommandInventory(Protocol):
+    """Optional command inventory capability for sandbox environments."""
+
+    async def list_commands(
+        self,
+        running: bool | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> ListCommandsPage:
+        """List a weakly consistent page of running and terminal commands."""
         ...

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
@@ -32,15 +32,22 @@ from opensandbox.adapters.converter.execution_converter import (
 )
 from opensandbox.adapters.converter.response_handler import (
     build_api_exception_from_httpx,
+    extract_request_id,
     handle_api_error,
 )
 from opensandbox.config.connection_sync import ConnectionConfigSync
-from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
+from opensandbox.exceptions import (
+    InvalidArgumentException,
+    SandboxApiException,
+    SandboxError,
+)
 from opensandbox.models.execd import (
     CommandLogs,
     CommandStatus,
     Execution,
+    ListCommandsPage,
     RunCommandOpts,
+    parse_list_commands_page,
 )
 from opensandbox.models.execd_sync import ExecutionHandlersSync
 from opensandbox.models.sandboxes import SandboxEndpoint
@@ -309,6 +316,41 @@ class CommandsAdapterSync(CommandsSync):
             return CommandLogs(content=content, cursor=next_cursor)
         except Exception as e:
             logger.error("Failed to get command logs", exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    def list_commands(
+        self,
+        running: bool | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> ListCommandsPage:
+        """List command inventory through the generated execd operation."""
+        try:
+            from opensandbox.api.execd.api.command import list_commands
+            from opensandbox.api.execd.types import UNSET
+
+            request_kwargs = list_commands._get_kwargs(
+                running=running if running is not None else UNSET,
+                limit=limit,
+                cursor=cursor if cursor is not None and cursor.strip() else UNSET,
+            )
+            response = self._client.get_httpx_client().request(**request_kwargs)
+            response.raise_for_status()
+            try:
+                return parse_list_commands_page(json.loads(response.content))
+            except ValueError as e:
+                logger.error("Invalid command inventory response", exc_info=e)
+                raise SandboxApiException(
+                    message="Invalid command inventory response",
+                    status_code=200,
+                    request_id=extract_request_id(response.headers),
+                    error=SandboxError(SandboxError.UNEXPECTED_RESPONSE, str(e)),
+                    cause=e,
+                ) from e
+        except SandboxApiException:
+            raise
+        except Exception as e:
+            logger.error("Failed to list commands", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def create_session(self, *, working_directory: str | None = None) -> str:

--- a/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
@@ -21,7 +21,7 @@ import logging
 import time
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, cast
 
 from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.constants import DEFAULT_EGRESS_PORT, DEFAULT_EXECD_PORT
@@ -49,6 +49,7 @@ from opensandbox.models.sandboxes import (
 )
 from opensandbox.sync.adapters.factory import AdapterFactorySync
 from opensandbox.sync.services import (
+    CommandInventorySync,
     CommandsSync,
     CredentialVaultSync,
     DiagnosticsSync,
@@ -175,6 +176,14 @@ class SandboxSync:
         Supports both one-shot command execution and SSE streaming output.
         """
         return self._command_service
+
+    @property
+    def command_inventory(self) -> CommandInventorySync | None:
+        """Provides optional access to command inventory operations."""
+        candidate = self._command_service
+        if not callable(getattr(candidate, "list_commands", None)):
+            return None
+        return cast(CommandInventorySync, candidate)
 
     @property
     def metrics(self) -> MetricsSync:

--- a/sdks/sandbox/python/src/opensandbox/sync/services/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/__init__.py
@@ -17,7 +17,7 @@
 Synchronous service interfaces (Protocols) for the sync SDK.
 """
 
-from opensandbox.sync.services.command import CommandsSync
+from opensandbox.sync.services.command import CommandInventorySync, CommandsSync
 from opensandbox.sync.services.diagnostics import DiagnosticsSync
 from opensandbox.sync.services.egress import CredentialVaultSync, EgressSync
 from opensandbox.sync.services.filesystem import FilesystemSync
@@ -31,6 +31,7 @@ from opensandbox.sync.services.sandbox import SandboxesSync
 
 __all__ = [
     "CommandsSync",
+    "CommandInventorySync",
     "CredentialVaultSync",
     "DiagnosticsSync",
     "EgressSync",

--- a/sdks/sandbox/python/src/opensandbox/sync/services/command.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/command.py
@@ -27,6 +27,7 @@ from opensandbox.models.execd import (
     CommandLogs,
     CommandStatus,
     Execution,
+    ListCommandsPage,
     RunCommandOpts,
 )
 from opensandbox.models.execd_sync import ExecutionHandlersSync
@@ -144,4 +145,17 @@ class CommandsSync(Protocol):
 
     def delete_session(self, session_id: str) -> None:
         """Delete a bash session and release resources."""
+        ...
+
+
+class CommandInventorySync(Protocol):
+    """Optional synchronous command inventory capability for sandbox environments."""
+
+    def list_commands(
+        self,
+        running: bool | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> ListCommandsPage:
+        """List a weakly consistent page of running and terminal commands."""
         ...

--- a/sdks/sandbox/python/tests/test_command_inventory_capability.py
+++ b/sdks/sandbox/python/tests/test_command_inventory_capability.py
@@ -1,0 +1,144 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from typing import Any, cast
+
+from opensandbox.adapters.command_adapter import CommandsAdapter
+from opensandbox.config import ConnectionConfig, ConnectionConfigSync
+from opensandbox.models.sandboxes import SandboxEndpoint
+from opensandbox.sandbox import Sandbox
+from opensandbox.services import CommandInventory, Commands
+from opensandbox.sync.adapters.command_adapter import CommandsAdapterSync
+from opensandbox.sync.sandbox import SandboxSync
+from opensandbox.sync.services import CommandInventorySync, CommandsSync
+
+
+class _Noop:
+    pass
+
+
+_NOOP = cast(Any, _Noop())
+
+
+class _LegacyCommands:
+    async def run(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    async def interrupt(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    async def get_command_status(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    async def get_background_command_logs(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    async def create_session(self, *args: Any, **kwargs: Any) -> str:
+        return "session"
+
+    async def run_in_session(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    async def delete_session(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class _LegacyCommandsSync:
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    def interrupt(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def get_command_status(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    def get_background_command_logs(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    def create_session(self, *args: Any, **kwargs: Any) -> str:
+        return "session"
+
+    def run_in_session(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    def delete_session(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+def test_legacy_command_services_have_no_inventory_capability() -> None:
+    legacy_commands: Commands = _LegacyCommands()
+    legacy_commands_sync: CommandsSync = _LegacyCommandsSync()
+
+    sandbox = Sandbox(
+        sandbox_id="sandbox-id",
+        sandbox_service=_NOOP,
+        filesystem_service=_NOOP,
+        command_service=legacy_commands,
+        health_service=_NOOP,
+        metrics_service=_NOOP,
+        egress_service=_NOOP,
+        diagnostics_service=_NOOP,
+        connection_config=ConnectionConfig(),
+    )
+    sandbox_sync = SandboxSync(
+        sandbox_id="sandbox-id",
+        sandbox_service=_NOOP,
+        filesystem_service=_NOOP,
+        command_service=legacy_commands_sync,
+        health_service=_NOOP,
+        metrics_service=_NOOP,
+        egress_service=_NOOP,
+        diagnostics_service=_NOOP,
+        connection_config=ConnectionConfigSync(),
+    )
+
+    assert sandbox.command_inventory is None
+    assert sandbox_sync.command_inventory is None
+
+
+def test_command_adapters_expose_inventory_capability() -> None:
+    endpoint = SandboxEndpoint(endpoint="localhost:8080")
+    sandbox = Sandbox(
+        sandbox_id="sandbox-id",
+        sandbox_service=_NOOP,
+        filesystem_service=_NOOP,
+        command_service=CommandsAdapter(ConnectionConfig(), endpoint),
+        health_service=_NOOP,
+        metrics_service=_NOOP,
+        egress_service=_NOOP,
+        diagnostics_service=_NOOP,
+        connection_config=ConnectionConfig(),
+    )
+    sandbox_sync = SandboxSync(
+        sandbox_id="sandbox-id",
+        sandbox_service=_NOOP,
+        filesystem_service=_NOOP,
+        command_service=CommandsAdapterSync(ConnectionConfigSync(), endpoint),
+        health_service=_NOOP,
+        metrics_service=_NOOP,
+        egress_service=_NOOP,
+        diagnostics_service=_NOOP,
+        connection_config=ConnectionConfigSync(),
+    )
+
+    inventory: CommandInventory | None = sandbox.command_inventory
+    inventory_sync: CommandInventorySync | None = sandbox_sync.command_inventory
+    assert inventory is not None
+    assert inventory_sync is not None
+    assert callable(inventory.list_commands)
+    assert callable(inventory_sync.list_commands)

--- a/sdks/sandbox/python/tests/test_command_inventory_validation.py
+++ b/sdks/sandbox/python/tests/test_command_inventory_validation.py
@@ -1,0 +1,310 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+import pytest
+
+from opensandbox.models.execd import (
+    RunningCommandSummary,
+    TerminalCommandSummary,
+    parse_list_commands_page,
+)
+
+
+def test_parser_selects_running_and_terminal_branches() -> None:
+    page = parse_list_commands_page(
+        {
+            "commands": [
+                {
+                    "session": "running",
+                    "running": True,
+                    "background": True,
+                    "started_at": "2026-07-24T01:02:03Z",
+                },
+                {
+                    "session": "terminal",
+                    "running": False,
+                    "background": False,
+                    "started_at": "2026-07-24T01:02:03Z",
+                    "finished_at": "2026-07-24T01:03:03Z",
+                    "exit_code": None,
+                    "error": "killed",
+                },
+            ],
+            "pagination": {"limit": 2, "nextCursor": "cursor", "future": True},
+            "future": True,
+        }
+    )
+
+    assert isinstance(page.commands[0], RunningCommandSummary)
+    assert isinstance(page.commands[1], TerminalCommandSummary)
+    assert page.pagination.next_cursor == "cursor"
+
+
+@pytest.mark.parametrize(
+    "started_at",
+    [
+        "2026-07-24T01:02:03Z",
+        "2026-07-24t01:02:03z",
+        "2026-07-24T01:02:03.123456Z",
+        "2026-07-24T01:02:03+08:00",
+    ],
+)
+def test_parser_accepts_rfc3339_command_started_at(started_at: str) -> None:
+    page = parse_list_commands_page(
+        {
+            "commands": [
+                {
+                    "session": "running",
+                    "running": True,
+                    "background": True,
+                    "started_at": started_at,
+                }
+            ],
+            "pagination": {"limit": 1},
+        }
+    )
+
+    assert page.commands[0].started_at.tzinfo is not None
+
+
+@pytest.mark.parametrize(
+    ("started_at", "microsecond"),
+    [
+        ("2026-07-24T01:02:03.1Z", 100_000),
+        ("2026-07-24T01:02:03.12Z", 120_000),
+        ("2026-07-24T01:02:03.12345Z", 123_450),
+        ("2026-07-24T01:02:03.123456789Z", 123_456),
+    ],
+)
+def test_parser_normalizes_rfc3339_fractional_seconds(
+    started_at: str, microsecond: int
+) -> None:
+    page = parse_list_commands_page(
+        {
+            "commands": [
+                {
+                    "session": "running",
+                    "running": True,
+                    "background": True,
+                    "started_at": started_at,
+                }
+            ],
+            "pagination": {"limit": 1},
+        }
+    )
+
+    assert page.commands[0].started_at.microsecond == microsecond
+
+
+@pytest.mark.parametrize(
+    "started_at",
+    [
+        "2026-07-24",
+        "2026-07-24T01:02:03",
+        "2026-07-24 01:02:03Z",
+        "20260724T010203Z",
+        "2026-13-24T01:02:03Z",
+        "2026-07-24T01:02:03+25:00",
+        "2026-07-24T01:02:03+01:60",
+        123,
+    ],
+)
+def test_parser_rejects_non_rfc3339_command_started_at(started_at: object) -> None:
+    with pytest.raises(ValueError):
+        parse_list_commands_page(
+            {
+                "commands": [
+                    {
+                        "session": "running",
+                        "running": True,
+                        "background": True,
+                        "started_at": started_at,
+                    }
+                ],
+                "pagination": {"limit": 1},
+            }
+        )
+
+
+def test_parser_accepts_rfc3339_terminal_timestamps() -> None:
+    page = parse_list_commands_page(
+        {
+            "commands": [
+                {
+                    "session": "terminal",
+                    "running": False,
+                    "background": False,
+                    "started_at": "2026-07-24t01:02:03z",
+                    "finished_at": "2026-07-24T01:03:03.123456+08:00",
+                    "exit_code": 0,
+                }
+            ],
+            "pagination": {"limit": 1},
+        }
+    )
+
+    command = page.commands[0]
+    assert command.started_at.tzinfo is not None
+    assert command.finished_at.tzinfo is not None
+
+
+@pytest.mark.parametrize("exit_code", [-2_147_483_649, 2_147_483_648])
+def test_parser_rejects_terminal_exit_code_outside_int32_range(exit_code: int) -> None:
+    with pytest.raises(ValueError, match="command.exit_code"):
+        parse_list_commands_page(
+            {
+                "commands": [
+                    {
+                        "session": "terminal",
+                        "running": False,
+                        "background": False,
+                        "started_at": "2026-07-24T01:02:03Z",
+                        "finished_at": "2026-07-24T01:03:03Z",
+                        "exit_code": exit_code,
+                    }
+                ],
+                "pagination": {"limit": 1},
+            }
+        )
+
+
+def test_parser_normalizes_terminal_rfc3339_fractional_seconds() -> None:
+    page = parse_list_commands_page(
+        {
+            "commands": [
+                {
+                    "session": "terminal",
+                    "running": False,
+                    "background": False,
+                    "started_at": "2026-07-24T01:02:03.12345Z",
+                    "finished_at": "2026-07-24T01:03:03.123456789Z",
+                    "exit_code": 0,
+                }
+            ],
+            "pagination": {"limit": 1},
+        }
+    )
+
+    command = page.commands[0]
+    assert command.started_at.microsecond == 123_450
+    assert command.finished_at.microsecond == 123_456
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("started_at", "2026-07-24T01:02:03"),
+        ("finished_at", "2026-07-24T01:03:03+01:60"),
+    ],
+)
+def test_parser_rejects_non_rfc3339_terminal_timestamps(
+    field: str, value: str
+) -> None:
+    command = {
+        "session": "terminal",
+        "running": False,
+        "background": False,
+        "started_at": "2026-07-24T01:02:03Z",
+        "finished_at": "2026-07-24T01:03:03Z",
+        "exit_code": 0,
+    }
+    command[field] = value
+
+    with pytest.raises(ValueError):
+        parse_list_commands_page(
+            {"commands": [command], "pagination": {"limit": 1}}
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"commands": [], "pagination": None},
+        {"commands": {}, "pagination": {"limit": 1}},
+        {"commands": [], "pagination": {"limit": True}},
+        {"commands": [], "pagination": {"limit": 0}},
+        {"commands": [], "pagination": {"limit": 101}},
+        {"commands": [], "pagination": {"limit": 1, "nextCursor": None}},
+        {"commands": [], "pagination": {"limit": 1, "nextCursor": 1}},
+        {"commands": [], "pagination": {"limit": 1, "nextCursor": ""}},
+        {"commands": [], "pagination": {"limit": 1, "nextCursor": " \t "}},
+        {
+            "commands": [
+                {
+                    "session": "bad-running",
+                    "running": "true",
+                    "background": True,
+                    "started_at": "2026-07-24T01:02:03Z",
+                }
+            ],
+            "pagination": {"limit": 1},
+        },
+        {
+            "commands": [
+                {
+                    "session": "running-terminal",
+                    "running": True,
+                    "background": True,
+                    "started_at": "2026-07-24T01:02:03Z",
+                    "finished_at": "2026-07-24T01:03:03Z",
+                }
+            ],
+            "pagination": {"limit": 1},
+        },
+        {
+            "commands": [
+                {
+                    "session": "running-extra",
+                    "running": True,
+                    "background": True,
+                    "started_at": "2026-07-24T01:02:03Z",
+                    "unknown": True,
+                }
+            ],
+            "pagination": {"limit": 1},
+        },
+        {
+            "commands": [
+                {
+                    "session": "terminal-missing",
+                    "running": False,
+                    "background": False,
+                    "started_at": "2026-07-24T01:02:03Z",
+                    "exit_code": None,
+                }
+            ],
+            "pagination": {"limit": 1},
+        },
+        {
+            "commands": [
+                {
+                    "session": "terminal-error",
+                    "running": False,
+                    "background": False,
+                    "started_at": "2026-07-24T01:02:03Z",
+                    "finished_at": "2026-07-24T01:03:03Z",
+                    "exit_code": None,
+                    "error": 1,
+                }
+            ],
+            "pagination": {"limit": 1},
+        },
+    ],
+)
+def test_parser_rejects_invalid_command_inventory_payload(payload: object) -> None:
+    with pytest.raises(ValueError):
+        parse_list_commands_page(payload)

--- a/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+import inspect
 import json
 from datetime import timedelta
 
@@ -23,8 +24,31 @@ import pytest
 
 from opensandbox.adapters.command_adapter import CommandsAdapter
 from opensandbox.config import ConnectionConfig
-from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
+from opensandbox.exceptions import (
+    InvalidArgumentException,
+    SandboxApiException,
+    SandboxError,
+)
 from opensandbox.models.sandboxes import SandboxEndpoint
+
+
+def test_async_commands_exposes_command_inventory_signature() -> None:
+    from opensandbox.services.command import CommandInventory
+
+    signature = inspect.signature(CommandInventory.list_commands)
+    assert list(signature.parameters) == ["self", "running", "limit", "cursor"]
+    assert signature.parameters["running"].default is None
+    assert signature.parameters["limit"].default == 50
+    assert signature.parameters["cursor"].default is None
+
+
+def _assert_malformed_inventory_response(
+    exception: SandboxApiException, request_id: str
+) -> None:
+    assert exception.status_code == 200
+    assert exception.request_id == request_id
+    assert exception.error.code == SandboxError.UNEXPECTED_RESPONSE
+    assert isinstance(exception.__cause__, ValueError)
 
 
 class _SseTransport(httpx.AsyncBaseTransport):
@@ -33,13 +57,17 @@ class _SseTransport(httpx.AsyncBaseTransport):
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         self.last_request = request
-        body = request.content.decode("utf-8") if isinstance(request.content, (bytes, bytearray)) else ""
+        body = (
+            request.content.decode("utf-8")
+            if isinstance(request.content, (bytes, bytearray))
+            else ""
+        )
         payload = json.loads(body) if body else {}
 
         if request.url.path == "/command" and payload.get("command") == "echo hi":
             sse = (
                 b'data: {"type":"init","text":"exec-1","timestamp":1}\n\n'
-                b'\n'
+                b"\n"
                 b'data: {"type":"stdout","text":"hi","timestamp":2}\n\n'
                 b"not-json\n\n"
                 b'data: {"type":"result","results":{"text":"ok"},"timestamp":3}\n\n'
@@ -52,11 +80,14 @@ class _SseTransport(httpx.AsyncBaseTransport):
                 request=request,
             )
 
-        if request.url.path == "/session/sess-1/run" and payload.get("command") == "pwd":
+        if (
+            request.url.path == "/session/sess-1/run"
+            and payload.get("command") == "pwd"
+        ):
             sse = (
-                b'event: stdout\n'
+                b"event: stdout\n"
                 b'data: {"type":"stdout","text":"/var","timestamp":1}\n\n'
-                b'event: execution_complete\n'
+                b"event: execution_complete\n"
                 b'data: {"type":"execution_complete","timestamp":2,"execution_time":3}\n\n'
             )
             return httpx.Response(
@@ -66,7 +97,10 @@ class _SseTransport(httpx.AsyncBaseTransport):
                 request=request,
             )
 
-        if request.url.path == "/session/sess-2/run" and payload.get("command") == "exit 7":
+        if (
+            request.url.path == "/session/sess-2/run"
+            and payload.get("command") == "exit 7"
+        ):
             sse = (
                 b'data: {"type":"init","text":"sess-exec-2","timestamp":1}\n\n'
                 b'data: {"type":"error","error":{"ename":"CommandExecError","evalue":"7","traceback":["exit status 7"]},"timestamp":2}\n\n'
@@ -149,7 +183,10 @@ async def test_run_command_streaming_tolerates_null_traceback() -> None:
 
     assert execution.id == "exec-null"
     assert execution.error is not None
-    assert execution.error.value == "fork/exec /usr/bin/bash: resource temporarily unavailable"
+    assert (
+        execution.error.value
+        == "fork/exec /usr/bin/bash: resource temporarily unavailable"
+    )
     assert execution.error.traceback == []
     assert execution.complete is None
 
@@ -217,3 +254,326 @@ async def test_run_in_session_non_zero_exit_updates_exit_code() -> None:
     assert execution.error.value == "7"
     assert execution.complete is None
     assert execution.exit_code == 7
+
+
+@pytest.mark.asyncio
+async def test_list_commands_maps_mixed_page_and_optional_query_values() -> None:
+    from opensandbox.models.execd import (
+        RunningCommandSummary,
+        TerminalCommandSummary,
+    )
+
+    class _ListTransport(httpx.AsyncBaseTransport):
+        def __init__(self) -> None:
+            self.last_request: httpx.Request | None = None
+            self.request_count = 0
+
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            self.last_request = request
+            self.request_count += 1
+            return httpx.Response(
+                200,
+                json={
+                    "commands": [
+                        {
+                            "session": "running-session",
+                            "running": True,
+                            "background": True,
+                            "started_at": "2026-07-22T01:02:03Z",
+                        },
+                        {
+                            "session": "terminal-session",
+                            "running": False,
+                            "background": False,
+                            "started_at": "2026-07-22T01:01:03Z",
+                            "finished_at": "2026-07-22T01:01:04Z",
+                            "exit_code": None,
+                            "error": "killed",
+                        },
+                    ],
+                    "pagination": {"limit": 2, "nextCursor": "  opaque +/=  "},
+                },
+                request=request,
+            )
+
+    transport = _ListTransport()
+    adapter = CommandsAdapter(
+        ConnectionConfig(protocol="http", transport=transport),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    cursor = "  opaque +/=  "
+    page = await adapter.list_commands(running=False, limit=2, cursor=cursor)
+
+    assert isinstance(page.commands[0], RunningCommandSummary)
+    assert isinstance(page.commands[1], TerminalCommandSummary)
+    assert page.commands[1].exit_code is None
+    assert page.pagination.next_cursor == cursor
+    assert transport.request_count == 1
+    assert transport.last_request is not None
+    assert transport.last_request.url.path == "/command"
+    assert transport.last_request.url.params.get("cursor") == cursor
+
+
+@pytest.mark.asyncio
+async def test_list_commands_normalizes_blank_request_cursors() -> None:
+    class _ListTransport(httpx.AsyncBaseTransport):
+        def __init__(self) -> None:
+            self.requests: list[httpx.Request] = []
+
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            self.requests.append(request)
+            return httpx.Response(
+                200,
+                json={"commands": [], "pagination": {"limit": 50}},
+                request=request,
+            )
+
+    transport = _ListTransport()
+    adapter = CommandsAdapter(
+        ConnectionConfig(protocol="http", transport=transport),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    for cursor in (None, "", " \t "):
+        page = await adapter.list_commands(cursor=cursor)
+        assert page.pagination.next_cursor is None
+
+    assert all("cursor" not in request.url.params for request in transport.requests)
+
+
+@pytest.mark.asyncio
+async def test_list_commands_maps_malformed_json_response() -> None:
+    class _ListTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=b'{"commands":',
+                headers={"X-Request-ID": "request-malformed-json"},
+                request=request,
+            )
+
+    adapter = CommandsAdapter(
+        ConnectionConfig(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        await adapter.list_commands()
+
+    _assert_malformed_inventory_response(
+        exc_info.value, "request-malformed-json"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("next_cursor", ["", " \t "])
+async def test_list_commands_rejects_blank_next_cursor(next_cursor: str) -> None:
+    class _ListTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"commands": [], "pagination": {"limit": 50, "nextCursor": next_cursor}},
+                headers={"X-Request-ID": "request-blank-cursor"},
+                request=request,
+            )
+
+    adapter = CommandsAdapter(
+        ConnectionConfig(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        await adapter.list_commands()
+
+    _assert_malformed_inventory_response(exc_info.value, "request-blank-cursor")
+
+
+@pytest.mark.asyncio
+async def test_list_commands_preserves_final_next_cursor_omission() -> None:
+    class _ListTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"commands": [], "pagination": {"limit": 50}},
+                request=request,
+            )
+
+    adapter = CommandsAdapter(
+        ConnectionConfig(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    page = await adapter.list_commands()
+
+    assert page.commands == []
+    assert page.pagination.next_cursor is None
+
+
+@pytest.mark.asyncio
+async def test_list_commands_rejects_terminal_exit_code_omission() -> None:
+    class _ListTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "commands": [
+                        {
+                            "session": "terminal-session",
+                            "running": False,
+                            "background": False,
+                            "started_at": "2026-07-22T01:01:03Z",
+                            "finished_at": "2026-07-22T01:01:04Z",
+                        }
+                    ],
+                    "pagination": {"limit": 1},
+                },
+                headers={"X-Request-ID": "request-missing-exit-code"},
+                request=request,
+            )
+
+    adapter = CommandsAdapter(
+        ConnectionConfig(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        await adapter.list_commands()
+
+    _assert_malformed_inventory_response(exc_info.value, "request-missing-exit-code")
+
+
+@pytest.mark.asyncio
+async def test_list_commands_rejects_terminal_exit_code_outside_int32_range() -> None:
+    class _ListTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "commands": [
+                        {
+                            "session": "terminal-session",
+                            "running": False,
+                            "background": False,
+                            "started_at": "2026-07-22T01:01:03Z",
+                            "finished_at": "2026-07-22T01:01:04Z",
+                            "exit_code": 2_147_483_648,
+                        }
+                    ],
+                    "pagination": {"limit": 1},
+                },
+                headers={"X-Request-ID": "request-invalid-exit-code"},
+                request=request,
+            )
+
+    adapter = CommandsAdapter(
+        ConnectionConfig(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        await adapter.list_commands()
+
+    _assert_malformed_inventory_response(exc_info.value, "request-invalid-exit-code")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command",
+    [
+        {
+            "session": "running-with-terminal-fields",
+            "running": True,
+            "background": True,
+            "started_at": "2026-07-22T01:02:03Z",
+            "finished_at": "2026-07-22T01:03:03Z",
+        },
+        {
+            "session": "terminal-with-invalid-error",
+            "running": False,
+            "background": False,
+            "started_at": "2026-07-22T01:02:03Z",
+            "finished_at": "2026-07-22T01:03:03Z",
+            "exit_code": None,
+            "error": 1,
+        },
+        {
+            "session": "running-with-extra-field",
+            "running": True,
+            "background": True,
+            "started_at": "2026-07-22T01:02:03Z",
+            "unexpected": True,
+        },
+    ],
+)
+async def test_list_commands_rejects_generated_model_validation_errors(
+    command: dict[str, object],
+) -> None:
+    class _ListTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"commands": [command], "pagination": {"limit": 1}},
+                headers={"X-Request-ID": "request-invalid-summary"},
+                request=request,
+            )
+
+    adapter = CommandsAdapter(
+        ConnectionConfig(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        await adapter.list_commands()
+
+    _assert_malformed_inventory_response(exc_info.value, "request-invalid-summary")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [400, 500])
+async def test_list_commands_maps_non_json_http_errors(status: int) -> None:
+    class _ListTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                status,
+                content=b"<html>unexpected error</html>",
+                headers={"X-Request-ID": "request-plain"},
+                request=request,
+            )
+
+    adapter = CommandsAdapter(
+        ConnectionConfig(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        await adapter.list_commands()
+
+    assert exc_info.value.status_code == status
+    assert exc_info.value.request_id == "request-plain"
+    assert exc_info.value.error.code == "UNEXPECTED_RESPONSE"
+
+
+@pytest.mark.asyncio
+async def test_list_commands_maps_structured_bad_request_error() -> None:
+    class _ListTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                400,
+                json={"code": "invalid_argument", "message": "bad limit"},
+                headers={"X-Request-ID": "request-400"},
+                request=request,
+            )
+
+    adapter = CommandsAdapter(
+        ConnectionConfig(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        await adapter.list_commands()
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.request_id == "request-400"
+    assert exc_info.value.error.code == "invalid_argument"
+    assert exc_info.value.error.message == "bad limit"

--- a/sdks/sandbox/python/tests/test_generate_api.py
+++ b/sdks/sandbox/python/tests/test_generate_api.py
@@ -1,0 +1,177 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "generate_api.py"
+
+
+@pytest.fixture
+def generate_api_module():
+    spec = importlib.util.spec_from_file_location("generate_api", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_target_execd_only_runs_isolated_generation(
+    monkeypatch: pytest.MonkeyPatch, generate_api_module
+) -> None:
+    generated: list[str] = []
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH), "--target", "execd"])
+    monkeypatch.setattr(
+        generate_api_module.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, stdout=b"0.28"),
+    )
+    monkeypatch.setattr(
+        generate_api_module,
+        "generate_execd_target",
+        lambda: generated.append("execd"),
+    )
+    monkeypatch.setattr(
+        generate_api_module,
+        "generate_execd_api_client",
+        lambda: pytest.fail("full generation must not run for --target execd"),
+    )
+
+    generate_api_module.main()
+
+    assert generated == ["execd"]
+
+
+def test_without_target_preserves_full_generation(
+    monkeypatch: pytest.MonkeyPatch, generate_api_module
+) -> None:
+    generated: list[str] = []
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH)])
+    monkeypatch.setattr(
+        generate_api_module.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, stdout=b"0.28"),
+    )
+    for target in ("execd", "egress", "diagnostic", "lifecycle"):
+        monkeypatch.setattr(
+            generate_api_module,
+            f"generate_{'sandbox_lifecycle' if target == 'lifecycle' else target}_api"
+            f"{'_client' if target != 'lifecycle' else ''}",
+            lambda target=target: generated.append(target),
+        )
+    monkeypatch.setattr(
+        generate_api_module,
+        "post_process_generated_code",
+        lambda: generated.append("post-process"),
+    )
+
+    generate_api_module.main()
+
+    assert generated == ["execd", "egress", "diagnostic", "lifecycle", "post-process"]
+
+
+def test_replace_execd_directory_restores_existing_output_when_promotion_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, generate_api_module
+) -> None:
+    output_path = tmp_path / "execd"
+    output_path.mkdir()
+    (output_path / "old.py").write_text("old", encoding="utf-8")
+    staged_package = tmp_path / "staged"
+    staged_package.mkdir()
+    (staged_package / "new.py").write_text("new", encoding="utf-8")
+
+    path_rename = Path.rename
+
+    def fail_staged_promotion(path: Path, target: Path) -> Path:
+        if path == staged_package:
+            raise OSError("promotion failed")
+        return path_rename(path, target)
+
+    monkeypatch.setattr(Path, "rename", fail_staged_promotion)
+
+    with pytest.raises(OSError, match="promotion failed"):
+        generate_api_module.replace_execd_directory(staged_package, output_path)
+
+    assert (output_path / "old.py").read_text(encoding="utf-8") == "old"
+
+
+def _prepare_execd_generation_workspace(tmp_path: Path) -> Path:
+    python_dir = tmp_path / "repo" / "sdks" / "sandbox" / "python"
+    (tmp_path / "repo" / "specs").mkdir(parents=True)
+    (tmp_path / "repo" / "specs" / "execd-api.yaml").write_text(
+        "openapi: 3.0.0", encoding="utf-8"
+    )
+    (python_dir / "scripts").mkdir(parents=True)
+    (python_dir / "scripts" / "openapi_execd_config.yaml").write_text(
+        "", encoding="utf-8"
+    )
+    output_path = python_dir / "src" / "opensandbox" / "api" / "execd"
+    output_path.mkdir(parents=True)
+    (output_path / "sentinel.py").write_text("preserve me", encoding="utf-8")
+    return python_dir
+
+
+def test_generate_execd_target_preserves_output_when_generation_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, generate_api_module
+) -> None:
+    python_dir = _prepare_execd_generation_workspace(tmp_path)
+    output_parent = python_dir / "src" / "opensandbox" / "api"
+    monkeypatch.chdir(python_dir)
+
+    def fail_generation(*args: object, **kwargs: object) -> None:
+        raise subprocess.CalledProcessError(1, "openapi-python-client")
+
+    monkeypatch.setattr(generate_api_module, "run_command", fail_generation)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        generate_api_module.generate_execd_target()
+
+    assert (output_parent / "execd" / "sentinel.py").read_text(encoding="utf-8") == (
+        "preserve me"
+    )
+    assert not list(output_parent.glob(".execd-generation-*"))
+    assert not list(output_parent.glob(".execd-backup-*"))
+
+
+def test_generate_execd_target_preserves_output_when_package_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, generate_api_module
+) -> None:
+    python_dir = _prepare_execd_generation_workspace(tmp_path)
+    output_parent = python_dir / "src" / "opensandbox" / "api"
+    monkeypatch.chdir(python_dir)
+    monkeypatch.setattr(
+        generate_api_module,
+        "run_command",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0),
+    )
+
+    with pytest.raises(
+        RuntimeError, match="execd generator did not produce opensandbox_api_execd"
+    ):
+        generate_api_module.generate_execd_target()
+
+    assert (output_parent / "execd" / "sentinel.py").read_text(encoding="utf-8") == (
+        "preserve me"
+    )
+    assert not list(output_parent.glob(".execd-generation-*"))
+    assert not list(output_parent.glob(".execd-backup-*"))

--- a/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
@@ -15,19 +15,48 @@
 #
 from __future__ import annotations
 
+import inspect
 import json
 from datetime import timedelta
 
 import httpx
+import pytest
 
 from opensandbox.config.connection_sync import ConnectionConfigSync
+from opensandbox.exceptions import (
+    SandboxApiException,
+    SandboxError,
+)
 from opensandbox.models.sandboxes import SandboxEndpoint
 from opensandbox.sync.adapters.command_adapter import CommandsAdapterSync
 
 
+def test_sync_commands_exposes_command_inventory_signature() -> None:
+    from opensandbox.sync.services.command import CommandInventorySync
+
+    signature = inspect.signature(CommandInventorySync.list_commands)
+    assert list(signature.parameters) == ["self", "running", "limit", "cursor"]
+    assert signature.parameters["running"].default is None
+    assert signature.parameters["limit"].default == 50
+    assert signature.parameters["cursor"].default is None
+
+
+def _assert_malformed_inventory_response(
+    exception: SandboxApiException, request_id: str
+) -> None:
+    assert exception.status_code == 200
+    assert exception.request_id == request_id
+    assert exception.error.code == SandboxError.UNEXPECTED_RESPONSE
+    assert isinstance(exception.__cause__, ValueError)
+
+
 class _SseTransport(httpx.BaseTransport):
     def handle_request(self, request: httpx.Request) -> httpx.Response:
-        body = request.content.decode("utf-8") if isinstance(request.content, (bytes, bytearray)) else ""
+        body = (
+            request.content.decode("utf-8")
+            if isinstance(request.content, (bytes, bytearray))
+            else ""
+        )
         payload = json.loads(body) if body else {}
 
         if request.url.path == "/command" and payload.get("command") == "echo hi":
@@ -43,11 +72,14 @@ class _SseTransport(httpx.BaseTransport):
                 request=request,
             )
 
-        if request.url.path == "/session/sess-1/run" and payload.get("command") == "pwd":
+        if (
+            request.url.path == "/session/sess-1/run"
+            and payload.get("command") == "pwd"
+        ):
             sse = (
-                b'event: stdout\n'
+                b"event: stdout\n"
                 b'data: {"type":"stdout","text":"/var","timestamp":1}\n\n'
-                b'event: execution_complete\n'
+                b"event: execution_complete\n"
                 b'data: {"type":"execution_complete","timestamp":2,"execution_time":3}\n\n'
             )
             return httpx.Response(
@@ -57,7 +89,10 @@ class _SseTransport(httpx.BaseTransport):
                 request=request,
             )
 
-        if request.url.path == "/session/sess-2/run" and payload.get("command") == "exit 7":
+        if (
+            request.url.path == "/session/sess-2/run"
+            and payload.get("command") == "exit 7"
+        ):
             sse = (
                 b'data: {"type":"init","text":"sess-exec-2","timestamp":1}\n\n'
                 b'data: {"type":"error","error":{"ename":"CommandExecError","evalue":"7","traceback":["exit status 7"]},"timestamp":2}\n\n'
@@ -128,7 +163,10 @@ def test_sync_run_command_streaming_tolerates_null_traceback() -> None:
 
     assert execution.id == "exec-null"
     assert execution.error is not None
-    assert execution.error.value == "fork/exec /usr/bin/bash: resource temporarily unavailable"
+    assert (
+        execution.error.value
+        == "fork/exec /usr/bin/bash: resource temporarily unavailable"
+    )
     assert execution.error.traceback == []
     assert execution.complete is None
 
@@ -164,3 +202,315 @@ def test_sync_run_in_session_non_zero_exit_updates_exit_code() -> None:
     assert execution.error.value == "7"
     assert execution.complete is None
     assert execution.exit_code == 7
+
+
+def test_sync_list_commands_maps_mixed_page_and_optional_query_values() -> None:
+    from opensandbox.models.execd import (
+        RunningCommandSummary,
+        TerminalCommandSummary,
+    )
+
+    class _ListTransport(httpx.BaseTransport):
+        def __init__(self) -> None:
+            self.last_request: httpx.Request | None = None
+            self.request_count = 0
+
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            self.last_request = request
+            self.request_count += 1
+            return httpx.Response(
+                200,
+                json={
+                    "commands": [
+                        {
+                            "session": "running-session",
+                            "running": True,
+                            "background": True,
+                            "started_at": "2026-07-22T01:02:03Z",
+                        },
+                        {
+                            "session": "terminal-session",
+                            "running": False,
+                            "background": False,
+                            "started_at": "2026-07-22T01:01:03Z",
+                            "finished_at": "2026-07-22T01:01:04Z",
+                            "exit_code": None,
+                        },
+                    ],
+                    "pagination": {"limit": 2, "nextCursor": "  opaque +/=  "},
+                },
+                request=request,
+            )
+
+    transport = _ListTransport()
+    adapter = CommandsAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=transport),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    cursor = "  opaque +/=  "
+    page = adapter.list_commands(running=False, limit=2, cursor=cursor)
+
+    assert isinstance(page.commands[0], RunningCommandSummary)
+    assert isinstance(page.commands[1], TerminalCommandSummary)
+    assert page.commands[1].exit_code is None
+    assert page.pagination.next_cursor == cursor
+    assert transport.request_count == 1
+    assert transport.last_request is not None
+    assert transport.last_request.url.path == "/command"
+    assert transport.last_request.url.params.get("cursor") == cursor
+
+
+def test_sync_list_commands_normalizes_blank_request_cursors() -> None:
+    class _ListTransport(httpx.BaseTransport):
+        def __init__(self) -> None:
+            self.requests: list[httpx.Request] = []
+
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            self.requests.append(request)
+            return httpx.Response(
+                200,
+                json={"commands": [], "pagination": {"limit": 50}},
+                request=request,
+            )
+
+    transport = _ListTransport()
+    adapter = CommandsAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=transport),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    for cursor in (None, "", " \t "):
+        page = adapter.list_commands(cursor=cursor)
+        assert page.pagination.next_cursor is None
+
+    assert all("cursor" not in request.url.params for request in transport.requests)
+
+
+def test_sync_list_commands_maps_malformed_json_response() -> None:
+    class _ListTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=b'{"commands":',
+                headers={"X-Request-ID": "request-malformed-json"},
+                request=request,
+            )
+
+    adapter = CommandsAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        adapter.list_commands()
+
+    _assert_malformed_inventory_response(
+        exc_info.value, "request-malformed-json"
+    )
+
+
+@pytest.mark.parametrize("next_cursor", ["", " \t "])
+def test_sync_list_commands_rejects_blank_next_cursor(next_cursor: str) -> None:
+    class _ListTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"commands": [], "pagination": {"limit": 50, "nextCursor": next_cursor}},
+                headers={"X-Request-ID": "request-blank-cursor"},
+                request=request,
+            )
+
+    adapter = CommandsAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        adapter.list_commands()
+
+    _assert_malformed_inventory_response(exc_info.value, "request-blank-cursor")
+
+
+def test_sync_list_commands_preserves_final_cursor_omission() -> None:
+    class _ListTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"commands": [], "pagination": {"limit": 50}},
+                request=request,
+            )
+
+    adapter = CommandsAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    page = adapter.list_commands()
+
+    assert page.commands == []
+    assert page.pagination.next_cursor is None
+
+
+def test_sync_list_commands_rejects_terminal_exit_code_omission() -> None:
+    class _ListTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "commands": [
+                        {
+                            "session": "terminal-session",
+                            "running": False,
+                            "background": False,
+                            "started_at": "2026-07-22T01:01:03Z",
+                            "finished_at": "2026-07-22T01:01:04Z",
+                        }
+                    ],
+                    "pagination": {"limit": 1},
+                },
+                headers={"X-Request-ID": "request-missing-exit-code"},
+                request=request,
+            )
+
+    adapter = CommandsAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        adapter.list_commands()
+
+    _assert_malformed_inventory_response(exc_info.value, "request-missing-exit-code")
+
+
+def test_sync_list_commands_rejects_terminal_exit_code_outside_int32_range() -> None:
+    class _ListTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "commands": [
+                        {
+                            "session": "terminal-session",
+                            "running": False,
+                            "background": False,
+                            "started_at": "2026-07-22T01:01:03Z",
+                            "finished_at": "2026-07-22T01:01:04Z",
+                            "exit_code": 2_147_483_648,
+                        }
+                    ],
+                    "pagination": {"limit": 1},
+                },
+                headers={"X-Request-ID": "request-invalid-exit-code"},
+                request=request,
+            )
+
+    adapter = CommandsAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        adapter.list_commands()
+
+    _assert_malformed_inventory_response(exc_info.value, "request-invalid-exit-code")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        {
+            "session": "running-with-terminal-fields",
+            "running": True,
+            "background": True,
+            "started_at": "2026-07-22T01:02:03Z",
+            "finished_at": "2026-07-22T01:03:03Z",
+        },
+        {
+            "session": "terminal-with-invalid-error",
+            "running": False,
+            "background": False,
+            "started_at": "2026-07-22T01:02:03Z",
+            "finished_at": "2026-07-22T01:03:03Z",
+            "exit_code": None,
+            "error": 1,
+        },
+        {
+            "session": "running-with-extra-field",
+            "running": True,
+            "background": True,
+            "started_at": "2026-07-22T01:02:03Z",
+            "unexpected": True,
+        },
+    ],
+)
+def test_sync_list_commands_rejects_generated_model_validation_errors(
+    command: dict[str, object],
+) -> None:
+    class _ListTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"commands": [command], "pagination": {"limit": 1}},
+                headers={"X-Request-ID": "request-invalid-summary"},
+                request=request,
+            )
+
+    adapter = CommandsAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        adapter.list_commands()
+
+    _assert_malformed_inventory_response(exc_info.value, "request-invalid-summary")
+
+
+@pytest.mark.parametrize("status", [400, 500])
+def test_sync_list_commands_maps_non_json_http_errors(status: int) -> None:
+    class _ListTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                status,
+                content=b"<html>unexpected error</html>",
+                headers={"X-Request-ID": "request-plain"},
+                request=request,
+            )
+
+    adapter = CommandsAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        adapter.list_commands()
+
+    assert exc_info.value.status_code == status
+    assert exc_info.value.request_id == "request-plain"
+    assert exc_info.value.error.code == "UNEXPECTED_RESPONSE"
+
+
+def test_sync_list_commands_maps_structured_bad_request_error() -> None:
+    class _ListTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                400,
+                json={"code": "invalid_argument", "message": "bad limit"},
+                headers={"X-Request-ID": "request-400"},
+                request=request,
+            )
+
+    adapter = CommandsAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=_ListTransport()),
+        SandboxEndpoint(endpoint="localhost:44772", port=44772),
+    )
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        adapter.list_commands()
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.request_id == "request-400"
+    assert exc_info.value.error.code == "invalid_argument"
+    assert exc_info.value.error.message == "bad limit"

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -395,6 +395,72 @@ paths:
           $ref: "#/components/responses/InternalServerError"
 
   /command:
+    get:
+      summary: List command inventory
+      description: |
+        Lists command inventory entries. Omitting `running` returns both running and
+        terminal commands; `running=true` returns only running commands; and
+        `running=false` returns only terminal commands. `limit` defaults to 50 and
+        the opaque `cursor` resumes a later page without client-side interpretation.
+        A cursor is bound to the exact `running` filter from its first request;
+        subsequent requests must preserve that filter or receive `INVALID_QUERY`.
+
+        The returned `session` is the same command identity exposed as `id` by the
+        legacy `GET /command/status/{id}` endpoint. Results are weakly consistent
+        and are not a snapshot: commands may transition or disappear between pages.
+        Responses must not be cached.
+      operationId: listCommands
+      tags:
+        - Command
+      parameters:
+        - name: running
+          in: query
+          required: false
+          description: Omit for all commands; true for running commands; false for terminal commands.
+          schema:
+            type: boolean
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of commands to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: cursor
+          in: query
+          required: false
+          description: Opaque nonblank pagination cursor returned by a previous response. It is bound to the exact `running` filter from the first request; preserve that filter or receive `INVALID_QUERY`. Omit to select the first page.
+          schema:
+            type: string
+            minLength: 1
+            pattern: '\S'
+      responses:
+        "200":
+          description: A weakly consistent page of command summaries.
+          headers:
+            Cache-Control:
+              description: Always `no-store` because command inventory is not cacheable.
+              schema:
+                type: string
+                example: no-store
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListCommandsResponse"
+        "400":
+          description: Invalid command inventory query.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                code: INVALID_QUERY
+                message: invalid cursor
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
     post:
       summary: Execute shell command
       description: |
@@ -1849,6 +1915,92 @@ components:
           nullable: true
           description: Finish time in RFC3339 format (null if still running)
           example: "2025-12-22T09:08:09Z"
+
+    RunningCommandSummary:
+      type: object
+      description: A command that is still running. Terminal fields are omitted.
+      additionalProperties: false
+      required:
+        - session
+        - running
+        - background
+        - started_at
+      properties:
+        session:
+          type: string
+          description: Command identity; equal to the legacy command status `id`.
+        running:
+          const: true
+        background:
+          type: boolean
+        started_at:
+          type: string
+          format: date-time
+
+    TerminalCommandSummary:
+      type: object
+      description: A command that has finished. `exit_code` is present and may be null.
+      additionalProperties: false
+      required:
+        - session
+        - running
+        - background
+        - started_at
+        - finished_at
+        - exit_code
+      properties:
+        session:
+          type: string
+          description: Command identity; equal to the legacy command status `id`.
+        running:
+          const: false
+        background:
+          type: boolean
+        started_at:
+          type: string
+          format: date-time
+        finished_at:
+          type: string
+          format: date-time
+        exit_code:
+          type: [integer, "null"]
+          format: int32
+        error:
+          type: string
+
+    CommandSummary:
+      description: A running or terminal command inventory summary.
+      oneOf:
+        - $ref: "#/components/schemas/RunningCommandSummary"
+        - $ref: "#/components/schemas/TerminalCommandSummary"
+
+    CommandPagination:
+      type: object
+      required:
+        - limit
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+        nextCursor:
+          type: string
+          minLength: 1
+          pattern: '\S'
+          description: Opaque nonblank cursor for the next page; omitted on the final page.
+
+    ListCommandsResponse:
+      type: object
+      required:
+        - commands
+        - pagination
+      properties:
+        commands:
+          type: array
+          items:
+            $ref: "#/components/schemas/CommandSummary"
+        pagination:
+          $ref: "#/components/schemas/CommandPagination"
 
     ServerStreamEvent:
       type: object


### PR DESCRIPTION
## Summary

- add additive, bounded `GET /command` inventory for commands retained by the current `execd` controller
- provide `running` filtering, opaque filter-bound cursor pagination, terminal-entry cap/TTL retention, and bounded JSON responses
- publish the OpenAPI contract and C#, Go, JavaScript, Kotlin, and Python SDK surfaces
- add deterministic smoke helpers, CI gates, runtime/controller/router coverage, and operational documentation

Closes #1308

## Contract

This is a runtime-local observation API, not durable command history or audit storage. It exposes no command content, environment, stdin, output, or log paths.

- Cursors are opaque, tied to the exact `running` filter and current controller instance. Preserve the filter for every page; after restart/controller replacement or a different instance, omit the cursor and restart pagination.
- Pagination is weakly consistent. Retention bounds terminal observations; it does not replace existing status/log endpoints.
- All inventory responses, including handler and authentication errors, use `Cache-Control: no-store`.
- No SSE/subscription/replay/backpressure surface and no process-group remediation are included.

## Retention boundary

The inventory TTL/cap applies only to its metadata index. It is independent of the known-ID command status and background-output retention introduced on main: completed command status and background output are retained for at least 24 hours and then removed by an hourly cleanup.

Inventory eviction does not remove those resources, and their cleanup does not remove inventory summaries. With an inventory TTL longer than 24 hours, a retained summary may outlive its detailed status and background logs. Foreground temporary output files are removed after streaming completes.

## Verification

Latest local verification: September 14 SSE-drain refresh, rebased onto main at `07f0a68d`:

- [x] Execd flags, runtime, web/controller/model package tests; flags/runtime/controller race selection covering inventory, recovery configuration, initialization, SSE and cleanup
- [x] Linux build, Windows runtime test cross-compilation, and actual CLI help exposing the 200ms drain default together with the inventory flags
- [x] Real Linux inventory smoke for default lifecycle, cap eviction and TTL expiry using the new 200ms default. A temporary copy of the existing smoke script removed only its 500ms environment override; the repository smoke script was not changed
- [x] Updated JS dependency lock installed with `--frozen-lockfile`; Sandbox typecheck, lint, build and command/inventory/native-argv tests (24)
- [x] Server Docker-service unit tests, including the incoming sidecar pause/resume changes (200; Docker is mocked, not a live container test)
- [x] Documentation build and diff-whitespace checks
- [ ] Native Windows execution and full upstream CI

The conflict resolution preserves the new 200ms graceful-shutdown default and its upstream regression test while retaining inventory TTL/cap initialization and configuration-validation coverage. Five of seven PR patches remain patch-equivalent; the other two differ only where they integrate with the upstream timeout change and test placement. No feature scope was added.

The Python, C#, Kotlin, Go and code-interpreter SDK source trees and execd OpenAPI spec are unchanged from the preceding verified branch. Earlier September 14 checks were not rerun wholesale: Python Sandbox 715 / code-interpreter 21, JavaScript Sandbox 171 / code-interpreter 10, Go test/vet/build, and real inventory smoke. Earlier C# results were 248 / 27 and Kotlin results were 398 / 22 on the final full rerun. This refresh rebuilt and retested the runtime against the new Go dependency versions and exercised the affected JavaScript dependency update as listed above.

Historical caveats remain recorded: the unchanged upstream Kotlin pool snapshot test failed once (expected 3, observed 4) on September 11, then the full suite passed without modifying that test or pool; the repository-wide license check failed on upstream `test_readiness_auth_fail_fast.py` missing a header. That repository-wide license check was not rerun in this refresh. No fresh independent review or full-project CI pass is claimed.

Generated Python OpenAPI models remain excluded from canonical Ruff/Pyright checks. The execd spec and generated execd clients were unchanged by this baseline update.

## Compatibility

- [x] Additive API; existing command routes and payloads are unchanged
- [x] No breaking changes
