### PR TITLE
docs(osep): align lifecycle runtime design

### DIFF
--- a/oseps/0020-sandbox-lifecycle-hooks.md
+++ b/oseps/0020-sandbox-lifecycle-hooks.md
@@ -3,7 +3,7 @@ title: Sandbox Lifecycle Hooks
 authors:
   - "@pjp"
 creation-date: 2026-08-17
-last-updated: 2026-08-17
+last-updated: 2026-08-21
 status: draft
 ---
 
@@ -41,7 +41,8 @@ Adds sandbox-level lifecycle hooks: `preStart`, `prePause`, `postResume`,
 `CreateSandboxRequest.lifecycle`; all hooks except `preStart` are updatable at
 runtime via `PATCH /sandboxes/{sandboxId}/lifecycle`. Execution is split into
 four channels chosen by event type (see [Execution Channels](#execution-channels));
-the contract is identical on Docker and Kubernetes backends.
+the contract is identical on Docker and Kubernetes backends when the provider
+topology satisfies the hook's capability requirements (R13).
 
 ## Motivation
 
@@ -64,9 +65,9 @@ Related: [#1458](https://github.com/opensandbox-group/OpenSandbox/issues/1458) (
 ### Goals
 
 1. Sandbox-level hooks for start, pause, resume, terminate, and periodic (cron) execution.
-2. Runtime-agnostic: identical contract and behavior on Docker and Kubernetes.
+2. Runtime-agnostic: identical contract and behavior on capable Docker and Kubernetes providers.
 3. Declarative at creation + runtime PATCH for all hooks except `preStart`.
-4. Guaranteed execution on platform-driven transitions (TTL, idle-pause, eviction), not only user-initiated ones.
+4. Cover platform-driven transitions (TTL, idle-pause, eviction), subject to the hook's capability and grace constraints, not only user-initiated ones.
 5. Per-hook timeout and failure policy; observable results; fully backward compatible (all hooks optional).
 
 ### Non-Goals
@@ -88,11 +89,12 @@ Related: [#1458](https://github.com/opensandbox-group/OpenSandbox/issues/1458) (
 | R5 | Abort: hook failure/timeout (incl. execd unreachable on a `Running` sandbox) aborts the transition, leaving the pre-transition state with a machine-readable reason |
 | R6 | Hooks never block **termination**: `preTerminate` runs only while `Running`; `Paused`/`Failed` sandboxes skip hooks (no SIGTERM handler / no pod) |
 | R7 | `periodic` runs on cron inside execd without server liveness dependency; in-flight run of the same `name` skips the tick (no queueing) |
-| R8 | Config survives server restarts (Docker: file-backed store; K8s: BatchSandbox/AgentSandbox annotation) and is **persisted inside the sandbox** (TOML file on the container rootfs) across execd restarts and pause/resume |
+| R8 | Provider-held config survives server restarts (Docker: file-backed store; K8s: BatchSandbox/AgentSandbox annotation). When the selected in-sandbox path is writable and covered by the provider persistence/snapshot contract, execd persists TOML there across execd restarts and pause/resume; failure to persist the default HOME path degrades to the validated in-memory config with a warning |
 | R9 | PATCH affects future transitions only (start-time snapshot); rejected with 409 when not `Running`; rejected for sandboxes whose execd lacks the lifecycle API (capability gate) |
 | R10 | Termination grace covers `preTerminate` (K8s `terminationGracePeriodSeconds` / Docker `stop` timeout ≥ hook timeout + buffer); PATCH cannot raise the timeout beyond the provisioned grace |
 | R11 | Pool-mode: per-sandbox injection via the existing task/alloc path (`spec.taskTemplate`), never the shared Pool template |
 | R12 | `preTerminate` fires only on genuine termination, never on pause: K8s pause-induced pod deletions (`completePause` normal-mode deletion and pool-GC release deletion) use **grace-0 (immediate) deletion**, so no SIGTERM is delivered; Docker pause sends no signals — backend parity |
+| R13 | Pool-mode `preTerminate` requires a process topology that delivers the task shim's TERM to execd. It is supported with `execd_run_as_init`; create/PATCH must reject `preTerminate` for the legacy background-bootstrap topology |
 
 ## Proposal
 
@@ -100,7 +102,7 @@ Related: [#1458](https://github.com/opensandbox-group/OpenSandbox/issues/1458) (
 
 | Hook | Channel | Declarative | Runtime PATCH | Failure default | Fires |
 |---|---|---|---|---|---|
-| `preStart` | in-process (bootstrap.sh) | yes | no | Abort | before entrypoint, every boot (incl. K8s resume) |
+| `preStart` | execd startup | yes | no | Abort | before entrypoint, every boot (incl. K8s resume) |
 | `prePause` | orchestrated (server triggers execd) | yes | yes | Abort | before pause (manual, idle, TTL-adjacent) |
 | `postResume` | orchestrated (server triggers execd) | yes | yes | Abort | after resume, before public `Running` |
 | `preTerminate` | signal-driven (execd catches SIGTERM) | yes | yes | Continue (fixed) | any platform termination of a `Running` sandbox (delete, TTL, eviction, `docker stop`) |
@@ -111,24 +113,30 @@ Related: [#1458](https://github.com/opensandbox-group/OpenSandbox/issues/1458) (
 ```
 IN-SANDBOX channels (self-contained)          ORCHESTRATED channel (server-driven)
 ────────────────────────────────────          ────────────────────────────────────────
-process-ordering:  bootstrap.sh               transition: server POSTs an event-only
-  materializes OPEN_SANDBOX_LIFECYCLE         trigger to execd → execd runs the hook
-  → /var/execd/lifecycle.toml                 resolved from its config file → result
-  → run preStart → exec entrypoint            decides advance/abort (prePause, postResume)
-signal-driven:     execd catches SIGTERM
+startup: bootstrap starts execd               transition: server POSTs an event-only
+  → execd loads config; persists if possible  trigger to execd → execd runs the hook
+  → execd starts HTTP → runs preStart         resolved from effective config → result
+  → normal: bootstrap starts entrypoint       decides advance/abort (prePause, postResume)
+  → init: execd starts entrypoint
+signal-driven: execd catches SIGTERM
   → run preTerminate → shutdown
-timer-driven:      execd cron ticker → periodic
+timer-driven: execd cron ticker → periodic
 ```
 
-Why: `preStart` is process-ordering (no window for a server round trip; runs
-again on every boot including K8s resume). `preTerminate` is signal-driven —
+Why: `preStart` is owned by the long-running execd process and runs after its
+HTTP server starts, so hook duration does not consume the execd health-check
+startup window. In normal mode, bootstrap waits for execd's private startup
+status before launching the user process. In init mode, execd runs `preStart`
+before launching the supervised entrypoint. It runs again on every boot,
+including K8s resume. `preTerminate` is signal-driven —
 every platform termination path (K8s pod delete for TTL/eviction/user delete,
-Docker `stop`) ends in a SIGTERM to the container, already forwarded to execd
-by `bootstrap.sh`, so it is as reliable without the server as with it.
+Docker `stop`) ends in a SIGTERM to the container. Dedicated containers reach
+execd through PID 1 bootstrap signal forwarding; Pool mode requires
+`execd_run_as_init` so the task shim reaches execd directly (R13).
 `prePause`/`postResume` are state-machine semantics: the server is the only
 component that sees both the config and the transition, and it must wait for
-the hook result before advancing. execd never interprets lifecycle semantics —
-it runs commands from its config file on trigger, ticker, or signal.
+the hook result before advancing. execd runs commands from its effective
+lifecycle config on startup, trigger, ticker, or signal.
 
 ### Risks and Mitigations
 
@@ -190,7 +198,7 @@ config rides the existing per-provider state:
 |---|---|---|
 | Docker | file-backed store (same mechanism as `services/docker/metadata.py`) | labels on running containers are **immutable** |
 | K8s | `sandbox.opensandbox.io/lifecycle` annotation on BatchSandbox **or AgentSandbox** — whichever workload CR the configured provider manages (`provider_factory.py` registers both) | schemaless, no CRD change; controller ignores the key (server-only contract; add to `kubernetes/AGENTS.md` annotation list) |
-| Both | env `OPEN_SANDBOX_LIFECYCLE` (TOML content) at create | **transport only** — `bootstrap.sh` materializes it to the config file on first provision (if absent); execd reads the file only |
+| Both | env `OPEN_SANDBOX_LIFECYCLE` (JSON content) at create | **transport only** — execd validates it and, when the selected path is writable, atomically persists the effective config; provider-held config remains the recovery source |
 
 **Pod-creation source stays current.** On PATCH, the server also updates the
 pod-creation source — BatchSandbox `spec.template` / `taskTemplate` env, or
@@ -205,8 +213,10 @@ deferred to replacement).
 
 ### 3. In-Sandbox Config File
 
-`/var/execd/lifecycle.toml` is the in-sandbox authority for all five hooks
-(desired state; atomic write, `version` key):
+`$HOME/.execd/lifecycle.toml` is the default in-sandbox lifecycle config
+(atomic write, `version` key). Operators may set `EXECD_LIFECYCLE_CONFIG` to
+an explicit path; execd and bootstrap use that value as-is and do not fall
+back to the default path:
 
 ```toml
 version = 1
@@ -234,23 +244,29 @@ command = ["/opt/hooks/checkpoint.sh"]
 timeout_seconds = 60
 ```
 
-- **Location**: container rootfs, deliberately **not** any mounted volume — not
-  the K8s `opensandbox-bin` emptyDir (`/opt/opensandbox`, wiped on pod
-  recreation) nor the isolation volume (`/var/lib/execd/isolation`), so it is
-  committed into the K8s rootfs snapshot on pause and restored on resume.
-- **Non-root images**: state dir resolution shared by `bootstrap.sh` and execd —
-  `/var/execd`, fall back to `$HOME/.opensandbox` (both on rootfs; the
-  `examples/chrome`, `examples/vscode` images cannot create `/var` dirs).
-- **Load order**: persisted file first, injected env as fallback. `bootstrap.sh`
-  writes the file only when absent (first provision), so PATCHed config
-  survives execd restarts, Docker pause/resume (rootfs persists), and K8s
-  resume (snapshot contains the file).
+- **Location**: resolving from `HOME` makes the default writable for both root
+  and non-root images. Platform deployments must ensure the default HOME
+  participates in the sandbox persistence/snapshot contract. An operator that
+  selects an explicit path owns the same durability requirement. Do not use the
+  K8s `opensandbox-bin` emptyDir (`/opt/opensandbox`).
+- **Current startup load order** (`preStart` + `periodic`, no PATCH): a nonblank
+  injected env is authoritative, is validated, and atomically refreshes the
+  persisted file; when the env is absent, execd loads the file. If the default
+  HOME path cannot be written, execd warns and uses the validated transport
+  config in memory for that process. An explicit path write failure is fatal.
+  Runtime PATCH persistence/reconciliation is deferred with the PATCH phase.
+- **Trust boundary**: hooks run as execd's OS user in the sandbox's existing
+  container namespaces and do not use isolated-session confinement. The same
+  identity (and any root workload) can modify or remove the persisted file.
+  Hooks are trusted setup/maintenance code, not a tamper-resistant audit or
+  mandatory-policy mechanism.
 - **Persistence principles** (apply to any future daemon state): config files
   are TOML (matching `--isolation-config`); config vs. rebuildable runtime
   state are separated (hook run results/counters stay in memory —
   `GET /v1/lifecycle/status` reflects the current process only); one concern =
-  one file/dir, events use append-only JSONL; load is fail-open (malformed →
-  log + fallback, never blocks boot).
+  one file/dir, events use append-only JSONL. Invalid transport or persisted
+  config fails closed; only failure to persist an already validated transport
+  config at the default HOME path falls back to in-memory execution.
 
 ### 4. execd Lifecycle API
 
@@ -277,10 +293,10 @@ Design notes:
 - `run` reuses the command runtime (`pkg/runtime/command.go`) synchronously
   (not `/command`'s background+poll shape — hooks need a hard deadline) and
   serves only `prePause`/`postResume`. **The request carries only the event,
-  never the command** — the config file is the single in-sandbox source of
-  truth for every hook (same file-read pattern as `preTerminate` and
-  `periodic`); the server stores config only for validation/display/
-  re-provisioning.
+  never the command** — execd's effective lifecycle config is the in-sandbox
+  source of truth for every hook (persisted file when available, otherwise the
+  validated in-memory startup config); the server stores config only for
+  validation/display/re-provisioning.
 - `executed: false` is explicit and differentiated: a hook the server believes
   is configured reporting `not_configured`/`config_unavailable` is treated as
   hook failure (R5) — the configured state flush must not silently vanish.
@@ -288,8 +304,8 @@ Design notes:
 - Periodic scheduling is a `robfig/cron/v3` ticker inside execd (5-field cron +
   descriptors, container-local timezone), started from the injected env and
   replaced live by `POST /v1/lifecycle/config`. One in-flight run per `name`;
-  Docker pause freezes the ticker naturally; K8s resume restarts it from the
-  file.
+  Docker pause freezes the ticker naturally; K8s resume reconstructs it from
+  the provider-injected or persisted effective config.
 - `prePause` does not wait for in-flight periodic runs — the final flush is
   `prePause`'s own responsibility.
 
@@ -315,18 +331,23 @@ or CRD change needed.
 Client visibility is unchanged: transitions surface as
 `Pausing`/`Resuming`/`Stopping`, hook results in `reason`/`message`.
 
-**preStart**: `bootstrap.sh` runs `[preStart]` as a child process (exec
-semantics; sourced env preparation stays with `EXECD_BOOTSTRAP_PRE_SCRIPT`)
-with a timeout-bounded wait before starting execd and the entrypoint; failure
-aborts the boot. When OSEP-0018 (execd as init) lands, execution moves into
-execd's launch path; contract unchanged.
+**preStart**: execd loads and, when possible, persists the lifecycle config,
+starts its HTTP server, then runs `[preStart]` with the configured timeout. In
+normal mode, bootstrap starts execd first and waits on a private,
+watchdog-bounded startup status channel;
+only a successful result releases the user entrypoint. In init mode, execd is
+PID 1 and launches the supervised entrypoint only after `preStart` succeeds.
+A failure or timeout aborts startup in both modes.
 
 ### 6. Signal-Driven preTerminate
 
 Every platform termination converges on SIGTERM to the container (K8s:
-kubelet during pod deletion; Docker: `docker stop`). Today PID 1 is
-`bootstrap.sh`, which forwards TERM to execd (`_shutdown_children`); under
-OSEP-0018 execd is PID 1 and receives it directly. execd:
+kubelet during pod deletion; Docker: `docker stop`). In dedicated normal-mode
+containers PID 1 bootstrap forwards TERM to execd (`_shutdown_children`); in
+init mode execd is PID 1 and receives it directly. The legacy Pool task shape
+backgrounds bootstrap behind a task shim and does not provide this guarantee,
+so `preTerminate` is unavailable there unless `execd_run_as_init` is enabled
+(R13). execd:
 
 ```go
 // main.go: intercept SIGTERM, run preTerminate to completion, then shut down.
@@ -343,12 +364,12 @@ server.Shutdown(shutdownCtx)                 // then stop HTTP and exit with the
 
 Properties:
 
-1. Covers all platform-driven terminations with no server in the path (TTL, eviction, node drain, delete, `docker stop`) — same reliability as user-initiated ones.
+1. On capable process topologies (R13), covers platform-driven terminations with no server in the path (TTL, eviction, node drain, delete, `docker stop`) — the same delivery path as user-initiated ones.
 2. `Running`-only by construction: a paused Docker sandbox is frozen, a paused K8s sandbox has no pod — no handler runs, termination proceeds (R6).
 3. Inherently best-effort: SIGKILL follows the grace period regardless → fixed `Continue` (R4).
 4. Grace-bounded: the deadline is `min(timeoutSeconds, grace remaining)` (R10).
 5. Runs concurrently with the app's own shutdown in today's topology (TERM forwarded to both) — hook contract is state flush, not app coordination.
-6. Reads the config file fresh at signal time, so the latest PATCHed definition applies.
+6. Resolves the effective lifecycle config at signal time, so the latest PATCHed definition applies.
 7. OSEP-0018 interaction: as PID 1, execd must distinguish the *external* container-stop SIGTERM from an in-namespace `kill 1` (open item already tracked in OSEP-0018 §3); the v1 topology is unaffected.
 8. **Never on pause** (R12): the K8s pause flow deletes the running pod (`completePause`), and kubelet would SIGTERM it — so pause-induced deletions (normal-mode `completePause` and pool-GC release) use grace-0 immediate deletion (SIGKILL, no SIGTERM). Docker pause sends no signals. `preTerminate` therefore runs only on genuine termination, with backend parity.
 
@@ -362,14 +383,14 @@ Properties:
 
 ## Test Plan
 
-- **Unit**: schema validation (shapes, `periodic.name` uniqueness, cron parse, PATCH merge, `preStart` rejection); execd `run` (timeout kill, output, exit code, `executed:false` differentiation); SIGTERM handler (file-resolved `[preTerminate]`, grace-bounded deadline, exit-after, absent-hook no-op); periodic (scheduling, in-flight skip, hot replacement, failure counter); config file (TOML parse, unsupported `version`, atomic write, load order, fail-open); failure-policy resolution.
-- **Integration**: `bootstrap.sh` runs `preStart` before execd/entrypoint (marker ordering), failure aborts boot; server orchestration against a fake execd (hook ordering, abort paths, unreachable-execd aborts per R5).
-- **E2E (Kind / Docker)**: Docker — `prePause` marker before `docker pause`, `postResume` after `unpause`, periodic checkpoints (ticker frozen while paused), `preTerminate` marker on `docker stop` **and on TTL expiry** (grace-bounded stop path). K8s — `prePause` before `spec.pause=true`, `postResume` after pod Ready + `/ping` before `Running`, resume re-runs `preStart`, TTL/delete/eviction all produce the `preTerminate` marker, paused sandbox deletion produces none. PATCH mid-flight snapshot; server restart restore (file-backed store/annotation); config persistence across execd restart and both pause/resume models; replacement pod after eviction materializes the PATCHed config from the updated pod-creation source.
+- **Unit**: schema validation (shapes, `periodic.name` uniqueness, cron parse, PATCH merge, `preStart` rejection); execd `run` (timeout kill, output, exit code, `executed:false` differentiation); SIGTERM handler (effective-config-resolved `[preTerminate]`, grace-bounded deadline, exit-after, absent-hook no-op); periodic (scheduling, in-flight skip, hot replacement, failure counter); config file (TOML parse, unsupported `version`, atomic write, load order, invalid-config failure, default-path memory fallback); failure-policy resolution.
+- **Integration**: bootstrap starts execd before the user entrypoint; execd serves HTTP, runs `preStart`, and reports success before the entrypoint starts. Cover hook failure, execd failing before status, and watchdog termination when execd never reports status. Server orchestration uses a fake execd for hook ordering, abort paths, and unreachable-execd behavior per R5.
+- **E2E (Kind / Docker)**: Docker — `prePause` marker before `docker pause`, `postResume` after `unpause`, periodic checkpoints (ticker frozen while paused), `preTerminate` marker on `docker stop` **and on TTL expiry** (grace-bounded stop path). K8s — `prePause` before `spec.pause=true`, `postResume` after pod Ready + `/ping` before `Running`, resume re-runs `preStart`, TTL/delete/eviction all produce the `preTerminate` marker, paused sandbox deletion produces none. Pool TTL/delete tests must cover `execd_run_as_init`; non-init Pool create/PATCH requests containing `preTerminate` must be rejected. PATCH mid-flight snapshot; server restart restore (file-backed store/annotation); config persistence across execd restart and both pause/resume models; replacement pod after eviction materializes the PATCHed config from the updated pod-creation source.
 
 ## Drawbacks
 
 1. Contract surface grows (lifecycle field + PATCH endpoint + execd API) — every field optional and additive.
-2. execd gains a scheduler + signal handler — isolated from user code by the existing access token and (eventually) OSEP-0018 hardening.
+2. execd gains a scheduler + signal handler. Hook code deliberately shares execd's OS identity and container namespaces; the documented trust boundary must be acceptable for each use case.
 3. Four execution channels — each event is mapped to exactly one channel in the contract to avoid ambiguity.
 4. `preTerminate` is bounded by the termination grace; hooks must stay small (R10).
 5. Hooks are in-sandbox code — a buggy hook slows transitions (bounded by timeout) or breaks boot (`preStart`).
@@ -395,11 +416,11 @@ rides a new, controller-ignored annotation).
 
 **Phased rollout**:
 
-1. execd: `run`/`config`/`status` endpoints + SIGTERM `preTerminate` handler + tests; execd image release.
-2. `specs/sandbox-lifecycle.yml` `lifecycle` field + PATCH endpoint; Docker provider orchestration (incl. `stop` timeout ≥ hook timeout); e2e.
-3. K8s provider orchestration + annotation persistence + `terminationGracePeriodSeconds` wiring; e2e (pause/resume/TTL/eviction).
-4. `preStart` in `bootstrap.sh` on both providers.
-5. Pool-mode parity via the per-sandbox `spec.taskTemplate` injection path (R11).
+1. execd: config persistence plus execd-owned `preStart` and `periodic`; tests and execd image release.
+2. `specs/sandbox-lifecycle.yml`: additive `CreateSandboxRequest.lifecycle` with `preStart` and `periodic`; regenerate SDKs and add server create-time transport.
+3. Future phase: `run`/`config`/`status` endpoints, PATCH, and the remaining transition hooks after their deferred persistence/failure semantics are resolved.
+4. Docker and K8s provider orchestration, grace-period wiring, and transition E2E coverage.
+5. Pool-mode parity via per-sandbox `spec.taskTemplate` injection (R11), with `preTerminate` gated on `execd_run_as_init` until another explicit TERM route exists (R13).
 
 **Docs**: `docs/` lifecycle hook guide (hooks, failure policies, idempotency,
 cron reference), `kubernetes/AGENTS.md` annotation contract note, SDK

--- a/oseps/0020-sandbox-lifecycle-hooks.md
+++ b/oseps/0020-sandbox-lifecycle-hooks.md
@@ -90,7 +90,7 @@ Related: [#1458](https://github.com/opensandbox-group/OpenSandbox/issues/1458) (
 | R5 | Abort: hook failure/timeout, lifecycle startup failure, or required execd lifecycle status being unreachable aborts the transition, leaving the pre-transition state with a machine-readable reason |
 | R6 | Hooks never block **termination**: `preTerminate` runs only while `Running`; `Paused`/`Failed` sandboxes skip hooks (no SIGTERM handler / no pod) |
 | R7 | `periodic` runs on cron inside execd without server liveness dependency; in-flight run of the same `name` skips the tick (no queueing) |
-| R8 | Provider-held config survives server restarts (Docker: file-backed store; K8s: BatchSandbox/AgentSandbox annotation). When the selected in-sandbox path is writable and covered by the provider persistence/snapshot contract, execd persists TOML there across execd restarts and pause/resume; failure to persist the default HOME path degrades to the validated in-memory config with a warning |
+| R8 | Provider-held config survives server restarts (Docker: file-backed store; K8s: BatchSandbox/AgentSandbox annotation). Execd atomically persists TOML at the selected in-sandbox path across execd restarts and pause/resume; inability to resolve or write that path fails lifecycle startup |
 | R9 | PATCH affects future transitions only (start-time snapshot); rejected with 409 when not `Running`; rejected for sandboxes whose execd lacks the lifecycle API (capability gate) |
 | R10 | Termination grace covers `preTerminate` (K8s `terminationGracePeriodSeconds` / Docker `stop` timeout ≥ hook timeout + buffer); PATCH cannot raise the timeout beyond the provisioned grace |
 | R11 | Pool-mode: per-sandbox injection via the existing task/alloc path (`spec.taskTemplate`), never the shared Pool template |
@@ -116,7 +116,7 @@ Related: [#1458](https://github.com/opensandbox-group/OpenSandbox/issues/1458) (
 IN-SANDBOX channels (self-contained)          ORCHESTRATED channel (server-driven)
 ────────────────────────────────────          ────────────────────────────────────────
 startup: bootstrap starts execd               transition: server POSTs an event-only
-  → execd loads config; persists if possible  trigger to execd → execd runs the hook
+  → execd loads and persists config           trigger to execd → execd runs the hook
   → execd starts HTTP → runs preStart         resolved from effective config → result
   → normal: bootstrap starts entrypoint       decides advance/abort (prePause, postResume)
   → init: execd starts entrypoint
@@ -201,7 +201,7 @@ config rides the existing per-provider state:
 |---|---|---|
 | Docker | file-backed store (same mechanism as `services/docker/metadata.py`) | labels on running containers are **immutable** |
 | K8s | `sandbox.opensandbox.io/lifecycle` annotation on BatchSandbox **or AgentSandbox** — whichever workload CR the configured provider manages (`provider_factory.py` registers both) | schemaless, no CRD change; controller ignores the key (server-only contract; add to `kubernetes/AGENTS.md` annotation list) |
-| Both | env `OPEN_SANDBOX_LIFECYCLE` (JSON content) at create | **transport only** — execd validates it and, when the selected path is writable, atomically persists the effective config; provider-held config remains the recovery source |
+| Both | env `OPEN_SANDBOX_LIFECYCLE` (JSON content) at create | **transport only** — execd validates it and atomically persists the effective config; failure to persist aborts lifecycle startup, while provider-held config remains the recovery source |
 
 **Pod-creation source stays current.** On PATCH, the server also updates the
 pod-creation source — BatchSandbox `spec.template` / `taskTemplate` env, or
@@ -247,17 +247,17 @@ command = ["/opt/hooks/checkpoint.sh"]
 timeout_seconds = 60
 ```
 
-- **Location**: resolving from `HOME` makes the default writable for both root
-  and non-root images. Platform deployments must ensure the default HOME
+- **Location**: resolving from `HOME` makes the default writable for root and
+  normal non-root images. Platform deployments must ensure the default HOME
   participates in the sandbox persistence/snapshot contract. An operator that
   selects an explicit path owns the same durability requirement. Do not use the
   K8s `opensandbox-bin` emptyDir (`/opt/opensandbox`).
 - **Current startup load order** (`preStart` + `periodic`, no PATCH): a nonblank
   injected env is authoritative, is validated, and atomically refreshes the
-  persisted file; when the env is absent, execd loads the file. If the default
-  HOME path cannot be written, execd warns and uses the validated transport
-  config in memory for that process. An explicit path write failure is fatal.
-  Runtime PATCH persistence/reconciliation is deferred with the PATCH phase.
+  persisted file; when the env is absent, execd loads the file. Failure to
+  resolve or persist either the default or an explicit path is fatal when a
+  transport config is present. Runtime PATCH persistence/reconciliation is
+  deferred with the PATCH phase.
 - **Trust boundary**: hooks run as execd's OS user in the sandbox's existing
   container namespaces and do not use isolated-session confinement. The same
   identity (and any root workload) can modify or remove the persisted file.
@@ -268,8 +268,7 @@ timeout_seconds = 60
   state are separated (hook run results/counters stay in memory —
   `GET /v1/lifecycle/status` reflects the current process only); one concern =
   one file/dir, events use append-only JSONL. Invalid transport or persisted
-  config fails closed; only failure to persist an already validated transport
-  config at the default HOME path falls back to in-memory execution.
+  config and transport persistence failures fail closed.
 
 ### 4. execd Lifecycle API
 
@@ -299,8 +298,8 @@ Design notes:
   (not `/command`'s background+poll shape — hooks need a hard deadline) and
   serves only `prePause`/`postResume`. **The request carries only the event,
   never the command** — execd's effective lifecycle config is the in-sandbox
-  source of truth for every hook (persisted file when available, otherwise the
-  validated in-memory startup config); the server stores config only for
+  source of truth for every hook (the persisted file and the current process's
+  matching validated startup config); the server stores config only for
   validation/display/re-provisioning.
 - `executed: false` is explicit and differentiated: a hook the server believes
   is configured reporting `not_configured`/`config_unavailable` is treated as
@@ -342,7 +341,7 @@ controller or CRD change needed.
 Client visibility is unchanged: transitions surface as
 `Pausing`/`Resuming`/`Stopping`, hook results in `reason`/`message`.
 
-**preStart**: execd loads and, when possible, persists the lifecycle config,
+**preStart**: execd loads and persists the lifecycle config,
 starts its HTTP server, then runs `[preStart]` with the configured timeout. In
 normal mode, bootstrap starts execd first and waits on a private,
 watchdog-bounded startup status channel; only a successful result releases the
@@ -395,7 +394,7 @@ Properties:
 
 ## Test Plan
 
-- **Unit**: schema validation (shapes, `periodic.name` uniqueness, cron parse, PATCH merge, `preStart` rejection); execd `run` (timeout kill, output, exit code, `executed:false` differentiation); lifecycle startup status (`pending`/`running`/`succeeded`/`failed`, including no-hook success); SIGTERM handler (effective-config-resolved `[preTerminate]`, grace-bounded deadline, exit-after, absent-hook no-op); periodic (scheduling, in-flight skip, hot replacement, failure counter); config file (TOML parse, unsupported `version`, atomic write, load order, invalid-config failure, default-path memory fallback); failure-policy resolution.
+- **Unit**: schema validation (shapes, `periodic.name` uniqueness, cron parse, PATCH merge, `preStart` rejection); execd `run` (timeout kill, output, exit code, `executed:false` differentiation); lifecycle startup status (`pending`/`running`/`succeeded`/`failed`, including no-hook success); SIGTERM handler (effective-config-resolved `[preTerminate]`, grace-bounded deadline, exit-after, absent-hook no-op); periodic (scheduling, in-flight skip, hot replacement, failure counter); config file (TOML parse, unsupported `version`, atomic write, load order, invalid-config or persistence failure); failure-policy resolution.
 - **Integration**: bootstrap starts execd before the user entrypoint; execd serves `/ping` while `preStart` is still non-ready, then reports lifecycle startup success before the entrypoint starts. Cover hook failure, execd failing before status, and watchdog termination when execd never reports status. Server orchestration uses a fake execd to verify resume waits for lifecycle startup success before `postResume`, plus hook ordering, abort paths, and lifecycle-status unreachability per R5.
 - **E2E (Kind / Docker)**: Docker — `prePause` marker before `docker pause`, `postResume` after `unpause`, periodic checkpoints (ticker frozen while paused), `preTerminate` marker on `docker stop` **and on TTL expiry** (grace-bounded stop path). K8s — during resume, `/ping` succeeds while a long `preStart` still keeps lifecycle startup non-ready; `postResume` and public `Running` occur only after startup succeeds, while startup failure or lifecycle-status unreachability rolls back to `Paused`. Also cover TTL/delete/eviction producing the `preTerminate` marker and paused sandbox deletion producing none. Pool TTL/delete tests must cover `execd_run_as_init`; non-init Pool create/PATCH requests containing `preTerminate` must be rejected. PATCH mid-flight snapshot; server restart restore (file-backed store/annotation); config persistence across execd restart and both pause/resume models; replacement pod after eviction materializes the PATCHed config from the updated pod-creation source.
 

--- a/oseps/0020-sandbox-lifecycle-hooks.md
+++ b/oseps/0020-sandbox-lifecycle-hooks.md
@@ -1,10 +1,11 @@
 ---
 title: Sandbox Lifecycle Hooks
 authors:
-  - "@pjp"
+  - "@Pangjiping"
+  - "@peijianping"
 creation-date: 2026-08-17
 last-updated: 2026-08-21
-status: draft
+status: implementing
 ---
 
 # OSEP-0020: Sandbox Lifecycle Hooks

--- a/oseps/0020-sandbox-lifecycle-hooks.md
+++ b/oseps/0020-sandbox-lifecycle-hooks.md
@@ -86,7 +86,7 @@ Related: [#1458](https://github.com/opensandbox-group/OpenSandbox/issues/1458) (
 | R2 | `preStart` executes in-sandbox before the entrypoint, with no server round trip; not PATCHable |
 | R3 | `prePause`/`postResume` are triggered by an event-only server POST (`/v1/lifecycle/run`); `preTerminate` runs in-sandbox on SIGTERM; `periodic` runs on an execd ticker |
 | R4 | `timeoutSeconds` (default 60) per hook. `failurePolicy`: `Abort` default for `prePause`/`postResume`; `preTerminate`/`periodic` fixed `Continue` (`Abort` rejected) |
-| R5 | Abort: hook failure/timeout (incl. execd unreachable on a `Running` sandbox) aborts the transition, leaving the pre-transition state with a machine-readable reason |
+| R5 | Abort: hook failure/timeout, lifecycle startup failure, or required execd lifecycle status being unreachable aborts the transition, leaving the pre-transition state with a machine-readable reason |
 | R6 | Hooks never block **termination**: `preTerminate` runs only while `Running`; `Paused`/`Failed` sandboxes skip hooks (no SIGTERM handler / no pod) |
 | R7 | `periodic` runs on cron inside execd without server liveness dependency; in-flight run of the same `name` skips the tick (no queueing) |
 | R8 | Provider-held config survives server restarts (Docker: file-backed store; K8s: BatchSandbox/AgentSandbox annotation). When the selected in-sandbox path is writable and covered by the provider persistence/snapshot contract, execd persists TOML there across execd restarts and pause/resume; failure to persist the default HOME path degrades to the validated in-memory config with a warning |
@@ -95,6 +95,7 @@ Related: [#1458](https://github.com/opensandbox-group/OpenSandbox/issues/1458) (
 | R11 | Pool-mode: per-sandbox injection via the existing task/alloc path (`spec.taskTemplate`), never the shared Pool template |
 | R12 | `preTerminate` fires only on genuine termination, never on pause: K8s pause-induced pod deletions (`completePause` normal-mode deletion and pool-GC release deletion) use **grace-0 (immediate) deletion**, so no SIGTERM is delivered; Docker pause sends no signals — backend parity |
 | R13 | Pool-mode `preTerminate` requires a process topology that delivers the task shim's TERM to execd. It is supported with `execd_run_as_init`; create/PATCH must reject `preTerminate` for the legacy background-bootstrap topology |
+| R14 | `/ping` is liveness-only and remains available while `preStart` runs. Resume waits for a separate lifecycle startup-complete status before triggering `postResume` or publishing `Running` |
 
 ## Proposal
 
@@ -125,10 +126,11 @@ timer-driven: execd cron ticker → periodic
 
 Why: `preStart` is owned by the long-running execd process and runs after its
 HTTP server starts, so hook duration does not consume the execd health-check
-startup window. In normal mode, bootstrap waits for execd's private startup
-status before launching the user process. In init mode, execd runs `preStart`
-before launching the supervised entrypoint. It runs again on every boot,
-including K8s resume. `preTerminate` is signal-driven —
+startup window. `/ping` therefore indicates liveness, not lifecycle readiness.
+In normal mode, bootstrap waits for execd's private startup status before
+launching the user process. In init mode, execd runs `preStart` before launching
+the supervised entrypoint. It runs again on every boot, including K8s resume.
+`preTerminate` is signal-driven —
 every platform termination path (K8s pod delete for TTL/eviction/user delete,
 Docker `stop`) ends in a SIGTERM to the container. Dedicated containers reach
 execd through PID 1 bootstrap signal forwarding; Pool mode requires
@@ -147,7 +149,7 @@ lifecycle config on startup, trigger, ticker, or signal.
 | Hook hangs forever | `timeoutSeconds` enforced by the execd runner |
 | SIGKILL cuts `preTerminate` off | Grace ≥ hook timeout + buffer; grace remaining is the hard deadline (R10) |
 | Old execd without lifecycle API | Capability gate on create/PATCH (R9) |
-| Post-resume hook before the app is ready | `postResume` fires after execd `/ping`, before public `Running`; app readiness is the hook's own job |
+| Post-resume hook before lifecycle startup completes | Resume waits for lifecycle startup success after execd `/ping`, then runs `postResume` before public `Running` (R14); app readiness is the hook's own job |
 
 ## Design Details
 
@@ -285,7 +287,9 @@ POST /v1/lifecycle/config # replace the whole in-sandbox config (hot update on P
   # stored state — omitting a section removes it (incl. immutable preStart
   # and unchanged postResume must be re-sent).
 
-GET  /v1/lifecycle/status  # per-hook state: lastRunAt, lastExitCode, consecutiveFailures, nextRunAt
+GET  /v1/lifecycle/status
+  # startup.state: pending | running | succeeded | failed
+  # plus per-hook state: lastRunAt, lastExitCode, consecutiveFailures, nextRunAt
 ```
 
 Design notes:
@@ -300,6 +304,10 @@ Design notes:
 - `executed: false` is explicit and differentiated: a hook the server believes
   is configured reporting `not_configured`/`config_unavailable` is treated as
   hook failure (R5) — the configured state flush must not silently vanish.
+- `status.startup.state` is scoped to the current execd process. It becomes
+  `succeeded` after `preStart` completes successfully, or immediately when no
+  `preStart` is configured. `/ping` may already succeed while this state is
+  `pending` or `running`; resume must not use `/ping` as its readiness gate.
 - `preTerminate` has **no endpoint** — execd runs it in a SIGTERM handler (§6).
 - Periodic scheduling is a `robfig/cron/v3` ticker inside execd (5-field cron +
   descriptors, container-local timezone), started from the injected env and
@@ -314,19 +322,21 @@ Design notes:
 | Transition | Sequence |
 |---|---|
 | Pause (manual, idle, TTL-adjacent) | trigger `prePause` → policy result → Docker `pause` / K8s patch `spec.pause=true` |
-| Resume | Docker `unpause` / K8s patch `pause=false` → wait pod re-creation + execd `/ping` → trigger `postResume` → success → public `Running`; abort → roll back to `Paused` |
+| Resume | Docker `unpause` / K8s patch `pause=false` → wait pod re-creation + execd `/ping` (liveness) → wait lifecycle startup `succeeded` → trigger `postResume` → success → public `Running`; startup failure, lifecycle-status unreachability, or hook abort → roll back to `Paused` |
 | Terminate (user delete, Docker `stop`) | server deletes; runtime SIGTERMs the container; execd runs `preTerminate` (§6); server only ensures grace ≥ hook timeout (R10) |
 | Docker TTL expiry | server timer routes expiration through a **grace-bounded `container.stop(timeout)`** (SIGTERM → hook → SIGKILL), then `remove` — never `kill` + `remove(force=True)` (the current `_expire_sandbox` path, which would skip the hook) |
 | K8s TTL/eviction/node drain | controller/kubelet deletes the pod; SIGTERM path — no server involvement |
 
 **K8s resume state gating**: the controller sets the CR phase to `Succeed`
-as soon as the pod is ready, independently of the server-side `postResume`
-call, so the CR phase cannot express "resuming, hooks in progress". The server
-owns the public `SandboxState` mapping: it keeps reporting `Resuming` until
-`postResume` completes (resume intent tracked in the same per-sandbox state as
-the hook config), then `Running`. On `Abort`, the server re-patches
-`spec.pause=true` so the controller re-pauses → public `Paused`. No controller
-or CRD change needed.
+as soon as the pod is ready, independently of execd's lifecycle startup state
+and the server-side `postResume` call, so the CR phase cannot express
+"resuming, hooks in progress". The server owns the public `SandboxState`
+mapping: after `/ping` confirms liveness, it waits for
+`GET /v1/lifecycle/status` to report startup `succeeded`, then triggers
+`postResume`, and keeps reporting `Resuming` until both complete. Startup
+failure, lifecycle-status unreachability, or an `Abort` result causes the server
+to re-patch `spec.pause=true` so the controller re-pauses → public `Paused`. No
+controller or CRD change needed.
 
 Client visibility is unchanged: transitions surface as
 `Pausing`/`Resuming`/`Stopping`, hook results in `reason`/`message`.
@@ -334,10 +344,11 @@ Client visibility is unchanged: transitions surface as
 **preStart**: execd loads and, when possible, persists the lifecycle config,
 starts its HTTP server, then runs `[preStart]` with the configured timeout. In
 normal mode, bootstrap starts execd first and waits on a private,
-watchdog-bounded startup status channel;
-only a successful result releases the user entrypoint. In init mode, execd is
-PID 1 and launches the supervised entrypoint only after `preStart` succeeds.
-A failure or timeout aborts startup in both modes.
+watchdog-bounded startup status channel; only a successful result releases the
+user entrypoint. In init mode, execd is PID 1 and launches the supervised
+entrypoint only after `preStart` succeeds. The public lifecycle startup status
+tracks the same result for orchestrated resume; `/ping` remains responsive while
+the hook runs. A failure or timeout aborts startup in both modes.
 
 ### 6. Signal-Driven preTerminate
 
@@ -376,16 +387,16 @@ Properties:
 ### 7. Failure, Timeout, and Degradation Semantics
 
 - **Timeout**: enforced at the execd runner (kill, `504`/`hook timeout`); never counted as success.
-- **Abort** (`prePause`/`postResume`): failure, timeout, or execd unreachable on a `Running` sandbox → transition aborts, sandbox returns to its pre-transition state, reason recorded; user may retry.
+- **Abort** (`prePause`/`postResume` and the resume startup gate): hook failure/timeout, startup `failed`, or the required lifecycle API remaining unreachable until the transition deadline → transition aborts, sandbox returns to its pre-transition state, reason recorded; user may retry.
 - **Continue** (`preTerminate`, `periodic`): failure recorded, transition proceeds.
 - **Not `Running`** (`Paused`/`Failed`/pod gone): hooks skipped; termination never blocks on a hook.
 - **Idempotency**: one execution per transition — the existing phase state machine (`Pausing`/`Resuming`/`Stopping`) and K8s `PauseObservedGeneration` prevent re-entry; hooks should be idempotent (failed `Abort` transitions may be retried). `preTerminate` runs at most once per container lifetime.
 
 ## Test Plan
 
-- **Unit**: schema validation (shapes, `periodic.name` uniqueness, cron parse, PATCH merge, `preStart` rejection); execd `run` (timeout kill, output, exit code, `executed:false` differentiation); SIGTERM handler (effective-config-resolved `[preTerminate]`, grace-bounded deadline, exit-after, absent-hook no-op); periodic (scheduling, in-flight skip, hot replacement, failure counter); config file (TOML parse, unsupported `version`, atomic write, load order, invalid-config failure, default-path memory fallback); failure-policy resolution.
-- **Integration**: bootstrap starts execd before the user entrypoint; execd serves HTTP, runs `preStart`, and reports success before the entrypoint starts. Cover hook failure, execd failing before status, and watchdog termination when execd never reports status. Server orchestration uses a fake execd for hook ordering, abort paths, and unreachable-execd behavior per R5.
-- **E2E (Kind / Docker)**: Docker — `prePause` marker before `docker pause`, `postResume` after `unpause`, periodic checkpoints (ticker frozen while paused), `preTerminate` marker on `docker stop` **and on TTL expiry** (grace-bounded stop path). K8s — `prePause` before `spec.pause=true`, `postResume` after pod Ready + `/ping` before `Running`, resume re-runs `preStart`, TTL/delete/eviction all produce the `preTerminate` marker, paused sandbox deletion produces none. Pool TTL/delete tests must cover `execd_run_as_init`; non-init Pool create/PATCH requests containing `preTerminate` must be rejected. PATCH mid-flight snapshot; server restart restore (file-backed store/annotation); config persistence across execd restart and both pause/resume models; replacement pod after eviction materializes the PATCHed config from the updated pod-creation source.
+- **Unit**: schema validation (shapes, `periodic.name` uniqueness, cron parse, PATCH merge, `preStart` rejection); execd `run` (timeout kill, output, exit code, `executed:false` differentiation); lifecycle startup status (`pending`/`running`/`succeeded`/`failed`, including no-hook success); SIGTERM handler (effective-config-resolved `[preTerminate]`, grace-bounded deadline, exit-after, absent-hook no-op); periodic (scheduling, in-flight skip, hot replacement, failure counter); config file (TOML parse, unsupported `version`, atomic write, load order, invalid-config failure, default-path memory fallback); failure-policy resolution.
+- **Integration**: bootstrap starts execd before the user entrypoint; execd serves `/ping` while `preStart` is still non-ready, then reports lifecycle startup success before the entrypoint starts. Cover hook failure, execd failing before status, and watchdog termination when execd never reports status. Server orchestration uses a fake execd to verify resume waits for lifecycle startup success before `postResume`, plus hook ordering, abort paths, and lifecycle-status unreachability per R5.
+- **E2E (Kind / Docker)**: Docker — `prePause` marker before `docker pause`, `postResume` after `unpause`, periodic checkpoints (ticker frozen while paused), `preTerminate` marker on `docker stop` **and on TTL expiry** (grace-bounded stop path). K8s — during resume, `/ping` succeeds while a long `preStart` still keeps lifecycle startup non-ready; `postResume` and public `Running` occur only after startup succeeds, while startup failure or lifecycle-status unreachability rolls back to `Paused`. Also cover TTL/delete/eviction producing the `preTerminate` marker and paused sandbox deletion producing none. Pool TTL/delete tests must cover `execd_run_as_init`; non-init Pool create/PATCH requests containing `preTerminate` must be rejected. PATCH mid-flight snapshot; server restart restore (file-backed store/annotation); config persistence across execd restart and both pause/resume models; replacement pod after eviction materializes the PATCHed config from the updated pod-creation source.
 
 ## Drawbacks
 
@@ -418,7 +429,7 @@ rides a new, controller-ignored annotation).
 
 1. execd: config persistence plus execd-owned `preStart` and `periodic`; tests and execd image release.
 2. `specs/sandbox-lifecycle.yml`: additive `CreateSandboxRequest.lifecycle` with `preStart` and `periodic`; regenerate SDKs and add server create-time transport.
-3. Future phase: `run`/`config`/`status` endpoints, PATCH, and the remaining transition hooks after their deferred persistence/failure semantics are resolved.
+3. Future phase: `run`/`config`/`status` endpoints (including lifecycle startup readiness), PATCH, and the remaining transition hooks after their deferred persistence/failure semantics are resolved.
 4. Docker and K8s provider orchestration, grace-period wiring, and transition E2E coverage.
 5. Pool-mode parity via per-sandbox `spec.taskTemplate` injection (R11), with `preTerminate` gated on `execd_run_as_init` until another explicit TERM route exists (R13).
 

--- a/oseps/README.md
+++ b/oseps/README.md
@@ -25,4 +25,4 @@ This is the complete list of OpenSandbox Enhancement Proposals:
 | [OSEP-0017](0017-resilient-sdk-transport.md)                   |      Resilient SDK Transport                                              | implementing  |  2026-07-22  |
 | [OSEP-0018](0018-execd-as-sandbox-init.md)                     |      execd as Sandbox Init                                                |     draft     |  2026-07-27  |
 | [OSEP-0019](0019-node-agent-sandbox-collection.md)             |      Node Agent for Node-Level Sandbox Collection                         | implementing  |  2026-08-11  |
-| [OSEP-0020](0020-sandbox-lifecycle-hooks.md)                   |      Sandbox Lifecycle Hooks                                             |     draft     |  2026-08-17  |
+| [OSEP-0020](0020-sandbox-lifecycle-hooks.md)                   |      Sandbox Lifecycle Hooks                                             | implementing  |  2026-08-21  |


### PR DESCRIPTION
## Summary

- align the default persisted config path with execd: `$HOME/.execd/lifecycle.toml`, with exact `EXECD_LIFECYCLE_CONFIG` override semantics
- fail lifecycle startup when the selected config path cannot be resolved or persisted
- document the lifecycle hook trust boundary
- update `preStart` ownership and ordering for normal bootstrap and init mode
- gate Pool `preTerminate` on `execd_run_as_init` and require Pool TTL/delete coverage
- refresh the phased rollout for the current `preStart` + `periodic` scope
- keep `/ping` as liveness and require future resume orchestration to wait for lifecycle startup success before `postResume` or public `Running`

## Deferred

This intentionally does not design the two items marked `delay` in the OSEP-0020 review:

- AgentSandbox pause/resume lifecycle semantics
- PATCH multi-write ordering, partial failure, and reconciliation

## Validation

- `git diff --check`
- two independent read-only source/diff reviews

Follow-up to #1542.
