### PR TITLE
feat(charts): add values schemas

### DIFF
--- a/kubernetes/charts/opensandbox-controller/values.schema.json
+++ b/kubernetes/charts/opensandbox-controller/values.schema.json
@@ -1,0 +1,284 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenSandbox Controller Helm values",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "type": "string"
+    },
+    "controller": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "resources": {
+          "$ref": "#/definitions/kubernetesObject"
+        },
+        "logLevel": {
+          "type": "string"
+        },
+        "kubeClient": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "qps": {
+              "type": "number",
+              "minimum": 0
+            },
+            "burst": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        },
+        "snapshot": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "imageCommitterImage": {
+              "type": "string"
+            },
+            "containerdSocketPath": {
+              "type": "string"
+            },
+            "commitJobTimeout": {
+              "type": "string"
+            },
+            "registry": {
+              "type": "string"
+            },
+            "registryInsecure": {
+              "type": "boolean"
+            },
+            "snapshotPushSecret": {
+              "type": "string"
+            },
+            "imageCommitterPullSecret": {
+              "type": "string"
+            },
+            "resumePullSecret": {
+              "type": "string"
+            }
+          }
+        },
+        "leaderElection": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "nodeSelector": {
+          "$ref": "#/definitions/stringMap"
+        },
+        "tolerations": {
+          "$ref": "#/definitions/kubernetesObjectArray"
+        },
+        "affinity": {
+          "$ref": "#/definitions/kubernetesObject"
+        },
+        "podSecurityContext": {
+          "$ref": "#/definitions/kubernetesObject"
+        },
+        "containerSecurityContext": {
+          "$ref": "#/definitions/kubernetesObject"
+        },
+        "podLabels": {
+          "$ref": "#/definitions/stringMap"
+        },
+        "podAnnotations": {
+          "$ref": "#/definitions/stringMap"
+        },
+        "priorityClassName": {
+          "type": "string"
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "$ref": "#/definitions/localObjectReferences"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "$ref": "#/definitions/stringMap"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean"
+        }
+      }
+    },
+    "crds": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "install": {
+          "type": "boolean"
+        },
+        "keep": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "$ref": "#/definitions/stringMap"
+        }
+      }
+    },
+    "extraEnv": {
+      "$ref": "#/definitions/kubernetesObjectArray"
+    },
+    "extraVolumes": {
+      "$ref": "#/definitions/kubernetesObjectArray"
+    },
+    "extraVolumeMounts": {
+      "$ref": "#/definitions/kubernetesObjectArray"
+    },
+    "extraInitContainers": {
+      "$ref": "#/definitions/kubernetesObjectArray"
+    },
+    "extraContainers": {
+      "$ref": "#/definitions/kubernetesObjectArray"
+    },
+    "global": {
+      "$ref": "#/definitions/kubernetesObject"
+    }
+  },
+  "definitions": {
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "kubernetesObject": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "kubernetesObjectArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/kubernetesObject"
+      }
+    },
+    "localObjectReferences": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "httpGet": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            }
+          }
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "successThreshold": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "stringMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/kubernetes/charts/opensandbox-server/values.schema.json
+++ b/kubernetes/charts/opensandbox-server/values.schema.json
@@ -1,0 +1,236 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenSandbox Server Helm values",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "type": "string"
+    },
+    "imagePullSecrets": {
+      "$ref": "#/definitions/localObjectReferences"
+    },
+    "server": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "env": {
+          "$ref": "#/definitions/kubernetesObjectArray"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "resources": {
+          "$ref": "#/definitions/kubernetesObject"
+        },
+        "tolerations": {
+          "$ref": "#/definitions/kubernetesObjectArray"
+        },
+        "affinity": {
+          "$ref": "#/definitions/kubernetesObject"
+        },
+        "volumeMounts": {
+          "$ref": "#/definitions/kubernetesObjectArray"
+        },
+        "volumes": {
+          "$ref": "#/definitions/kubernetesObjectArray"
+        },
+        "nodeSelector": {
+          "$ref": "#/definitions/stringMap"
+        },
+        "podSecurityContext": {
+          "$ref": "#/definitions/kubernetesObject"
+        },
+        "containerSecurityContext": {
+          "$ref": "#/definitions/kubernetesObject"
+        },
+        "podAnnotations": {
+          "$ref": "#/definitions/stringMap"
+        },
+        "podLabels": {
+          "$ref": "#/definitions/stringMap"
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+        "topologySpreadConstraints": {
+          "$ref": "#/definitions/kubernetesObjectArray"
+        },
+        "gateway": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "host": {
+              "type": "string"
+            },
+            "gatewayRouteMode": {
+              "type": "string",
+              "enum": [
+                "header",
+                "uri"
+              ]
+            },
+            "image": {
+              "$ref": "#/definitions/image"
+            },
+            "replicaCount": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "dataplaneNamespace": {
+              "type": "string"
+            },
+            "providerType": {
+              "type": "string"
+            },
+            "logLevel": {
+              "type": "string"
+            },
+            "env": {
+              "$ref": "#/definitions/kubernetesObjectArray"
+            },
+            "resources": {
+              "$ref": "#/definitions/kubernetesObject"
+            },
+            "secureAccess": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "activeKey": {
+                  "type": "string",
+                  "pattern": "^$|^[0-9a-z]$"
+                },
+                "keys": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "key_id",
+                      "key"
+                    ],
+                    "properties": {
+                      "key_id": {
+                        "type": "string",
+                        "pattern": "^[0-9a-z]$"
+                      },
+                      "key": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "nodeSelector": {
+              "$ref": "#/definitions/stringMap"
+            },
+            "podSecurityContext": {
+              "$ref": "#/definitions/kubernetesObject"
+            },
+            "containerSecurityContext": {
+              "$ref": "#/definitions/kubernetesObject"
+            },
+            "podAnnotations": {
+              "$ref": "#/definitions/stringMap"
+            },
+            "podLabels": {
+              "$ref": "#/definitions/stringMap"
+            },
+            "priorityClassName": {
+              "type": "string"
+            },
+            "topologySpreadConstraints": {
+              "$ref": "#/definitions/kubernetesObjectArray"
+            },
+            "tolerations": {
+              "$ref": "#/definitions/kubernetesObjectArray"
+            },
+            "affinity": {
+              "$ref": "#/definitions/kubernetesObject"
+            }
+          }
+        }
+      }
+    },
+    "configToml": {
+      "type": "string"
+    },
+    "global": {
+      "$ref": "#/definitions/kubernetesObject"
+    }
+  },
+  "definitions": {
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "kubernetesObject": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "kubernetesObjectArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/kubernetesObject"
+      }
+    },
+    "localObjectReferences": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "stringMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/kubernetes/charts/opensandbox/values.schema.json
+++ b/kubernetes/charts/opensandbox/values.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenSandbox all-in-one Helm values",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "opensandbox-controller": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "opensandbox-server": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/kubernetes/charts/opensandbox/values.yaml
+++ b/kubernetes/charts/opensandbox/values.yaml
@@ -25,7 +25,7 @@ opensandbox-server:
     replicaCount: 2
 
 # Global values (passed to both sub-charts)
-global:
+global: {}
   # Example: shared image pull secrets
   # imagePullSecrets:
   #   - name: my-registry-secret


### PR DESCRIPTION
## Summary

- add hand-crafted Draft 7 `values.schema.json` files for the controller, server, and all-in-one Helm charts
- reject unknown chart-owned keys and validate scalar types while keeping Kubernetes-native extension objects such as resources, affinity, security contexts, env, and volumes open-ended
- model controller QPS and burst as numbers and make the all-in-one `global` default an actual empty object

## Why

The charts previously accepted misspelled keys and invalid scalar types until rendering or deployment. Inferred schemas also misclassify intentionally open values such as `global` and the floating-point Kubernetes client rate limits, so the schemas are maintained explicitly alongside `values.yaml`.

## User impact

Valid existing values continue to render, while mistakes such as `controller.logLevl` or a string `controller.replicaCount` now fail during `helm lint`, `helm install`, or `helm upgrade` before resources reach the cluster.

## Testing

- Helm v3.21.3: linted all three charts with default values
- linted representative valid overrides, including decimal QPS/burst, gateway env, and all-in-one global/sub-chart values
- confirmed Helm rejects invalid replica types and unknown controller, gateway, all-in-one, and nested sub-chart keys
- packaged all three charts and verified every archive contains its schema, including both dependency schemas in the all-in-one package

Closes #1262
