### PR TITLE
fix(server): use supported no-new-privileges separator

### DIFF
--- a/server/opensandbox_server/services/docker/container_ops.py
+++ b/server/opensandbox_server/services/docker/container_ops.py
@@ -348,7 +348,7 @@ class DockerContainerOpsMixin:
         security_opts: list[str] = []
         docker_cfg = self.app_config.docker
         if docker_cfg.no_new_privileges:
-            security_opts.append("no-new-privileges:true")
+            security_opts.append("no-new-privileges=true")
         if docker_cfg.apparmor_profile:
             security_opts.append(f"apparmor={docker_cfg.apparmor_profile}")
         if docker_cfg.seccomp_profile:

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -143,7 +143,7 @@ async def test_create_sandbox_applies_security_defaults(mock_docker):
     mock_client = MagicMock()
     mock_client.containers.list.return_value = []
     mock_client.api.create_host_config.return_value = {
-        "security_opt": ["no-new-privileges:true"],
+        "security_opt": ["no-new-privileges=true"],
         "cap_drop": _app_config().docker.drop_capabilities,
         "pids_limit": _app_config().docker.pids_limit,
     }
@@ -175,7 +175,7 @@ async def test_create_sandbox_applies_security_defaults(mock_docker):
         await service.create_sandbox(request)
 
     host_config = mock_client.api.create_container.call_args.kwargs["host_config"]
-    assert "no-new-privileges:true" in host_config.get("security_opt", [])
+    assert "no-new-privileges=true" in host_config.get("security_opt", [])
     assert host_config.get("cap_drop") == service.app_config.docker.drop_capabilities
     assert host_config.get("pids_limit") == service.app_config.docker.pids_limit
 


### PR DESCRIPTION
## Summary

- replace the deprecated `no-new-privileges:true` Docker security option with the supported `no-new-privileges=true` form
- keep the existing `no_new_privileges` configuration behavior unchanged

Closes #1377.

## Verification

- `server/.venv/bin/pytest tests/test_docker_service.py -q` (124 passed)
- `server/.venv/bin/ruff check opensandbox_server/services/docker/container_ops.py tests/test_docker_service.py`
- `git diff --check`
