### PR TITLE
fix(sdks): windowed degraded detection for pool backoff

### DIFF
--- a/docs/guides/client-pool.md
+++ b/docs/guides/client-pool.md
@@ -49,10 +49,30 @@ because it is the only part of the pool that is gated by a distributed lock:
 ### Lifecycle model
 
 Each pool instance moves through `NOT_STARTED → STARTING → RUNNING → DRAINING → STOPPED`.
-Health is tracked separately as `HEALTHY | DEGRADED | DRAINING | STOPPED`; after
-`degraded_threshold` consecutive create failures the pool enters `DEGRADED` and applies
-exponential backoff before retrying warmup. Callers do not need to observe these states
-directly — `snapshot()` exposes them for diagnostics.
+Health is tracked separately as `HEALTHY | DEGRADED | DRAINING | STOPPED`. Create failures
+are counted inside a sliding time window (`failure_window`): once `degraded_threshold`
+failures fall inside the window, the pool enters `DEGRADED` and applies exponential backoff
+before retrying warmup. Detection is rate-based — a successful create never resets the
+window, so a pool with a sustained high failure rate stays paused even when successes are
+interleaved. The pool returns to `HEALTHY` only once the window drains and no backoff is
+active. Callers do not need to observe these states directly — `snapshot()` exposes them
+for diagnostics.
+
+::: warning Behavior change from the next release
+Starting with the next release after Kotlin `java/sandbox` v1.0.18, Go `sdks/sandbox/go`
+v1.0.5, and Python `opensandbox` v0.1.15, degraded detection changes from **consecutive**
+failures (any success reset the count) to **rate-based** detection over the sliding
+`failure_window` (default `60 s`). Concretely:
+
+- A successful warmup no longer resets the failure count or cancels an active backoff.
+- While `DEGRADED`, an expired backoff window is renewed automatically as long as the
+  failure window is still hot — the pool stays paused until the failure rate actually
+  drops below the threshold, instead of retrying every backoff step.
+- Recovery is time-based: the pool returns to `HEALTHY` when the failure window drains.
+- The new `failure_window` knob (default `60 s`) is added to all three SDKs; the existing
+  `degraded_threshold` semantics change from "consecutive failures" to "failures inside
+  the window".
+:::
 
 ![Client pool lifecycle state machine](/images/client-pool-lifecycle.svg)
 
@@ -97,7 +117,8 @@ canonical reference; refer to the per-language builder or constructor for exact 
 | `warmup_concurrency`                  | `max(1, ceil(max_idle * 0.2))`     | Warmup worker pool size                                                          |
 | `primary_lock_ttl`                    | `60 s`                             | Leader-lock TTL; must exceed `warmup_ready_timeout` + preparer time              |
 | `reconcile_interval`                  | `30 s`                             | Interval between reconcile ticks                                                 |
-| `degraded_threshold`                  | `3`                                | Consecutive create failures before entering `DEGRADED` with backoff              |
+| `degraded_threshold`                  | `3`                                | Create failures inside `failure_window` before entering `DEGRADED` with backoff |
+| `failure_window`                      | `60 s`                             | Sliding time window over which create failures are counted for degraded detection |
 | `acquire_ready_timeout`               | `30 s`                             | Max wait for the returned sandbox to become ready                                |
 | `acquire_health_check_polling_interval` | `200 ms`                         | Ready-poll interval during acquire                                               |
 | `acquire_health_check`                | `null`                             | Custom readiness predicate for acquire                                           |
@@ -277,7 +298,7 @@ _ = result
 Every SDK exposes read-only accessors:
 
 - `snapshot()` — pool phase, health, counters (idle size, in-flight warmups,
-  consecutive failures, last error).
+  failures inside the sliding window, last error).
 - `snapshot_idle_entries()` — the current idle sandbox IDs with expiry timestamps.
 - `resize(max_idle)` — change the target buffer size at runtime.
 - `release_all_idle()` — drain the currently visible idle buffer and best-effort kill

--- a/sdks/sandbox/go/pool.go
+++ b/sdks/sandbox/go/pool.go
@@ -674,7 +674,10 @@ func (p *DefaultSandboxPool) Snapshot(ctx context.Context) (*PoolSnapshot, error
 	var backoffActive bool
 	var lastError string
 	if recon != nil {
-		_, failureCount, backoffActive, lastError = recon.snapshot()
+		// Use the refreshed health state from the reconcile state machine (which prunes the
+		// failure window and runs recovery on read) instead of the cached p.healthState, so
+		// the snapshot never reports DEGRADED alongside a fresh failureCount/backoffActive.
+		hs, failureCount, backoffActive, lastError = recon.snapshot()
 	}
 
 	return &PoolSnapshot{

--- a/sdks/sandbox/go/pool.go
+++ b/sdks/sandbox/go/pool.go
@@ -127,6 +127,9 @@ func (p *DefaultSandboxPool) Start(ctx context.Context) error {
 			"warmup_ready_timeout", p.config.WarmupReadyTimeout)
 	}
 	p.reconciler = newReconcileState(p.config.DegradedThreshold)
+	if p.config.FailureWindow > 0 {
+		p.reconciler.failureWindow = p.config.FailureWindow
+	}
 	p.ticker = time.NewTicker(p.config.ReconcileInterval)
 	p.done = make(chan struct{})
 	p.doneClosed = false

--- a/sdks/sandbox/go/pool_builder.go
+++ b/sdks/sandbox/go/pool_builder.go
@@ -37,6 +37,7 @@ func NewSandboxPoolBuilder() *SandboxPoolBuilder {
 			PrimaryLockTTL:                    60 * time.Second,
 			ReconcileInterval:                 30 * time.Second,
 			DegradedThreshold:                 3,
+			FailureWindow:                     60 * time.Second,
 			AcquireReadyTimeout:               30 * time.Second,
 			WarmupReadyTimeout:                30 * time.Second,
 			AcquireHealthCheckPollingInterval: 200 * time.Millisecond,
@@ -104,10 +105,17 @@ func (b *SandboxPoolBuilder) PrimaryLockTTL(d time.Duration) *SandboxPoolBuilder
 	return b
 }
 
-// DegradedThreshold sets the number of consecutive failures before the pool
-// is considered degraded.
+// DegradedThreshold sets the number of failures inside the failure window
+// before the pool is considered degraded.
 func (b *SandboxPoolBuilder) DegradedThreshold(n int) *SandboxPoolBuilder {
 	b.config.DegradedThreshold = n
+	return b
+}
+
+// FailureWindow sets the sliding time window over which create failures are
+// counted for degraded detection. Must be positive. Default: 60s.
+func (b *SandboxPoolBuilder) FailureWindow(d time.Duration) *SandboxPoolBuilder {
+	b.config.FailureWindow = d
 	return b
 }
 
@@ -227,6 +235,9 @@ func (b *SandboxPoolBuilder) Build() (*DefaultSandboxPool, error) {
 	}
 	if b.config.DegradedThreshold <= 0 {
 		return nil, fmt.Errorf("opensandbox: pool builder: DegradedThreshold must be positive")
+	}
+	if b.config.FailureWindow <= 0 {
+		return nil, fmt.Errorf("opensandbox: pool builder: FailureWindow must be positive")
 	}
 	if b.config.SandboxCreator == nil && b.config.CreationSpec.Image == "" && b.config.CreationSpec.SnapshotID == "" {
 		return nil, fmt.Errorf("opensandbox: pool builder: CreationSpec (with Image or SnapshotID) is required when no SandboxCreator is set")

--- a/sdks/sandbox/go/pool_reconciler.go
+++ b/sdks/sandbox/go/pool_reconciler.go
@@ -139,11 +139,16 @@ func (s *reconcileState) activateNextBackoff(now time.Time) {
 	if shift > 30 {
 		shift = 30
 	}
-	backoff := reconcileBackoffBase * (1 << shift)
-	if backoff > reconcileMaxBackoff {
-		backoff = reconcileMaxBackoff
+	// Cap the delay in seconds before constructing the duration: with sustained
+	// renewals backoffAttempts grows without bound, and 30s << 29 already overflows
+	// the int64 nanosecond range of time.Duration (wrapping negative and defeating
+	// the max check below).
+	maxSeconds := int64(reconcileMaxBackoff / time.Second)
+	delaySeconds := int64(reconcileBackoffBase/time.Second) << shift
+	if delaySeconds > maxSeconds {
+		delaySeconds = maxSeconds
 	}
-	s.backoffUntil = now.Add(backoff)
+	s.backoffUntil = now.Add(time.Duration(delaySeconds) * time.Second)
 }
 
 func (s *reconcileState) recover() {

--- a/sdks/sandbox/go/pool_reconciler.go
+++ b/sdks/sandbox/go/pool_reconciler.go
@@ -107,7 +107,14 @@ func (s *reconcileState) recordFailures(count int, err error) {
 func (s *reconcileState) shouldBackoff() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	now := s.now()
+	return s.refreshLocked(s.now())
+}
+
+// refreshLocked advances the state machine at the current time and reports whether create
+// attempts should be suppressed: prunes the sliding failure window, renews an expired backoff
+// window while the window is still hot, and recovers to healthy once the window drains.
+// Callers must hold s.mu.
+func (s *reconcileState) refreshLocked(now time.Time) bool {
 	s.pruneExpired(now)
 	if s.healthState != PoolDegraded || s.backoffUntil.IsZero() {
 		return false
@@ -123,12 +130,13 @@ func (s *reconcileState) shouldBackoff() bool {
 	return false
 }
 
-// snapshot returns a point-in-time view of the reconcile health state.
+// snapshot returns a point-in-time view of the reconcile health state. It advances the state
+// machine first (prune/renew/recover) so readers never observe a stale DEGRADED state or stale
+// failure count after the window has drained.
 func (s *reconcileState) snapshot() (PoolHealthState, int, bool, string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	backoffActive := s.healthState == PoolDegraded &&
-		!s.backoffUntil.IsZero() && s.now().Before(s.backoffUntil)
+	backoffActive := s.refreshLocked(s.now())
 	return s.healthState, s.failureCount, backoffActive, s.lastError
 }
 

--- a/sdks/sandbox/go/pool_reconciler.go
+++ b/sdks/sandbox/go/pool_reconciler.go
@@ -24,36 +24,45 @@ import (
 const (
 	reconcileBackoffBase = 30 * time.Second
 	reconcileMaxBackoff  = 24 * time.Hour
+	// defaultFailureWindow is the default sliding time window over which create
+	// failures are counted for degraded detection.
+	defaultFailureWindow = 60 * time.Second
 )
 
 // reconcileState tracks the health and backoff state of the reconcile loop.
+//
+// Degradation is detected by failure *rate* rather than consecutive failures: every failure is
+// recorded with a timestamp and ages out of failureWindow. The pool enters PoolDegraded and opens
+// an exponential backoff window once degradedThreshold failures are present inside the window.
+// Successful creates never reset the window (recovery is time-based, not success-based), and an
+// active backoff window is never cancelled by a success.
+//
+// While PoolDegraded, an expired backoff window is renewed automatically whenever the failure
+// window is still hot, so the pool stays paused until the failure rate actually drops below the
+// threshold. The pool returns to PoolHealthy only once the failure window drains and no backoff
+// is active.
 type reconcileState struct {
 	mu                sync.Mutex
 	degradedThreshold int
+	failureWindow     time.Duration
 	failureCount      int
+	failureTimes      []time.Time
 	backoffAttempts   int
 	backoffUntil      time.Time
 	lastError         string
 	healthState       PoolHealthState
+	now               func() time.Time
 }
 
-// newReconcileState creates a new reconcileState with the given degraded threshold.
+// newReconcileState creates a new reconcileState with the given degraded threshold and the
+// default failure window.
 func newReconcileState(degradedThreshold int) *reconcileState {
 	return &reconcileState{
 		degradedThreshold: degradedThreshold,
+		failureWindow:     defaultFailureWindow,
 		healthState:       PoolHealthy,
+		now:               time.Now,
 	}
-}
-
-// recordSuccess resets the failure state and marks the pool as healthy.
-func (s *reconcileState) recordSuccess() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.failureCount = 0
-	s.backoffAttempts = 0
-	s.backoffUntil = time.Time{}
-	s.lastError = ""
-	s.healthState = PoolHealthy
 }
 
 // recordFailure records a single failure. Delegates to recordFailures.
@@ -61,49 +70,100 @@ func (s *reconcileState) recordFailure(err error) {
 	s.recordFailures(1, err)
 }
 
-// recordFailures records count failures in one call. If the cumulative count
-// reaches or exceeds the degraded threshold, the pool transitions to degraded
-// state and backoffAttempts is incremented (escalating the backoff duration).
-// In production, this is called once per reconcile tick, so backoff escalates
-// per failing tick, not per individual failed sandbox creation.
+// recordFailures records count failures in one call. Failures are recorded with the current
+// timestamp and age out of the sliding failureWindow; the pool transitions to degraded and opens
+// an exponential backoff window when the windowed count reaches or exceeds the degraded
+// threshold. Failures recorded while a backoff window is already active do not advance the
+// exponential delay (only the counter and last error are updated).
 func (s *reconcileState) recordFailures(count int, err error) {
 	if count <= 0 {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.failureCount += count
+	now := s.now()
+	for i := 0; i < count; i++ {
+		s.failureTimes = append(s.failureTimes, now)
+	}
+	s.pruneExpired(now)
 	if err != nil {
 		s.lastError = err.Error()
 	}
-	if s.failureCount >= s.degradedThreshold {
-		s.healthState = PoolDegraded
-		s.backoffAttempts++
-		shift := s.backoffAttempts - 1
-		if shift > 15 {
-			shift = 15
-		}
-		backoff := reconcileBackoffBase * (1 << shift)
-		if backoff > reconcileMaxBackoff {
-			backoff = reconcileMaxBackoff
-		}
-		s.backoffUntil = time.Now().Add(backoff)
+	if s.failureCount < s.degradedThreshold {
+		return
 	}
+	if s.healthState == PoolDegraded && !s.backoffUntil.IsZero() && now.Before(s.backoffUntil) {
+		return
+	}
+	s.activateNextBackoff(now)
 }
 
 // shouldBackoff returns true if the reconciler is in a backoff period.
+//
+// Advances the state machine on the read path: while PoolDegraded, an expired backoff window is
+// renewed when the failure window is still hot, so the pool stays paused until the failure rate
+// falls below the threshold; once the failure window drains and no backoff is active, the pool
+// recovers to PoolHealthy.
 func (s *reconcileState) shouldBackoff() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return time.Now().Before(s.backoffUntil)
+	now := s.now()
+	s.pruneExpired(now)
+	if s.healthState != PoolDegraded || s.backoffUntil.IsZero() {
+		return false
+	}
+	if now.Before(s.backoffUntil) {
+		return true
+	}
+	if s.failureCount >= s.degradedThreshold {
+		s.activateNextBackoff(now)
+		return true
+	}
+	s.recover()
+	return false
 }
 
 // snapshot returns a point-in-time view of the reconcile health state.
 func (s *reconcileState) snapshot() (PoolHealthState, int, bool, string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	backoffActive := time.Now().Before(s.backoffUntil)
+	backoffActive := s.healthState == PoolDegraded &&
+		!s.backoffUntil.IsZero() && s.now().Before(s.backoffUntil)
 	return s.healthState, s.failureCount, backoffActive, s.lastError
+}
+
+func (s *reconcileState) activateNextBackoff(now time.Time) {
+	s.healthState = PoolDegraded
+	s.backoffAttempts++
+	shift := s.backoffAttempts - 1
+	if shift > 30 {
+		shift = 30
+	}
+	backoff := reconcileBackoffBase * (1 << shift)
+	if backoff > reconcileMaxBackoff {
+		backoff = reconcileMaxBackoff
+	}
+	s.backoffUntil = now.Add(backoff)
+}
+
+func (s *reconcileState) recover() {
+	s.healthState = PoolHealthy
+	s.backoffUntil = time.Time{}
+	s.backoffAttempts = 0
+	s.lastError = ""
+}
+
+func (s *reconcileState) pruneExpired(now time.Time) {
+	cutoff := now.Add(-s.failureWindow)
+	kept := 0
+	for _, ts := range s.failureTimes {
+		if !ts.Before(cutoff) {
+			s.failureTimes[kept] = ts
+			kept++
+		}
+	}
+	s.failureTimes = s.failureTimes[:kept]
+	s.failureCount = kept
 }
 
 // reconcileTick performs a single reconciliation pass. It is designed to be
@@ -207,7 +267,9 @@ func reconcileTick(
 			removedCount++
 		}
 		if !shrinkErr && removedCount > 0 {
-			state.recordSuccess()
+			logger.Debug("reconcile: shrunk excess idle",
+				"pool_name", poolName,
+				"removed", removedCount)
 		}
 		return
 	}
@@ -282,7 +344,8 @@ func reconcileTick(
 		state.recordFailures(failCount, lastCreateErr)
 	}
 
-	// Place created sandboxes into idle pool; record success per-putIdle.
+	// Place created sandboxes into idle pool. Successful puts do not reset the failure
+	// window; recovery is time-based (see reconcileState).
 	for i, id := range createdIDs {
 		renewed, renewErr := store.RenewPrimaryLock(ctx, poolName, ownerID, lockTTL)
 		if renewErr != nil || !renewed {
@@ -309,7 +372,6 @@ func reconcileTick(
 				"orphan_count", len(createdIDs)-i)
 			return
 		}
-		state.recordSuccess()
 	}
 
 	if len(createdIDs) > 0 {

--- a/sdks/sandbox/go/pool_reconciler_test.go
+++ b/sdks/sandbox/go/pool_reconciler_test.go
@@ -338,6 +338,31 @@ func TestReconciler_InterleavedCreatesTriggerDegraded(t *testing.T) {
 	}
 }
 
+func TestReconciler_BackoffCapDoesNotOverflow(t *testing.T) {
+	state := newReconcileState(1)
+	state.failureWindow = 100 * 24 * time.Hour
+
+	// Sustained renewals grow backoffAttempts without bound; the delay must be capped at
+	// one day instead of overflowing time.Duration (which wraps negative and moves
+	// backoffUntil into the past).
+	for i := 0; i < 40; i++ {
+		state.mu.Lock()
+		state.backoffUntil = time.Now().Add(-time.Second) // previous window expired
+		state.mu.Unlock()
+		state.recordFailures(1, errors.New("boom"))
+	}
+
+	state.mu.Lock()
+	delay := state.backoffUntil.Sub(time.Now())
+	state.mu.Unlock()
+	if delay <= 0 || delay > reconcileMaxBackoff {
+		assert.Fail(t, fmt.Sprintf("expected backoff capped at 24h in the future, got %v", delay))
+	}
+	if !state.shouldBackoff() {
+		assert.Fail(t, "expected backoff to be active")
+	}
+}
+
 func TestReconciler_ShrinkExcess(t *testing.T) {
 	store := NewInMemoryPoolStateStore()
 	_ = store.SetMaxIdle(context.Background(), "test-pool", 2)

--- a/sdks/sandbox/go/pool_reconciler_test.go
+++ b/sdks/sandbox/go/pool_reconciler_test.go
@@ -210,10 +210,14 @@ func TestReconciler_ExponentialBackoff(t *testing.T) {
 
 	// Escalation via recordFailures with batch count:
 	// threshold=1, recordFailures(1) => backoffAttempts=1 (30s)
-	// Then recordFailures(1) again => backoffAttempts=2 (60s)
+	// Then, once the first window expires while the failure window is still hot,
+	// recordFailures(1) again => backoffAttempts=2 (60s).
 	// This simulates two consecutive failing ticks (each calling recordFailures once).
 	state3 := newReconcileState(1)
 	state3.recordFailures(1, errors.New("tick-1-fail")) // backoffAttempts=1, backoff=30s
+	state3.mu.Lock()
+	state3.backoffUntil = time.Now().Add(-time.Second) // first backoff window expired
+	state3.mu.Unlock()
 	state3.recordFailures(1, errors.New("tick-2-fail")) // backoffAttempts=2, backoff=60s
 	state3.mu.Lock()
 	backoffDuration2 := state3.backoffUntil.Sub(time.Now())
@@ -223,8 +227,11 @@ func TestReconciler_ExponentialBackoff(t *testing.T) {
 	}
 }
 
-func TestReconciler_RecoveryAfterSuccess(t *testing.T) {
+func TestReconciler_RecoveryAfterWindowDrain(t *testing.T) {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	state := newReconcileState(2)
+	state.now = func() time.Time { return now }
+	state.failureWindow = time.Minute
 
 	// Drive into degraded state
 	state.recordFailure(errors.New("fail-1"))
@@ -235,12 +242,23 @@ func TestReconciler_RecoveryAfterSuccess(t *testing.T) {
 		assert.Fail(t, fmt.Sprintf("expected PoolDegraded before recovery, got %v", healthState))
 	}
 
-	// Record success: should recover
-	state.recordSuccess()
+	// The 30s backoff expires while the failure window is still hot: the pool stays
+	// paused (renewed), not recovered. Successes do not reset anything.
+	now = now.Add(31 * time.Second)
+	if !state.shouldBackoff() {
+		assert.Fail(t, "expected backoff to stay active while the failure window is hot")
+	}
+
+	// Once the failure window drains and the renewed backoff window (t=31+60s) expires,
+	// the pool recovers to healthy.
+	now = now.Add(70 * time.Second)
+	if state.shouldBackoff() {
+		assert.Fail(t, "expected shouldBackoff() to be false after window drain")
+	}
 
 	healthState, failureCount, backoffActive, lastError := state.snapshot()
 	if healthState != PoolHealthy {
-		assert.Fail(t, fmt.Sprintf("expected PoolHealthy after recovery, got %v", healthState))
+		assert.Fail(t, fmt.Sprintf("expected PoolHealthy after window drain, got %v", healthState))
 	}
 	if failureCount != 0 {
 		assert.Fail(t, fmt.Sprintf("expected failureCount 0 after recovery, got %d", failureCount))
@@ -251,8 +269,72 @@ func TestReconciler_RecoveryAfterSuccess(t *testing.T) {
 	if lastError != "" {
 		assert.Fail(t, fmt.Sprintf("expected empty lastError after recovery, got %q", lastError))
 	}
-	if state.shouldBackoff() {
-		assert.Fail(t, "expected shouldBackoff() to be false after recovery")
+}
+
+func TestReconciler_WindowedFailuresTriggerDegraded(t *testing.T) {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	state := newReconcileState(3)
+	state.now = func() time.Time { return now }
+	state.failureWindow = time.Minute
+
+	state.recordFailure(errors.New("boom-1"))
+	now = now.Add(2 * time.Second)
+	state.recordFailure(errors.New("boom-2"))
+	healthState, _, _, _ := state.snapshot()
+	if healthState != PoolHealthy {
+		assert.Fail(t, fmt.Sprintf("expected PoolHealthy after two failures, got %v", healthState))
+	}
+
+	// Failures spread across the window count by rate, not consecutively: gaps of
+	// healthy operation between failures do not reset the count.
+	now = now.Add(2 * time.Second)
+	state.recordFailure(errors.New("boom-3"))
+	healthState, failureCount, _, _ := state.snapshot()
+	if healthState != PoolDegraded {
+		assert.Fail(t, fmt.Sprintf("expected PoolDegraded after three windowed failures, got %v", healthState))
+	}
+	if failureCount != 3 {
+		assert.Fail(t, fmt.Sprintf("expected failureCount 3, got %d", failureCount))
+	}
+}
+
+func TestReconciler_InterleavedCreatesTriggerDegraded(t *testing.T) {
+	// Regression: with the old consecutive-failure counter, every successful warmup reset
+	// the failure count, so a pool with interleaved successes and failures never degraded.
+	// Detection must be rate-based over a sliding window instead.
+	store := NewInMemoryPoolStateStore()
+	_ = store.SetMaxIdle(context.Background(), "test-pool", 5)
+	cfg := defaultTestPoolConfig(store)
+	cfg.WarmupConcurrency = 4
+	cfg.DegradedThreshold = 3
+	state := newReconcileState(cfg.DegradedThreshold)
+
+	var createCount atomic.Int32
+	createFn := func(ctx context.Context, reason PooledSandboxCreateReason) (string, error) {
+		n := createCount.Add(1)
+		if n%2 == 0 {
+			return "", errors.New("create boom")
+		}
+		return fmt.Sprintf("sbx-%d", n), nil
+	}
+	deleteFn := func(sandboxID string) {}
+
+	// Tick 1: 2 successes + 2 failures (batch count reaches 2). Tick 2 adds failures
+	// while successful creates are interleaved; the windowed count crosses the threshold
+	// and degrades the pool. Tick 3 must skip creation due to backoff.
+	reconcileTick(context.Background(), cfg, store, state, testLogger, createFn, deleteFn)
+	reconcileTick(context.Background(), cfg, store, state, testLogger, createFn, deleteFn)
+	reconcileTick(context.Background(), cfg, store, state, testLogger, createFn, deleteFn)
+
+	healthState, failureCount, backoffActive, _ := state.snapshot()
+	if healthState != PoolDegraded {
+		assert.Fail(t, fmt.Sprintf("expected PoolDegraded with interleaved successes, got %v", healthState))
+	}
+	if failureCount < 3 {
+		assert.Fail(t, fmt.Sprintf("expected windowed failureCount >= 3, got %d", failureCount))
+	}
+	if !backoffActive {
+		assert.Fail(t, "expected backoff to be active")
 	}
 }
 

--- a/sdks/sandbox/go/pool_reconciler_test.go
+++ b/sdks/sandbox/go/pool_reconciler_test.go
@@ -363,6 +363,38 @@ func TestReconciler_BackoffCapDoesNotOverflow(t *testing.T) {
 	}
 }
 
+func TestReconciler_SnapshotAdvancesStateMachine(t *testing.T) {
+	// Regression: snapshot() must prune the failure window and run recovery on the read
+	// path. Otherwise a DEGRADED pool with no deficit (idle full) would keep reporting a
+	// stale DEGRADED state and failure count long after the window drained, because
+	// reconcileTick returns before shouldBackoff() in that case.
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	state := newReconcileState(2)
+	state.now = func() time.Time { return now }
+	state.failureWindow = time.Minute
+
+	state.recordFailure(errors.New("fail-1"))
+	state.recordFailure(errors.New("fail-2"))
+
+	// The 60s window drains and the 30s backoff expires; only a snapshot is taken (no
+	// shouldBackoff call). The snapshot itself must recover the pool.
+	now = now.Add(61 * time.Second)
+
+	healthState, failureCount, backoffActive, lastError := state.snapshot()
+	if healthState != PoolHealthy {
+		assert.Fail(t, fmt.Sprintf("expected PoolHealthy after window drain via snapshot, got %v", healthState))
+	}
+	if failureCount != 0 {
+		assert.Fail(t, fmt.Sprintf("expected failureCount 0 after window drain, got %d", failureCount))
+	}
+	if backoffActive {
+		assert.Fail(t, "expected backoff to be inactive after window drain")
+	}
+	if lastError != "" {
+		assert.Fail(t, fmt.Sprintf("expected empty lastError after window drain, got %q", lastError))
+	}
+}
+
 func TestReconciler_ShrinkExcess(t *testing.T) {
 	store := NewInMemoryPoolStateStore()
 	_ = store.SetMaxIdle(context.Background(), "test-pool", 2)

--- a/sdks/sandbox/go/pool_test.go
+++ b/sdks/sandbox/go/pool_test.go
@@ -758,6 +758,56 @@ func TestPool_Snapshot(t *testing.T) {
 	}
 }
 
+func TestPool_SnapshotReflectsRefreshedHealth(t *testing.T) {
+	// Regression: Snapshot() must return the refreshed reconcile health state, not the
+	// cached p.healthState, so it never pairs stale DEGRADED with fresh failure/backoff.
+	execdSrv := newMockExecdServer(t)
+	lifecycleSrv := newMockLifecycleServer(t, execdSrv.URL)
+
+	pool := newTestPool(t, lifecycleSrv.URL)
+	ctx := context.Background()
+
+	err := pool.Start(ctx)
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer pool.Shutdown(ctx, false)
+
+	// Drive the reconcile state into DEGRADED without waiting for a reconcile tick.
+	pool.reconciler.recordFailures(3, errors.New("boom"))
+	snap, err := pool.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	if snap.HealthState != PoolDegraded {
+		t.Errorf("HealthState = %v, want DEGRADED", snap.HealthState)
+	}
+	if !snap.BackoffActive {
+		t.Errorf("BackoffActive = false, want true")
+	}
+
+	// Drain the failure window and expire the backoff: the snapshot read path must recover
+	// the pool by itself (no reconcile tick involved).
+	pool.reconciler.mu.Lock()
+	pool.reconciler.failureTimes = nil
+	pool.reconciler.backoffUntil = time.Now().Add(-time.Second)
+	pool.reconciler.mu.Unlock()
+
+	snap, err = pool.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	if snap.HealthState != PoolHealthy {
+		t.Errorf("HealthState = %v, want HEALTHY after window drain", snap.HealthState)
+	}
+	if snap.FailureCount != 0 {
+		t.Errorf("FailureCount = %d, want 0 after window drain", snap.FailureCount)
+	}
+	if snap.BackoffActive {
+		t.Errorf("BackoffActive = true, want false after window drain")
+	}
+}
+
 func TestPool_SnapshotIdleEntries(t *testing.T) {
 	execdSrv := newMockExecdServer(t)
 	lifecycleSrv := newMockLifecycleServer(t, execdSrv.URL)

--- a/sdks/sandbox/go/pool_types.go
+++ b/sdks/sandbox/go/pool_types.go
@@ -124,10 +124,11 @@ type ReapResult struct {
 
 // PoolSnapshot is a point-in-time snapshot of the pool state.
 type PoolSnapshot struct {
-	LifecycleState     PoolLifecycleState
-	HealthState        PoolHealthState
-	IdleCount          int
-	MaxIdle            int
+	LifecycleState PoolLifecycleState
+	HealthState    PoolHealthState
+	IdleCount      int
+	MaxIdle        int
+	// FailureCount is the number of create failures currently inside the sliding failure window.
 	FailureCount       int
 	BackoffActive      bool
 	LastError          string
@@ -217,10 +218,15 @@ type PoolConfig struct {
 	PrimaryLockTTL    time.Duration
 	ReconcileInterval time.Duration
 	DegradedThreshold int
-	EmptyBehavior     AcquirePolicy
-	StateStore        PoolStateStore
-	ConnectionConfig  ConnectionConfig
-	CreationSpec      PoolCreationSpec
+	// FailureWindow is the sliding time window over which create failures are counted for
+	// degraded detection. A pool enters degraded when at least DegradedThreshold failures fall
+	// inside the window, and stays paused until the window no longer contains that many
+	// failures. Default: 60s.
+	FailureWindow    time.Duration
+	EmptyBehavior    AcquirePolicy
+	StateStore       PoolStateStore
+	ConnectionConfig ConnectionConfig
+	CreationSpec     PoolCreationSpec
 
 	AcquireReadyTimeout               time.Duration
 	WarmupReadyTimeout                time.Duration

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/pool/PoolConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/pool/PoolConfig.kt
@@ -37,7 +37,12 @@ import kotlin.math.ceil
  * @property sandboxCreator Optional custom creator for pool-created sandboxes. When absent, the pool uses
  * [creationSpec] and the standard sandbox lifecycle API.
  * @property reconcileInterval Interval between reconcile ticks (default: 30s).
- * @property degradedThreshold Consecutive create failures required to transition to DEGRADED (default: 3).
+ * @property degradedThreshold Create failures inside [failureWindow] required to transition to DEGRADED
+ * (default: 3). Failures are counted in a sliding time window, not consecutively, so interleaved
+ * successful creates do not reset the count.
+ * @property failureWindow Sliding time window over which create failures are counted for degraded
+ * detection (default: 60s). A pool enters DEGRADED when at least [degradedThreshold] failures fall
+ * inside the window, and remains paused until the window no longer contains that many failures.
  * @property acquireReadyTimeout Max time to wait for a sandbox returned by acquire to become ready (default: 30s).
  * @property acquireHealthCheckPollingInterval Poll interval while waiting for a sandbox returned by acquire to become
  * ready (default: 200ms).
@@ -81,6 +86,7 @@ class PoolConfig private constructor(
     val sandboxCreator: PooledSandboxCreator?,
     val reconcileInterval: Duration,
     val degradedThreshold: Int,
+    val failureWindow: Duration,
     val acquireReadyTimeout: Duration,
     val acquireHealthCheckPollingInterval: Duration,
     val acquireHealthCheck: ((Sandbox) -> Boolean)?,
@@ -101,6 +107,7 @@ class PoolConfig private constructor(
         require(maxIdle >= 0) { "maxIdle must be >= 0" }
         require(warmupConcurrency > 0) { "warmupConcurrency must be positive" }
         require(degradedThreshold > 0) { "degradedThreshold must be positive" }
+        require(!failureWindow.isNegative && !failureWindow.isZero) { "failureWindow must be positive" }
         require(!reconcileInterval.isNegative && !reconcileInterval.isZero) { "reconcileInterval must be positive" }
         require(!primaryLockTtl.isNegative && !primaryLockTtl.isZero) { "primaryLockTtl must be positive" }
         require(!acquireReadyTimeout.isNegative && !acquireReadyTimeout.isZero) {
@@ -127,6 +134,7 @@ class PoolConfig private constructor(
         private val DEFAULT_RECONCILE_INTERVAL = Duration.ofSeconds(30)
         private val DEFAULT_PRIMARY_LOCK_TTL = Duration.ofSeconds(60)
         private const val DEFAULT_DEGRADED_THRESHOLD = 3
+        private val DEFAULT_FAILURE_WINDOW = Duration.ofSeconds(60)
         private val DEFAULT_ACQUIRE_READY_TIMEOUT = Duration.ofSeconds(30)
         private val DEFAULT_ACQUIRE_HEALTH_CHECK_POLLING_INTERVAL = Duration.ofMillis(200)
         private val DEFAULT_ACQUIRE_MIN_REMAINING_TTL_CAP: Duration = Duration.ofSeconds(60)
@@ -168,6 +176,7 @@ class PoolConfig private constructor(
             sandboxCreator = sandboxCreator,
             reconcileInterval = reconcileInterval,
             degradedThreshold = degradedThreshold,
+            failureWindow = failureWindow,
             acquireReadyTimeout = acquireReadyTimeout,
             acquireHealthCheckPollingInterval = acquireHealthCheckPollingInterval,
             acquireHealthCheck = acquireHealthCheck,
@@ -196,6 +205,7 @@ class PoolConfig private constructor(
         private var sandboxCreator: PooledSandboxCreator? = null
         private var reconcileInterval: Duration = DEFAULT_RECONCILE_INTERVAL
         private var degradedThreshold: Int = DEFAULT_DEGRADED_THRESHOLD
+        private var failureWindow: Duration = DEFAULT_FAILURE_WINDOW
         private var acquireReadyTimeout: Duration = DEFAULT_ACQUIRE_READY_TIMEOUT
         private var acquireHealthCheckPollingInterval: Duration = DEFAULT_ACQUIRE_HEALTH_CHECK_POLLING_INTERVAL
         private var acquireHealthCheck: ((Sandbox) -> Boolean)? = null
@@ -262,6 +272,16 @@ class PoolConfig private constructor(
 
         fun degradedThreshold(degradedThreshold: Int): Builder {
             this.degradedThreshold = degradedThreshold
+            return this
+        }
+
+        /**
+         * Sets the sliding time window over which create failures are counted for degraded
+         * detection. A pool enters DEGRADED when at least `degradedThreshold` failures fall inside
+         * the window. Must be positive. Default: 60s.
+         */
+        fun failureWindow(failureWindow: Duration): Builder {
+            this.failureWindow = failureWindow
             return this
         }
 
@@ -374,6 +394,7 @@ class PoolConfig private constructor(
                 sandboxCreator = sandboxCreator,
                 reconcileInterval = reconcileInterval,
                 degradedThreshold = degradedThreshold,
+                failureWindow = failureWindow,
                 acquireReadyTimeout = acquireReadyTimeout,
                 acquireHealthCheckPollingInterval = acquireHealthCheckPollingInterval,
                 acquireHealthCheck = acquireHealthCheck,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/pool/PoolSnapshot.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/pool/PoolSnapshot.kt
@@ -23,7 +23,7 @@ package com.alibaba.opensandbox.sandbox.domain.pool
  * @property lifecycleState Detailed pool lifecycle state.
  * @property idleCount Number of idle sandboxes in the store.
  * @property maxIdle Current max idle target visible to this pool.
- * @property failureCount Number of consecutive reconcile failures currently tracked.
+ * @property failureCount Number of create failures currently inside the sliding failure window.
  * @property backoffActive Whether reconcile create attempts are currently suppressed by backoff.
  * @property lastError Last error message if pool is DEGRADED or after failure; null otherwise.
  * @property inFlightOperations Number of pool operations currently in flight on this node.

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
@@ -137,13 +137,12 @@ internal class ReconcileState(
         state = PoolState.DEGRADED
         backoffAttempts++
         val exponent = (backoffAttempts - 1).coerceAtMost(30)
-        val delaySeconds = backoffBase.seconds * (1L shl exponent)
-        val delayMs =
-            minOf(
-                Duration.ofSeconds(delaySeconds).toMillis(),
-                backoffMax.toMillis(),
-            )
-        backoffUntil = now.plusMillis(delayMs)
+        // Cap the delay in seconds before constructing a Duration: with sustained renewals
+        // backoffAttempts grows without bound, and Duration.ofSeconds on the raw product
+        // (30s << 30) overflows its nanosecond capacity and throws ArithmeticException,
+        // defeating the max check below.
+        val delaySeconds = (backoffBase.seconds * (1L shl exponent)).coerceAtMost(backoffMax.seconds)
+        backoffUntil = now.plusSeconds(delaySeconds)
     }
 
     private fun recover() {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
@@ -21,14 +21,28 @@ import java.time.Duration
 import java.time.Instant
 
 /**
- * Mutable state for reconcile loop: failure count, pool state, and exponential backoff.
+ * Mutable state for reconcile loop: sliding-window failure detection, pool state, and exponential
+ * backoff.
+ *
+ * Degradation is detected by failure *rate* rather than consecutive failures: every failure is
+ * recorded with a timestamp and ages out of [failureWindow]. The pool enters DEGRADED and opens an
+ * exponential backoff window once [degradedThreshold] failures are present inside the window.
+ * Successful creates never reset the window (recovery is time-based, not success-based), and an
+ * active backoff window is never cancelled by a success.
+ *
+ * While DEGRADED, an expired backoff window is renewed automatically whenever the failure window
+ * is still hot, so the pool stays paused until the failure rate actually drops below the
+ * threshold. The pool returns to HEALTHY only once the failure window drains and no backoff is
+ * active.
  *
  * Thread-safe for use from reconcile worker and from pool snapshot.
  */
 internal class ReconcileState(
     private val degradedThreshold: Int,
+    private val failureWindow: Duration = Duration.ofSeconds(60),
     private val backoffBase: Duration = Duration.ofSeconds(30),
     private val backoffMax: Duration = Duration.ofDays(1),
+    private val clock: () -> Instant = Instant::now,
 ) {
     @Volatile
     var failureCount: Int = 0
@@ -47,35 +61,24 @@ internal class ReconcileState(
 
     private var backoffAttempts: Int = 0
 
-    @Synchronized
-    fun recordSuccess() {
-        failureCount = 0
-        if (state == PoolState.DEGRADED) state = PoolState.HEALTHY
-        backoffUntil = null
-        backoffAttempts = 0
-        lastError = null
-    }
-
-    @Synchronized
-    fun recordFailure(errorMessage: String?) {
-        recordFailures(1, errorMessage)
-    }
+    private val failureTimestamps: ArrayDeque<Instant> = ArrayDeque()
 
     /**
-     * Records one independently completed rolling-window warmup failure.
+     * Records one independently completed warmup failure.
      *
-     * Unlike batch failure accounting, multiple tasks that finish while the same backoff window
-     * is active must not advance the exponential delay once per completion. The first failure
-     * that reaches the threshold opens (or, after expiry, advances) one backoff window; remaining
-     * in-flight failures only update counters and the last error.
+     * Multiple tasks that finish while the same backoff window is active must not advance the
+     * exponential delay once per completion: the first failure that reaches the threshold opens
+     * (or, after expiry, advances) one backoff window; remaining in-flight failures only update
+     * counters and the last error.
      */
     @Synchronized
     fun recordAsyncFailure(errorMessage: String?) {
-        failureCount++
+        val now = clock()
+        failureTimestamps.addLast(now)
+        pruneExpired(now)
         lastError = errorMessage
         if (failureCount < degradedThreshold) return
 
-        val now = Instant.now()
         val activeUntil = backoffUntil
         if (state == PoolState.DEGRADED && activeUntil != null && now.isBefore(activeUntil)) {
             return
@@ -84,15 +87,49 @@ internal class ReconcileState(
     }
 
     @Synchronized
+    fun recordFailure(errorMessage: String?) {
+        recordFailures(1, errorMessage)
+    }
+
+    @Synchronized
     fun recordFailures(
         count: Int,
         errorMessage: String?,
     ) {
         if (count <= 0) return
-        failureCount += count
+        val now = clock()
+        repeat(count) { failureTimestamps.addLast(now) }
+        pruneExpired(now)
         lastError = errorMessage
-        if (failureCount >= degradedThreshold) {
-            activateNextBackoff(Instant.now())
+        if (failureCount < degradedThreshold) return
+
+        val activeUntil = backoffUntil
+        if (state == PoolState.DEGRADED && activeUntil != null && now.isBefore(activeUntil)) {
+            return
+        }
+        activateNextBackoff(now)
+    }
+
+    /**
+     * True if the reconciler should skip create attempts this tick (in backoff window).
+     *
+     * Advances the state machine on the read path: while DEGRADED, an expired backoff window is
+     * renewed when the failure window is still hot, so the pool stays paused until the failure
+     * rate falls below the threshold; once the failure window drains and no backoff is active,
+     * the pool recovers to HEALTHY.
+     */
+    @Synchronized
+    fun isBackoffActive(now: Instant = clock()): Boolean {
+        pruneExpired(now)
+        val until = backoffUntil
+        if (state != PoolState.DEGRADED || until == null) return false
+        if (now.isBefore(until)) return true
+        return if (failureCount >= degradedThreshold) {
+            activateNextBackoff(now)
+            true
+        } else {
+            recover()
+            false
         }
     }
 
@@ -109,9 +146,18 @@ internal class ReconcileState(
         backoffUntil = now.plusMillis(delayMs)
     }
 
-    /** True if reconciler should skip create attempts this tick (in backoff window). */
-    fun isBackoffActive(now: Instant = Instant.now()): Boolean {
-        val until = backoffUntil ?: return false
-        return state == PoolState.DEGRADED && now.isBefore(until)
+    private fun recover() {
+        state = PoolState.HEALTHY
+        backoffUntil = null
+        backoffAttempts = 0
+        lastError = null
+    }
+
+    private fun pruneExpired(now: Instant) {
+        val cutoff = now.minus(failureWindow)
+        while (failureTimestamps.isNotEmpty() && failureTimestamps.first().isBefore(cutoff)) {
+            failureTimestamps.removeFirst()
+        }
+        failureCount = failureTimestamps.size
     }
 }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -583,6 +583,9 @@ class SandboxPool internal constructor(
      */
     fun snapshot(): PoolSnapshot {
         val lifecycleState = lifecycleState.get()
+        // Advance the reconcile state machine first (prune/renew/recover) so readers never
+        // observe a stale DEGRADED state, failure count, or last error after the window drained.
+        val backoffActive = reconcileState.isBackoffActive()
         val state =
             when (lifecycleState) {
                 LifecycleState.NOT_STARTED,
@@ -598,7 +601,7 @@ class SandboxPool internal constructor(
             idleCount = counters.idleCount,
             maxIdle = resolveMaxIdle(),
             failureCount = reconcileState.failureCount,
-            backoffActive = reconcileState.isBackoffActive(),
+            backoffActive = backoffActive,
             lastError = reconcileState.lastError,
             inFlightOperations = currentRun?.inFlightOperations?.get() ?: 0,
         )

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -112,7 +112,7 @@ class SandboxPool internal constructor(
     private val connectionConfig: ConnectionConfig = config.connectionConfig
     private val creationSpec: PoolCreationSpec = config.creationSpec
     private val sandboxCreator: PooledSandboxCreator? = config.sandboxCreator
-    private val reconcileState = ReconcileState(config.degradedThreshold)
+    private val reconcileState = ReconcileState(config.degradedThreshold, config.failureWindow)
 
     @Volatile
     private var currentMaxIdle: Int = config.maxIdle
@@ -1136,7 +1136,6 @@ class SandboxPool internal constructor(
                         cleanupSource = "warmup-lock-lost"
                     } else {
                         stateStore.putIdle(config.poolName, sandboxId)
-                        reconcileState.recordSuccess()
                         logger.debug(
                             "Pool warmup sandbox entered idle: pool_name={} sandbox_id={} run={}",
                             config.poolName,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -1803,6 +1803,11 @@ class SandboxPool internal constructor(
             return this
         }
 
+        fun failureWindow(failureWindow: Duration): Builder {
+            configBuilder.failureWindow(failureWindow)
+            return this
+        }
+
         fun acquireReadyTimeout(acquireReadyTimeout: Duration): Builder {
             configBuilder.acquireReadyTimeout(acquireReadyTimeout)
             return this

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
@@ -24,6 +24,7 @@ import com.alibaba.opensandbox.sandbox.domain.pool.PoolStateStore
 import com.alibaba.opensandbox.sandbox.domain.pool.StoreCounters
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant
@@ -110,6 +111,28 @@ class PoolReconcilerStateTest {
         assertFalse(state.isBackoffActive(clock.now.plus(Duration.ofHours(25))))
         assertEquals(PoolState.HEALTHY, state.state)
         assertEquals(0, state.failureCount)
+    }
+
+    @Test
+    fun `backoff escalation stays capped at one day under sustained renewals`() {
+        val clock = MutableClock(Instant.parse("2025-01-01T00:00:00Z"))
+        val state =
+            ReconcileState(
+                degradedThreshold = 1,
+                failureWindow = Duration.ofDays(100),
+                clock = { clock.now },
+            )
+
+        // Each failure lands just after the previous backoff window (at most one day), forcing
+        // a new escalation. The 31st activation must not overflow Duration's nanosecond
+        // capacity and must stay capped at backoffMax.
+        repeat(40) {
+            clock.advance(Duration.ofSeconds(86_401))
+            state.recordAsyncFailure("boom")
+        }
+
+        assertEquals(PoolState.DEGRADED, state.state)
+        assertTrue(state.isBackoffActive())
     }
 
     @Test

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
@@ -30,51 +30,104 @@ import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
 class PoolReconcilerStateTest {
+    private class MutableClock(var now: Instant) {
+        fun advance(amount: Duration) {
+            now = now.plus(amount)
+        }
+    }
+
     @Test
-    fun `recordFailure transitions to DEGRADED when failure count reaches threshold`() {
-        val state = ReconcileState(degradedThreshold = 3, backoffBase = Duration.ofMillis(10), backoffMax = Duration.ofSeconds(1))
+    fun `recordFailures transitions to DEGRADED when windowed count reaches threshold`() {
+        val clock = MutableClock(Instant.parse("2025-01-01T00:00:00Z"))
+        val state =
+            ReconcileState(
+                degradedThreshold = 3,
+                failureWindow = Duration.ofSeconds(60),
+                backoffBase = Duration.ofMillis(10),
+                backoffMax = Duration.ofSeconds(1),
+                clock = { clock.now },
+            )
         state.recordFailure("boom-1")
+        clock.advance(Duration.ofSeconds(1))
         state.recordFailure("boom-2")
         assertEquals(PoolState.HEALTHY, state.state)
         assertFalse(state.isBackoffActive())
 
+        clock.advance(Duration.ofSeconds(1))
         state.recordFailure("boom-3")
         assertEquals(PoolState.DEGRADED, state.state)
         assertEquals(3, state.failureCount)
     }
 
     @Test
-    fun `default degraded backoff caps at one day`() {
-        val state = ReconcileState(degradedThreshold = 1)
+    fun `windowed failures trigger DEGRADED even when spread across the window`() {
+        val clock = MutableClock(Instant.parse("2025-01-01T00:00:00Z"))
+        val state = ReconcileState(degradedThreshold = 3, clock = { clock.now })
 
-        repeat(20) { state.recordFailure("boom") }
+        state.recordAsyncFailure("boom-1")
+        clock.advance(Duration.ofSeconds(2))
+        state.recordAsyncFailure("boom-2")
+        assertEquals(PoolState.HEALTHY, state.state)
 
+        // The detection window counts failures by rate, not consecutively: a gap of healthy
+        // operation between failures (interleaved successes) does not reset the count.
+        clock.advance(Duration.ofSeconds(2))
+        state.recordAsyncFailure("boom-3")
         assertEquals(PoolState.DEGRADED, state.state)
-        assertEquals(20, state.failureCount)
-        assertEquals(true, state.isBackoffActive(Instant.now().plus(Duration.ofHours(23))))
-        assertFalse(state.isBackoffActive(Instant.now().plus(Duration.ofHours(25))))
+        assertEquals(3, state.failureCount)
     }
 
     @Test
     fun `default degraded backoff starts at thirty seconds`() {
-        val state = ReconcileState(degradedThreshold = 1)
+        val clock = MutableClock(Instant.parse("2025-01-01T00:00:00Z"))
+        val state = ReconcileState(degradedThreshold = 1, clock = { clock.now })
 
         state.recordFailure("boom")
 
-        assertEquals(true, state.isBackoffActive(Instant.now().plus(Duration.ofSeconds(29))))
-        assertFalse(state.isBackoffActive(Instant.now().plus(Duration.ofSeconds(31))))
+        assertEquals(true, state.isBackoffActive(clock.now.plus(Duration.ofSeconds(29))))
+        // The 30s backoff expires at t=30, but the failure is still inside the 60s window, so
+        // the backoff is renewed (t=30 -> t=91) and the pool stays paused.
+        assertEquals(true, state.isBackoffActive(clock.now.plus(Duration.ofSeconds(31))))
+        assertFalse(state.isBackoffActive(clock.now.plus(Duration.ofSeconds(92))))
+        assertEquals(PoolState.HEALTHY, state.state)
+        assertEquals(0, state.failureCount)
+        assertEquals(null, state.lastError)
     }
 
     @Test
-    fun `rolling failures advance backoff once while current window is active`() {
-        val state = ReconcileState(degradedThreshold = 3)
+    fun `sustained failures keep backoff active and recovery follows window drain`() {
+        val clock = MutableClock(Instant.parse("2025-01-01T00:00:00Z"))
+        val state = ReconcileState(degradedThreshold = 1, clock = { clock.now })
 
-        repeat(10) { state.recordAsyncFailure("boom-$it") }
+        repeat(5_000) {
+            clock.advance(Duration.ofSeconds(30))
+            state.recordFailure("boom")
+        }
 
-        assertEquals(10, state.failureCount)
         assertEquals(PoolState.DEGRADED, state.state)
-        assertEquals(true, state.isBackoffActive(Instant.now().plus(Duration.ofSeconds(29))))
-        assertFalse(state.isBackoffActive(Instant.now().plus(Duration.ofSeconds(31))))
+        assertEquals(true, state.isBackoffActive())
+        // Once failures stop, the pool stays paused until the failure window drains.
+        assertFalse(state.isBackoffActive(clock.now.plus(Duration.ofHours(25))))
+        assertEquals(PoolState.HEALTHY, state.state)
+        assertEquals(0, state.failureCount)
+    }
+
+    @Test
+    fun `in-window failures do not advance backoff per completion`() {
+        val clock = MutableClock(Instant.parse("2025-01-01T00:00:00Z"))
+        val state = ReconcileState(degradedThreshold = 3, clock = { clock.now })
+
+        repeat(3) { state.recordAsyncFailure("boom") }
+        repeat(6) {
+            clock.advance(Duration.ofSeconds(5))
+            state.recordAsyncFailure("boom")
+        }
+
+        assertEquals(9, state.failureCount)
+        // Exactly one escalation: the 30s window opened at t=0 and was renewed once at expiry
+        // (t=30 -> t=90), not once per in-window failure completion.
+        assertEquals(true, state.isBackoffActive(clock.now.plus(Duration.ofSeconds(59))))
+        assertFalse(state.isBackoffActive(clock.now.plus(Duration.ofSeconds(61))))
     }
 
     @Test

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -323,6 +323,50 @@ class SandboxPoolTest {
     }
 
     @Test
+    fun `interleaved warmup successes and failures still trigger degraded backoff`() {
+        // Regression: with the old consecutive-failure counter, every successful warmup reset
+        // the failure count, so a pool with interleaved successes and failures never degraded.
+        // Detection must be rate-based over a sliding window instead.
+        val store = AlternatingPutIdleFailureStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val createAttempts = AtomicInteger(0)
+        val pool =
+            SandboxPool(
+                config =
+                    PoolConfig.builder()
+                        .poolName("mixed-outcome-pool")
+                        .ownerId("mixed-owner")
+                        .maxIdle(5)
+                        .warmupConcurrency(3)
+                        .degradedThreshold(3)
+                        .stateStore(store)
+                        .connectionConfig(ConnectionConfig.builder().build())
+                        .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                        .sandboxCreator(
+                            PooledSandboxCreator {
+                                val attempt = createAttempts.getAndIncrement()
+                                mockk<Sandbox>(relaxed = true).apply {
+                                    every { id } returns "sandbox-$attempt"
+                                }
+                            },
+                        ).warmupSkipHealthCheck()
+                        .reconcileInterval(Duration.ofSeconds(30))
+                        .build(),
+                sandboxManagerFactory = { manager },
+            )
+
+        pool.start()
+        try {
+            awaitCondition { pool.snapshot().backoffActive }
+            assertEquals(PoolState.DEGRADED, pool.snapshot().state)
+            // Successful warmups were interleaved with the failures; the rate detector still fired.
+            assertTrue(store.succeededIds.isNotEmpty())
+        } finally {
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
     fun `shutdown graceful waits for in-flight warmup without interrupting it`() {
         val store = InMemoryPoolStateStore()
         val sandbox = mockk<Sandbox>(relaxed = true)
@@ -2204,6 +2248,24 @@ class SandboxPoolTest {
             sandboxId: String,
         ) {
             throw RuntimeException("put failed")
+        }
+    }
+
+    private class AlternatingPutIdleFailureStore : PoolStateStore by InMemoryPoolStateStore() {
+        val succeededIds: List<String> = java.util.Collections.synchronizedList(mutableListOf())
+        private val putIdleCalls = AtomicInteger(0)
+        private val delegate = InMemoryPoolStateStore()
+
+        override fun putIdle(
+            poolName: String,
+            sandboxId: String,
+        ) {
+            if (putIdleCalls.getAndIncrement() % 2 == 0) {
+                (succeededIds as MutableList<String>).add(sandboxId)
+                delegate.putIdle(poolName, sandboxId)
+            } else {
+                throw RuntimeException("put failed")
+            }
         }
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -2009,6 +2009,28 @@ class SandboxPoolTest {
     }
 
     @Test
+    fun `sandbox pool builder forwards degraded detection settings into config`() {
+        val pool =
+            SandboxPool.builder()
+                .poolName("test-pool")
+                .ownerId("test-owner")
+                .maxIdle(2)
+                .stateStore(InMemoryPoolStateStore())
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .degradedThreshold(5)
+                .failureWindow(Duration.ofMinutes(2))
+                .build()
+
+        val configField = pool.javaClass.getDeclaredField("config")
+        configField.isAccessible = true
+        val config = configField.get(pool) as com.alibaba.opensandbox.sandbox.domain.pool.PoolConfig
+
+        assertEquals(5, config.degradedThreshold)
+        assertEquals(Duration.ofMinutes(2), config.failureWindow)
+    }
+
+    @Test
     fun `start aligns state store idle ttl hook with idleTimeout`() {
         val store = InMemoryPoolStateStore()
         val pool =

--- a/sdks/sandbox/python/src/opensandbox/_async_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_async_pool_reconciler.py
@@ -122,7 +122,6 @@ async def _run_primary_replenish_once(
         try:
             await state_store.put_idle(pool_name, sandbox_id)
             created += 1
-            reconcile_state.record_success()
         except Exception as exc:
             reconcile_state.record_failure(str(exc))
             for orphaned_id in created_ids[index:]:

--- a/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from concurrent.futures import Executor, wait
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
 from opensandbox.pool_types import (
@@ -37,7 +37,22 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ReconcileState:
+    """Sliding-window failure detection, pool state, and exponential backoff.
+
+    Degradation is detected by failure *rate* rather than consecutive failures: every failure is
+    recorded with a timestamp and ages out of ``failure_window``. The pool enters DEGRADED and
+    opens an exponential backoff window once ``degraded_threshold`` failures are present inside
+    the window. Successful creates never reset the window (recovery is time-based, not
+    success-based), and an active backoff window is never cancelled by a success.
+
+    While DEGRADED, an expired backoff window is renewed automatically whenever the failure
+    window is still hot, so the pool stays paused until the failure rate actually drops below the
+    threshold. The pool returns to HEALTHY only once the failure window drains and no backoff is
+    active.
+    """
+
     degraded_threshold: int
+    failure_window: timedelta = timedelta(seconds=60)
     backoff_base: timedelta = timedelta(seconds=30)
     backoff_max: timedelta = timedelta(days=1)
     failure_count: int = 0
@@ -45,14 +60,7 @@ class ReconcileState:
     last_error: str | None = None
     backoff_until: datetime | None = None
     backoff_attempts: int = 0
-
-    def record_success(self) -> None:
-        self.failure_count = 0
-        if self.state == PoolState.DEGRADED:
-            self.state = PoolState.HEALTHY
-        self.backoff_until = None
-        self.backoff_attempts = 0
-        self.last_error = None
+    _failure_timestamps: list[datetime] = field(default_factory=list, repr=False)
 
     def record_failure(self, error_message: str | None) -> None:
         self.record_failures(1, error_message)
@@ -60,26 +68,56 @@ class ReconcileState:
     def record_failures(self, count: int, error_message: str | None) -> None:
         if count <= 0:
             return
-        self.failure_count += count
+        now = datetime.now(timezone.utc)
+        self._failure_timestamps.extend([now] * count)
+        self._prune_expired(now)
         self.last_error = error_message
-        if self.failure_count >= self.degraded_threshold:
-            self.state = PoolState.DEGRADED
-            self.backoff_attempts += 1
-            exponent = min(self.backoff_attempts - 1, 30)
-            delay = min(
-                self.backoff_base.total_seconds() * (1 << exponent),
-                self.backoff_max.total_seconds(),
-            )
-            self.backoff_until = datetime.now(timezone.utc) + timedelta(seconds=delay)
+        if self.failure_count < self.degraded_threshold:
+            return
+        if (
+            self.state == PoolState.DEGRADED
+            and self.backoff_until is not None
+            and now < self.backoff_until
+        ):
+            return
+        self._activate_next_backoff(now)
 
     def is_backoff_active(self, now: datetime | None = None) -> bool:
+        now = now or datetime.now(timezone.utc)
+        self._prune_expired(now)
         until = self.backoff_until
-        if until is None:
+        if self.state != PoolState.DEGRADED or until is None:
             return False
-        return (
-            self.state == PoolState.DEGRADED
-            and (now or datetime.now(timezone.utc)) < until
+        if now < until:
+            return True
+        if self.failure_count >= self.degraded_threshold:
+            self._activate_next_backoff(now)
+            return True
+        self._recover()
+        return False
+
+    def _activate_next_backoff(self, now: datetime) -> None:
+        self.state = PoolState.DEGRADED
+        self.backoff_attempts += 1
+        exponent = min(self.backoff_attempts - 1, 30)
+        delay = min(
+            self.backoff_base.total_seconds() * (1 << exponent),
+            self.backoff_max.total_seconds(),
         )
+        self.backoff_until = now + timedelta(seconds=delay)
+
+    def _recover(self) -> None:
+        self.state = PoolState.HEALTHY
+        self.backoff_until = None
+        self.backoff_attempts = 0
+        self.last_error = None
+
+    def _prune_expired(self, now: datetime) -> None:
+        cutoff = now - self.failure_window
+        self._failure_timestamps = [
+            ts for ts in self._failure_timestamps if not ts < cutoff
+        ]
+        self.failure_count = len(self._failure_timestamps)
 
 
 def run_reconcile_tick(
@@ -175,7 +213,6 @@ def _run_primary_replenish_once(
         try:
             state_store.put_idle(pool_name, sandbox_id)
             created += 1
-            reconcile_state.record_success()
         except Exception as exc:
             reconcile_state.record_failure(str(exc))
             for orphaned_id in created_ids[index:]:

--- a/sdks/sandbox/python/src/opensandbox/pool_async.py
+++ b/sdks/sandbox/python/src/opensandbox/pool_async.py
@@ -77,7 +77,6 @@ class SandboxPoolAsync:
         primary_lock_ttl: timedelta = timedelta(seconds=60),
         reconcile_interval: timedelta = timedelta(seconds=30),
         degraded_threshold: int = 3,
-        failure_window: timedelta = timedelta(seconds=60),
         acquire_ready_timeout: timedelta = timedelta(seconds=30),
         acquire_health_check_polling_interval: timedelta = timedelta(milliseconds=200),
         acquire_health_check: Callable[[Sandbox], Awaitable[bool]] | None = None,
@@ -96,6 +95,9 @@ class SandboxPoolAsync:
         ] = SandboxManager.create,
         sandbox_factory: type[Sandbox] = Sandbox,
         sandbox_creator: AsyncPooledSandboxCreator | None = None,
+        # Appended after all pre-existing parameters so positional calls stay backward
+        # compatible.
+        failure_window: timedelta = timedelta(seconds=60),
     ) -> None:
         self._config = AsyncPoolConfig(
             pool_name=pool_name,

--- a/sdks/sandbox/python/src/opensandbox/pool_async.py
+++ b/sdks/sandbox/python/src/opensandbox/pool_async.py
@@ -474,6 +474,9 @@ class SandboxPoolAsync:
         return len(sandbox_ids)
 
     async def snapshot(self) -> PoolSnapshot:
+        # Advance the reconcile state machine first (prune/renew/recover) so readers never
+        # observe a stale DEGRADED state, failure count, or last error after the window drained.
+        backoff_active = self._reconcile_state.is_backoff_active()
         lifecycle_state = self._lifecycle_state
         if lifecycle_state in (
             PoolLifecycleState.NOT_STARTED,
@@ -491,7 +494,7 @@ class SandboxPoolAsync:
             idle_count=counters.idle_count,
             max_idle=await self._resolve_max_idle(),
             failure_count=self._reconcile_state.failure_count,
-            backoff_active=self._reconcile_state.is_backoff_active(),
+            backoff_active=backoff_active,
             last_error=self._reconcile_state.last_error,
             in_flight_operations=self._in_flight,
         )

--- a/sdks/sandbox/python/src/opensandbox/pool_async.py
+++ b/sdks/sandbox/python/src/opensandbox/pool_async.py
@@ -77,6 +77,7 @@ class SandboxPoolAsync:
         primary_lock_ttl: timedelta = timedelta(seconds=60),
         reconcile_interval: timedelta = timedelta(seconds=30),
         degraded_threshold: int = 3,
+        failure_window: timedelta = timedelta(seconds=60),
         acquire_ready_timeout: timedelta = timedelta(seconds=30),
         acquire_health_check_polling_interval: timedelta = timedelta(milliseconds=200),
         acquire_health_check: Callable[[Sandbox], Awaitable[bool]] | None = None,
@@ -107,6 +108,7 @@ class SandboxPoolAsync:
             creation_spec=creation_spec,
             reconcile_interval=reconcile_interval,
             degraded_threshold=degraded_threshold,
+            failure_window=failure_window,
             acquire_ready_timeout=acquire_ready_timeout,
             acquire_health_check_polling_interval=acquire_health_check_polling_interval,
             acquire_health_check=acquire_health_check,
@@ -127,7 +129,7 @@ class SandboxPoolAsync:
         self._creation_spec = creation_spec
         self._sandbox_manager_factory = sandbox_manager_factory
         self._sandbox_factory = sandbox_factory
-        self._reconcile_state = ReconcileState(degraded_threshold)
+        self._reconcile_state = ReconcileState(degraded_threshold, failure_window)
         self._current_max_idle = max_idle
         self._lifecycle_state = PoolLifecycleState.NOT_STARTED
         self._lifecycle_lock = asyncio.Lock()

--- a/sdks/sandbox/python/src/opensandbox/pool_types.py
+++ b/sdks/sandbox/python/src/opensandbox/pool_types.py
@@ -340,7 +340,6 @@ class PoolConfig:
     primary_lock_ttl: timedelta = timedelta(seconds=60)
     reconcile_interval: timedelta = timedelta(seconds=30)
     degraded_threshold: int = 3
-    failure_window: timedelta = timedelta(seconds=60)
     acquire_ready_timeout: timedelta = timedelta(seconds=30)
     acquire_health_check_polling_interval: timedelta = timedelta(milliseconds=200)
     acquire_health_check: Callable[[SandboxSync], bool] | None = None
@@ -355,6 +354,9 @@ class PoolConfig:
     acquire_min_remaining_ttl: timedelta | None = None
     sandbox_creator: PooledSandboxCreator | None = None
     max_acquire_retries: int = 3
+    # Appended after all pre-existing fields so positional construction stays backward
+    # compatible (exported dataclass constructors accept positional arguments).
+    failure_window: timedelta = timedelta(seconds=60)
 
     def __post_init__(self) -> None:
         owner_id = self.owner_id or f"pool-owner-{uuid4()}"
@@ -420,7 +422,6 @@ class AsyncPoolConfig:
     primary_lock_ttl: timedelta = timedelta(seconds=60)
     reconcile_interval: timedelta = timedelta(seconds=30)
     degraded_threshold: int = 3
-    failure_window: timedelta = timedelta(seconds=60)
     acquire_ready_timeout: timedelta = timedelta(seconds=30)
     acquire_health_check_polling_interval: timedelta = timedelta(milliseconds=200)
     acquire_health_check: Callable[[Sandbox], Awaitable[bool]] | None = None
@@ -435,6 +436,9 @@ class AsyncPoolConfig:
     acquire_min_remaining_ttl: timedelta | None = None
     sandbox_creator: AsyncPooledSandboxCreator | None = None
     max_acquire_retries: int = 3
+    # Appended after all pre-existing fields so positional construction stays backward
+    # compatible (exported dataclass constructors accept positional arguments).
+    failure_window: timedelta = timedelta(seconds=60)
 
     def __post_init__(self) -> None:
         owner_id = self.owner_id or f"pool-owner-{uuid4()}"

--- a/sdks/sandbox/python/src/opensandbox/pool_types.py
+++ b/sdks/sandbox/python/src/opensandbox/pool_types.py
@@ -340,6 +340,7 @@ class PoolConfig:
     primary_lock_ttl: timedelta = timedelta(seconds=60)
     reconcile_interval: timedelta = timedelta(seconds=30)
     degraded_threshold: int = 3
+    failure_window: timedelta = timedelta(seconds=60)
     acquire_ready_timeout: timedelta = timedelta(seconds=30)
     acquire_health_check_polling_interval: timedelta = timedelta(milliseconds=200)
     acquire_health_check: Callable[[SandboxSync], bool] | None = None
@@ -371,6 +372,7 @@ class PoolConfig:
             raise ValueError("warmup_concurrency must be positive")
         if self.degraded_threshold <= 0:
             raise ValueError("degraded_threshold must be positive")
+        _require_positive(self.failure_window, "failure_window must be positive")
         _require_positive(self.primary_lock_ttl, "primary_lock_ttl must be positive")
         _require_positive(
             self.reconcile_interval, "reconcile_interval must be positive"
@@ -418,6 +420,7 @@ class AsyncPoolConfig:
     primary_lock_ttl: timedelta = timedelta(seconds=60)
     reconcile_interval: timedelta = timedelta(seconds=30)
     degraded_threshold: int = 3
+    failure_window: timedelta = timedelta(seconds=60)
     acquire_ready_timeout: timedelta = timedelta(seconds=30)
     acquire_health_check_polling_interval: timedelta = timedelta(milliseconds=200)
     acquire_health_check: Callable[[Sandbox], Awaitable[bool]] | None = None
@@ -449,6 +452,7 @@ class AsyncPoolConfig:
             raise ValueError("warmup_concurrency must be positive")
         if self.degraded_threshold <= 0:
             raise ValueError("degraded_threshold must be positive")
+        _require_positive(self.failure_window, "failure_window must be positive")
         _require_positive(self.primary_lock_ttl, "primary_lock_ttl must be positive")
         _require_positive(
             self.reconcile_interval, "reconcile_interval must be positive"

--- a/sdks/sandbox/python/src/opensandbox/sync/pool.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/pool.py
@@ -462,6 +462,9 @@ class SandboxPoolSync:
         return len(sandbox_ids)
 
     def snapshot(self) -> PoolSnapshot:
+        # Advance the reconcile state machine first (prune/renew/recover) so readers never
+        # observe a stale DEGRADED state, failure count, or last error after the window drained.
+        backoff_active = self._reconcile_state.is_backoff_active()
         lifecycle_state = self._lifecycle_state
         if lifecycle_state in (
             PoolLifecycleState.NOT_STARTED,
@@ -479,7 +482,7 @@ class SandboxPoolSync:
             idle_count=counters.idle_count,
             max_idle=self._resolve_max_idle(),
             failure_count=self._reconcile_state.failure_count,
-            backoff_active=self._reconcile_state.is_backoff_active(),
+            backoff_active=backoff_active,
             last_error=self._reconcile_state.last_error,
             in_flight_operations=self._in_flight,
         )

--- a/sdks/sandbox/python/src/opensandbox/sync/pool.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/pool.py
@@ -76,6 +76,7 @@ class SandboxPoolSync:
         primary_lock_ttl: timedelta = timedelta(seconds=60),
         reconcile_interval: timedelta = timedelta(seconds=30),
         degraded_threshold: int = 3,
+        failure_window: timedelta = timedelta(seconds=60),
         acquire_ready_timeout: timedelta = timedelta(seconds=30),
         acquire_health_check_polling_interval: timedelta = timedelta(milliseconds=200),
         acquire_health_check: Callable[[SandboxSync], bool] | None = None,
@@ -106,6 +107,7 @@ class SandboxPoolSync:
             creation_spec=creation_spec,
             reconcile_interval=reconcile_interval,
             degraded_threshold=degraded_threshold,
+            failure_window=failure_window,
             acquire_ready_timeout=acquire_ready_timeout,
             acquire_health_check_polling_interval=acquire_health_check_polling_interval,
             acquire_health_check=acquire_health_check,
@@ -126,7 +128,7 @@ class SandboxPoolSync:
         self._creation_spec = creation_spec
         self._sandbox_manager_factory = sandbox_manager_factory
         self._sandbox_factory = sandbox_factory
-        self._reconcile_state = ReconcileState(degraded_threshold)
+        self._reconcile_state = ReconcileState(degraded_threshold, failure_window)
         self._current_max_idle = max_idle
         self._lifecycle_state = PoolLifecycleState.NOT_STARTED
         self._lifecycle_lock = threading.RLock()

--- a/sdks/sandbox/python/src/opensandbox/sync/pool.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/pool.py
@@ -76,7 +76,6 @@ class SandboxPoolSync:
         primary_lock_ttl: timedelta = timedelta(seconds=60),
         reconcile_interval: timedelta = timedelta(seconds=30),
         degraded_threshold: int = 3,
-        failure_window: timedelta = timedelta(seconds=60),
         acquire_ready_timeout: timedelta = timedelta(seconds=30),
         acquire_health_check_polling_interval: timedelta = timedelta(milliseconds=200),
         acquire_health_check: Callable[[SandboxSync], bool] | None = None,
@@ -95,6 +94,9 @@ class SandboxPoolSync:
         ] = SandboxManagerSync.create,
         sandbox_factory: type[SandboxSync] = SandboxSync,
         sandbox_creator: PooledSandboxCreator | None = None,
+        # Appended after all pre-existing parameters so positional calls stay backward
+        # compatible.
+        failure_window: timedelta = timedelta(seconds=60),
     ) -> None:
         self._config = PoolConfig(
             pool_name=pool_name,

--- a/sdks/sandbox/python/tests/test_pool_async.py
+++ b/sdks/sandbox/python/tests/test_pool_async.py
@@ -41,6 +41,7 @@ from opensandbox.pool import (
     PooledSandboxCreateReason,
     SandboxPoolAsync,
 )
+from opensandbox.pool_types import PoolState
 
 
 @pytest.mark.asyncio
@@ -210,9 +211,12 @@ async def test_async_reconcile_batch_failures_only_advance_backoff_once() -> Non
 
     assert state.failure_count == 10
     assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=29))
+    # The window is still hot when the 30s backoff expires, so the pool stays paused.
+    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=31))
     assert not state.is_backoff_active(
-        datetime.now(timezone.utc) + timedelta(seconds=31)
+        datetime.now(timezone.utc) + timedelta(seconds=92)
     )
+    assert state.state == PoolState.HEALTHY
 
 
 @pytest.mark.asyncio

--- a/sdks/sandbox/python/tests/test_pool_config.py
+++ b/sdks/sandbox/python/tests/test_pool_config.py
@@ -156,19 +156,47 @@ def test_async_pool_config_positional_owner_id_stays_compatible() -> None:
     assert config.sandbox_creator is None
 
 
+def test_sync_pool_config_positional_after_degraded_threshold_stays_compatible() -> None:
+    # failure_window is appended after all pre-existing fields: positional calls that reach
+    # the acquire/warmup options must keep their meaning.
+    kwargs = _sync_kwargs()
+    config = PoolConfig(
+        kwargs["pool_name"],  # type: ignore[arg-type]
+        kwargs["max_idle"],  # type: ignore[arg-type]
+        kwargs["state_store"],  # type: ignore[arg-type]
+        kwargs["connection_config"],  # type: ignore[arg-type]
+        kwargs["creation_spec"],  # type: ignore[arg-type]
+        "owner-1",
+        4,  # warmup_concurrency
+        timedelta(seconds=60),  # primary_lock_ttl
+        timedelta(seconds=30),  # reconcile_interval
+        3,  # degraded_threshold
+        timedelta(seconds=15),  # acquire_ready_timeout
+    )
+
+    assert config.warmup_concurrency == 4
+    assert config.degraded_threshold == 3
+    assert config.acquire_ready_timeout == timedelta(seconds=15)
+    assert config.failure_window == timedelta(seconds=60)
+
+
 def test_pool_facade_sandbox_creator_is_appended_after_factories() -> None:
     sync_params = list(inspect.signature(SandboxPoolSync).parameters)
     async_params = list(inspect.signature(SandboxPoolAsync).parameters)
 
-    assert sync_params[-3:] == [
+    # New optional params must be appended after the factories so positional calls stay
+    # backward compatible; failure_window is the newest one.
+    assert sync_params[-4:] == [
         "sandbox_manager_factory",
         "sandbox_factory",
         "sandbox_creator",
+        "failure_window",
     ]
-    assert async_params[-3:] == [
+    assert async_params[-4:] == [
         "sandbox_manager_factory",
         "sandbox_factory",
         "sandbox_creator",
+        "failure_window",
     ]
 
 

--- a/sdks/sandbox/python/tests/test_pool_sync.py
+++ b/sdks/sandbox/python/tests/test_pool_sync.py
@@ -40,22 +40,28 @@ from opensandbox.pool import (
     PooledSandboxCreateContext,
     PooledSandboxCreateReason,
 )
+from opensandbox.pool_types import PoolState
 from opensandbox.sync.pool import SandboxPoolSync
 
 
-def test_degraded_backoff_caps_at_one_day() -> None:
+def test_sustained_failures_keep_backoff_active_until_drain() -> None:
     state = ReconcileState(degraded_threshold=1)
 
-    for _ in range(20):
+    for _ in range(5000):
         state.record_failure("boom")
 
-    assert state.failure_count == 20
-    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(hours=23))
+    assert state.state == PoolState.DEGRADED
+    assert state.is_backoff_active()
+    # Once failures stop, the pool stays paused until the failure window drains.
     assert not state.is_backoff_active(datetime.now(timezone.utc) + timedelta(hours=25))
+    assert state.state == PoolState.HEALTHY
+    assert state.failure_count == 0
 
 
 def test_degraded_backoff_starts_at_thirty_seconds() -> None:
-    state = ReconcileState(degraded_threshold=1)
+    state = ReconcileState(
+        degraded_threshold=1, failure_window=timedelta(milliseconds=1)
+    )
 
     state.record_failure("boom")
 
@@ -63,6 +69,22 @@ def test_degraded_backoff_starts_at_thirty_seconds() -> None:
     assert not state.is_backoff_active(
         datetime.now(timezone.utc) + timedelta(seconds=31)
     )
+
+
+def test_backoff_renews_while_window_hot_and_recovers_after_drain() -> None:
+    state = ReconcileState(degraded_threshold=1)
+
+    state.record_failure("boom")
+
+    # The 30s backoff expires at t=30, but the failure is still inside the 60s window,
+    # so the backoff is renewed (t=30 -> t=91) and the pool stays paused.
+    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=31))
+    assert not state.is_backoff_active(
+        datetime.now(timezone.utc) + timedelta(seconds=92)
+    )
+    assert state.state == PoolState.HEALTHY
+    assert state.failure_count == 0
+    assert state.last_error is None
 
 
 def test_reconcile_batch_failures_only_advance_backoff_once() -> None:
@@ -93,9 +115,52 @@ def test_reconcile_batch_failures_only_advance_backoff_once() -> None:
 
     assert state.failure_count == 10
     assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=29))
+    # The window is still hot when the 30s backoff expires, so the pool stays paused.
+    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=31))
     assert not state.is_backoff_active(
-        datetime.now(timezone.utc) + timedelta(seconds=31)
+        datetime.now(timezone.utc) + timedelta(seconds=92)
     )
+    assert state.state == PoolState.HEALTHY
+
+
+def test_interleaved_creates_trigger_degraded_backoff() -> None:
+    # Regression: with the old consecutive-failure counter, every successful warmup reset
+    # the failure count, so a pool with interleaved successes and failures never degraded.
+    # Detection must be rate-based over a sliding window instead.
+    store = InMemoryPoolStateStore()
+    config = PoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=5,
+        warmup_concurrency=4,
+        state_store=store,
+        connection_config=ConnectionConfigSync(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        degraded_threshold=3,
+    )
+    state = ReconcileState(degraded_threshold=3)
+    attempts = {"count": 0}
+
+    def flaky_create() -> str:
+        n = attempts["count"]
+        attempts["count"] += 1
+        if n % 2 == 0:
+            raise RuntimeError("boom")
+        return f"sbx-{n}"
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        for _ in range(3):
+            run_reconcile_tick(
+                config=config,
+                state_store=store,
+                create_one=flaky_create,
+                on_discard_sandbox=lambda _sandbox_id: None,
+                reconcile_state=state,
+                warmup_executor=executor,
+            )
+
+    assert state.state == PoolState.DEGRADED
+    assert state.is_backoff_active()
 
 
 def test_acquire_fail_fast_empty_raises_pool_empty() -> None:

--- a/sdks/sandbox/python/tests/test_pool_sync.py
+++ b/sdks/sandbox/python/tests/test_pool_sync.py
@@ -123,6 +123,20 @@ def test_reconcile_batch_failures_only_advance_backoff_once() -> None:
     assert state.state == PoolState.HEALTHY
 
 
+def test_backoff_escalation_stays_capped_at_one_day() -> None:
+    state = ReconcileState(degraded_threshold=1, failure_window=timedelta(days=100))
+
+    # Sustained renewals grow backoff_attempts without bound; the delay must stay capped
+    # at backoff_max instead of growing with each renewal.
+    for _ in range(40):
+        state.backoff_until = datetime.now(timezone.utc) - timedelta(seconds=1)
+        state.record_failure("boom")
+
+    delay = state.backoff_until - datetime.now(timezone.utc)
+    assert timedelta(0) < delay <= timedelta(days=1)
+    assert state.is_backoff_active()
+
+
 def test_interleaved_creates_trigger_degraded_backoff() -> None:
     # Regression: with the old consecutive-failure counter, every successful warmup reset
     # the failure count, so a pool with interleaved successes and failures never degraded.


### PR DESCRIPTION
## Summary

The sandbox pool reconcile loop detected degradation with a *consecutive-failure* counter that any successful warmup reset to zero (`recordSuccess` zeroed `failureCount`, `backoffAttempts`, and cancelled the active backoff window). Under a sustained high failure rate with interleaved successes (e.g. ~50 failures/s + ~9.4 successes/s), the count could never reach `degradedThreshold`, so `DEGRADED`/backoff never triggered and the pool churned for hours.

This PR replaces the counter with **rate-based detection over a sliding time window**:

- Failures are recorded with timestamps and age out of a new `failure_window` knob (default 60s)
- `degradedThreshold` now means *failures inside the window*, not consecutive failures
- Successful warmups no longer reset the failure count or cancel an active backoff window
- While DEGRADED, an expired backoff window is **auto-renewed** as long as the window is still hot — the pool stays paused until the failure rate actually drops below the threshold
- Recovery is time-based only: the pool returns to HEALTHY when the window drains (backoff attempts / lastError reset then)

Implemented identically in **Kotlin, Go, and Python (sync + async)**; `recordSuccess` removed in all languages. Docs updated (`docs/guides/client-pool.md`) noting the change takes effect from the next SDK release.

## Tests

- Kotlin: `./gradlew spotlessApply :sandbox:test :code-interpreter:test` ✅
- Go: `go test ./...` ✅
- Python: `uv run pytest tests/` + ruff + pyright ✅
- Docs: `pnpm docs:build` ✅

New regression tests (fail under the old counter logic):
- Pool-level interleaved success/failure warmup streams now trigger DEGRADED + backoff (Kotlin `SandboxPoolTest`, Go `TestReconciler_InterleavedCreatesTriggerDegraded`, Python `test_interleaved_creates_trigger_degraded_backoff`)
- Windowed trigger across time gaps, backoff auto-renewal while hot, drain-based recovery, and escalation-rate tests

## Behavior change (public)

- `failure_window` new config (default 60s) in all three SDKs
- `degradedThreshold` semantics: consecutive → windowed
- Pools with a high sustained failure rate stay paused (auto-renewed backoff) instead of probing every backoff step