### PR TITLE
chore(egress): prune dead code, stale docs, and ineffective tests

### DIFF
--- a/components/egress/Dockerfile
+++ b/components/egress/Dockerfile
@@ -124,10 +124,10 @@ RUN chown mitmproxy:mitmproxy /var/lib/mitmproxy/.mitmproxy/config.yaml \
 COPY --from=builder /out/egress /opt/opensandbox-egress/egress
 COPY --from=builder /out/opensandbox-supervisor /opt/opensandbox-egress/supervisor
 # Pre-start hook: reap any mitmdump left over from a previous crashed
-# egress so the new launch can bind the transparent-MITM listen port.
-# Intentionally does NOT touch iptables/nft rules — the sidecar shares
-# a network namespace with the workload, so leaving rules in place keeps
-# egress filtering active across the supervisor's backoff window.
+# egress, and remove stale DNS-redirect iptables rules + opensandbox_dns_redirect
+# nft tables left pointing at a dead proxy. The `inet opensandbox` policy table
+# is intentionally NOT touched — the nftables manager prepends its own delete
+# and recreates the table on every ApplyStatic, so it is idempotent.
 COPY components/egress/scripts/cleanup.sh /opt/opensandbox-egress/cleanup.sh
 RUN chmod 0755 /opt/opensandbox-egress/cleanup.sh \
             /opt/opensandbox-egress/egress \
@@ -137,9 +137,9 @@ RUN chmod 0755 /opt/opensandbox-egress/cleanup.sh \
 COPY components/egress/mitmscripts /var/egress/mitmscripts
 
 # Supervisor wraps the egress binary: restarts on crash with backoff and
-# forwards SIGTERM gracefully. The cleanup hook runs only as pre-start;
-# running it on post-exit would tear down enforcement during the backoff
-# window and leave the workload unprotected.
+# forwards SIGTERM gracefully. The cleanup hook runs only as pre-start; the
+# next egress process re-installs all redirect rules itself after startup,
+# so there is nothing to run on post-exit.
 # Expects OPENSANDBOX_NETWORK_POLICY env at runtime.
 ENTRYPOINT ["/opt/opensandbox-egress/supervisor", \
             "--pre-start=/opt/opensandbox-egress/cleanup.sh", \

--- a/components/egress/hooks/doc.go
+++ b/components/egress/hooks/doc.go
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package hooks: side-effect import target. Add files here whose init() registers startup.Register/RegisterFunc;
+// Package hooks: side-effect import target. Add files here whose init() registers startup.Register;
 // hooks run in startup.RunPost after the MITM/iptables path in main, before blocking on signal.
 package hooks

--- a/components/egress/mitmproxy_transparent.go
+++ b/components/egress/mitmproxy_transparent.go
@@ -30,10 +30,9 @@ import (
 	"github.com/alibaba/opensandbox/internal/safego"
 )
 
-// exitEvent carries an OnExit notification tagged with the generation of the
-// mitmdump process that produced it. Generation tagging lets the watcher tell
-// "the currently-running mitmdump just died" apart from "a half-launched
-// attempt we already killed during a retry storm just finished reaping".
+// exitEvent carries an OnExit notification tagged with the mitmdump generation
+// that produced it, so the watcher can tell the live process dying apart from
+// a killed half-launched attempt being reaped.
 type exitEvent struct {
 	gen uint64
 	err error
@@ -72,15 +71,10 @@ func (m *mitmTransparent) getCurrentGen() uint64 {
 }
 
 // launchTagged starts mitmdump with an OnExit closure that publishes the death
-// of this specific process (identified by gen) into restartCh.
-//
-// The send is blocking with shutdownCh as the only escape: dropping an exit
-// event while the watcher is still running can leave egress in a silent dead
-// state (the watcher would never see the death and never trigger a restart).
-// Stale events from killed half-launched attempts are still cheap to discard
-// downstream via the gen check in watchMitmproxy; we just must not lose them
-// in transit. Shutdown is the only legitimate reason to give up on a send,
-// and we log a warning when that happens so the drop is observable.
+// of this specific process (identified by gen) into restartCh. The send blocks
+// (shutdownCh is the only escape): losing an exit event would leave the watcher
+// blind to a dead mitmdump, while stale events from killed attempts are cheap
+// to discard via the gen check in watchMitmproxy.
 func launchTagged(cfg mitmproxy.Config, restartCh chan<- exitEvent, shutdownCh <-chan struct{}, gen uint64) (*mitmproxy.Running, error) {
 	cfg.OnExit = func(err error) {
 		select {
@@ -114,11 +108,8 @@ func startMitmproxyTransparentIfEnabled() (*mitmTransparent, error) {
 		UserName:    mitmproxy.RunAsUser,
 		ScriptPaths: parseScriptPaths(os.Getenv(constants.EnvMitmproxyScript)),
 	}
-	// Buffer absorbs OnExit events from a retry storm so OnExit goroutines
-	// don't all park waiting for the watcher to drain. Correctness does not
-	// depend on the size: launchTagged uses a blocking send with shutdownCh
-	// as the only escape, so events cannot be silently dropped while the
-	// watcher is alive.
+	// Buffer absorbs a retry storm; correctness does not depend on the size
+	// (launchTagged sends block, so events are never silently dropped).
 	restartCh := make(chan exitEvent, 64)
 	shutdownCh := make(chan struct{})
 	const initialGen uint64 = 1
@@ -191,14 +182,13 @@ func (m *mitmTransparent) watchMitmproxy(ctx context.Context, gate *mitmproxy.He
 	})
 }
 
-// restartWithBackoff retries mitmdump launch indefinitely with exponential backoff
-// (1s, 2s, 4s, ..., capped at 30s) until it succeeds or ctx is cancelled.
-// Transient OOM / resource pressure must not leave egress in a permanent dead state.
+// restartWithBackoff retries mitmdump launch indefinitely with exponential
+// backoff (1s..30s) until it succeeds or ctx is cancelled, so transient OOM /
+// resource pressure cannot leave egress permanently dead.
 //
-// Each attempt is tagged with a fresh generation; setRunning publishes that
-// generation as the "live" one. Exit events for older (killed) generations are
-// filtered out by watchMitmproxy, so we do NOT drain restartCh here -- doing
-// so could swallow a real death of the freshly-restarted mitmdump.
+// Each attempt gets a fresh generation. Exit events for older (killed)
+// generations are filtered by watchMitmproxy, so restartCh must not be drained
+// here — doing so could swallow a real death of the freshly-restarted mitmdump.
 func (m *mitmTransparent) restartWithBackoff(ctx context.Context, gate *mitmproxy.HealthGate) {
 	const (
 		initialBackoff = time.Second

--- a/components/egress/pkg/dnsproxy/proxy.go
+++ b/components/egress/pkg/dnsproxy/proxy.go
@@ -295,18 +295,6 @@ func (p *Proxy) shouldFailoverAfterResponse(resp *dns.Msg) (tryNext bool, reason
 	}
 }
 
-func (p *Proxy) UpstreamHost() string {
-	list := p.forwardUpstreams()
-	if len(list) == 0 {
-		return ""
-	}
-	host, _, err := net.SplitHostPort(list[0])
-	if err != nil {
-		return ""
-	}
-	return host
-}
-
 // UpdatePolicy replaces the user policy from POST/GET /policy (not the always file overlay). Nil → default deny-all.
 func (p *Proxy) UpdatePolicy(newPolicy *policy.NetworkPolicy) {
 	p.policyMu.Lock()

--- a/components/egress/pkg/dnsproxy/proxy_test.go
+++ b/components/egress/pkg/dnsproxy/proxy_test.go
@@ -206,20 +206,10 @@ func TestForwardClassifiesFailures(t *testing.T) {
 func TestSetOnResolved(t *testing.T) {
 	proxy, err := New(policy.DefaultDenyPolicy(), "", nil, nil)
 	require.NoError(t, err)
-	var called bool
-	var capturedDomain string
-	var capturedIPs []nftables.ResolvedIP
-	proxy.SetOnResolved(func(domain string, ips []nftables.ResolvedIP) {
-		called = true
-		capturedDomain = domain
-		capturedIPs = ips
-	})
+	proxy.SetOnResolved(func(_ string, _ []nftables.ResolvedIP) {})
 	require.NotNil(t, proxy.onResolved, "SetOnResolved did not set callback")
 	proxy.SetOnResolved(nil)
 	require.Nil(t, proxy.onResolved, "SetOnResolved(nil) did not clear callback")
-	_ = called
-	_ = capturedDomain
-	_ = capturedIPs
 }
 
 func TestMaybeNotifyResolved_CallsCallbackWhenAOrAAAA(t *testing.T) {

--- a/components/egress/pkg/dnsproxy/upstream_test.go
+++ b/components/egress/pkg/dnsproxy/upstream_test.go
@@ -116,9 +116,6 @@ func TestShouldFailoverAfterResponse(t *testing.T) {
 	try, _ := p2.shouldFailoverAfterResponse(emptyOK)
 	require.False(t, try, "empty NOERROR should not failover")
 
-	try, _ = p2.shouldFailoverAfterResponse(emptyOK)
-	require.False(t, try, "empty NOERROR on last upstream should not failover")
-
 	emptyNODATA := new(dns.Msg)
 	emptyNODATA.Rcode = dns.RcodeSuccess
 	emptyNODATA.Ns = []dns.RR{

--- a/components/egress/pkg/events/events_test.go
+++ b/components/egress/pkg/events/events_test.go
@@ -36,12 +36,18 @@ func (c *captureSubscriber) HandleBlocked(_ context.Context, ev BlockedEvent) {
 }
 
 type blockingSubscriber struct {
-	block chan struct{}
-	recv  chan BlockedEvent
+	entered chan struct{}
+	block   chan struct{}
+	recv    chan BlockedEvent
 }
 
 func (b *blockingSubscriber) HandleBlocked(_ context.Context, ev BlockedEvent) {
-	// Block until the channel is closed to simulate a slow consumer and trigger backpressure.
+	// Signal the test that the handler is busy, then block until the channel
+	// is closed to simulate a slow consumer and trigger backpressure.
+	select {
+	case b.entered <- struct{}{}:
+	default:
+	}
 	<-b.block
 	select {
 	case b.recv <- ev:
@@ -86,29 +92,36 @@ func TestBroadcasterDropsWhenSubscriberBackedUp(t *testing.T) {
 
 	// Small queue; blocking subscriber holds the first event it handles.
 	b := NewBroadcaster(ctx, BroadcasterConfig{QueueSize: 1})
+	entered := make(chan struct{})
 	block := make(chan struct{})
-	sub := &blockingSubscriber{block: block, recv: make(chan BlockedEvent, 8)}
+	sub := &blockingSubscriber{entered: entered, block: block, recv: make(chan BlockedEvent, 8)}
 	b.AddSubscriber(sub)
 
 	ev1 := BlockedEvent{Hostname: "first.example", Timestamp: time.Now()}
 	ev2 := BlockedEvent{Hostname: "second.example", Timestamp: time.Now()}
+	ev3 := BlockedEvent{Hostname: "third.example", Timestamp: time.Now()}
 
+	// ev1 is handed directly to the subscriber, which then blocks in its handler.
 	b.Publish(ev1)
-	// This publish should drop because the subscriber is busy and the queue is full.
+	<-entered
+	// Subscriber is provably busy: ev2 fills the one-slot queue, ev3 is dropped.
 	b.Publish(ev2)
+	b.Publish(ev3)
 
 	// Allow subscriber to drain whatever was queued.
 	close(block)
 
-	select {
-	case got := <-sub.recv:
-		require.Equal(t, ev1.Hostname, got.Hostname, "first event must be delivered")
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "subscriber did not receive the first event")
+	for _, want := range []BlockedEvent{ev1, ev2} {
+		select {
+		case got := <-sub.recv:
+			require.Equal(t, want.Hostname, got.Hostname, "expected %s to be delivered", want.Hostname)
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "subscriber did not receive %s", want.Hostname)
+		}
 	}
 	select {
 	case dropped := <-sub.recv:
-		require.FailNow(t, "second event should have been dropped, got %s", dropped.Hostname)
+		require.FailNow(t, "third event should have been dropped, got %s", dropped.Hostname)
 	case <-time.After(200 * time.Millisecond):
 	}
 

--- a/components/egress/pkg/events/events_test.go
+++ b/components/egress/pkg/events/events_test.go
@@ -37,12 +37,16 @@ func (c *captureSubscriber) HandleBlocked(_ context.Context, ev BlockedEvent) {
 
 type blockingSubscriber struct {
 	block chan struct{}
+	recv  chan BlockedEvent
 }
 
 func (b *blockingSubscriber) HandleBlocked(_ context.Context, ev BlockedEvent) {
 	// Block until the channel is closed to simulate a slow consumer and trigger backpressure.
 	<-b.block
-	_ = ev
+	select {
+	case b.recv <- ev:
+	default:
+	}
 }
 
 func TestBroadcasterFanout(t *testing.T) {
@@ -80,21 +84,33 @@ func TestBroadcasterDropsWhenSubscriberBackedUp(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Small queue; blocking subscriber will hold the first event.
+	// Small queue; blocking subscriber holds the first event it handles.
 	b := NewBroadcaster(ctx, BroadcasterConfig{QueueSize: 1})
 	block := make(chan struct{})
-	sub := &blockingSubscriber{block: block}
+	sub := &blockingSubscriber{block: block, recv: make(chan BlockedEvent, 8)}
 	b.AddSubscriber(sub)
 
 	ev1 := BlockedEvent{Hostname: "first.example", Timestamp: time.Now()}
 	ev2 := BlockedEvent{Hostname: "second.example", Timestamp: time.Now()}
 
 	b.Publish(ev1)
-	// This publish should drop because subscriber is blocked and queue size is 1.
+	// This publish should drop because the subscriber is busy and the queue is full.
 	b.Publish(ev2)
 
-	// Allow subscriber to drain and exit.
+	// Allow subscriber to drain whatever was queued.
 	close(block)
+
+	select {
+	case got := <-sub.recv:
+		require.Equal(t, ev1.Hostname, got.Hostname, "first event must be delivered")
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "subscriber did not receive the first event")
+	}
+	select {
+	case dropped := <-sub.recv:
+		require.FailNow(t, "second event should have been dropped, got %s", dropped.Hostname)
+	case <-time.After(200 * time.Millisecond):
+	}
 
 	b.Close()
 }

--- a/components/egress/pkg/mitmproxy/cacert_export.go
+++ b/components/egress/pkg/mitmproxy/cacert_export.go
@@ -63,13 +63,10 @@ func waitMitmCACertPath(confDirEnv, home string) (string, error) {
 }
 
 // PurgeStaleExportedCA removes any mitmproxy-ca-cert.pem left on the shared
-// volume by a previous generation of this egress container. mitmproxy's CA
-// lives in the egress container's ephemeral confdir, so an egress container
-// restart rotates the CA while the previous public cert is still on the
-// (pod-scoped) shared volume; without this purge, an agent container starting
-// alongside us would pass its bootstrap readiness check on the stale file
-// and install a CA that no longer matches what mitmproxy will sign with.
-// See upstream issue #1370. Must be called as early as possible in main().
+// volume by a previous egress generation: a restart rotates the CA in the
+// ephemeral confdir, and the stale cert would let an agent pass its bootstrap
+// readiness check and install a CA mitmproxy no longer signs with (issue #1370).
+// Must be called as early as possible in main().
 func PurgeStaleExportedCA() {
 	if !constants.IsTruthy(os.Getenv(constants.EnvMitmproxyTransparent)) {
 		return

--- a/components/egress/pkg/mitmproxy/launch.go
+++ b/components/egress/pkg/mitmproxy/launch.go
@@ -42,12 +42,11 @@ const listenHostLoopback = "127.0.0.1"
 // (COPY components/egress/mitmscripts /var/egress/mitmscripts). Always loaded.
 const systemScriptPath = "/var/egress/mitmscripts/system.py"
 
-// Config: mitmdump --mode transparent. Static options (mode, connection_strategy,
-// listen_host, stream_large_bodies, ignore_hosts,
-// ssl_verify_upstream_trusted_confdir) live in
-// /var/lib/mitmproxy/.mitmproxy/config.yaml and are auto-loaded by mitmdump.
-// This struct carries only per-launch dynamic values that override those
-// defaults via `--set`.
+// Config carries only per-launch dynamic values, applied via `--set`. Static
+// options (mode, listen_host, connection_strategy, stream_large_bodies,
+// ignore_hosts, ssl_verify_upstream_trusted_confdir) are auto-loaded by
+// mitmdump from /var/lib/mitmproxy/.mitmproxy/config.yaml (shipped from
+// components/egress/mitmproxy/config.yaml).
 type Config struct {
 	ListenPort int
 	UserName   string

--- a/components/egress/pkg/nftables/manager.go
+++ b/components/egress/pkg/nftables/manager.go
@@ -61,10 +61,6 @@ type Manager struct {
 	tracker *connectionTracker
 }
 
-func NewManager() *Manager {
-	return newManager(defaultRunner, Options{BlockDoT: true})
-}
-
 func NewManagerWithRunner(r runner) *Manager {
 	return newManager(r, Options{BlockDoT: true})
 }
@@ -149,20 +145,15 @@ func (m *Manager) AddResolvedIPs(ctx context.Context, ips []ResolvedIP) error {
 }
 
 // StartConnectionRefresh keeps DNS-learned IPs authorized while a TCP
-// connection to them is active. The normal set timeout remains as the grace
-// period after the connection closes.
+// connection to them is active; the set timeout remains as the grace period
+// after the connection closes.
 //
-// Renewal is intentionally best-effort:
-//   - an active connection first observed after its entry expires is restored
-//     on the next poll, so reconnects may fail for up to one refresh interval;
-//   - a connection that starts and closes entirely between polls cannot be
-//     observed and requires a later DNS lookup to restore its expired entry;
-//   - delayed polls or nft failures can extend the temporary reconnect gap;
-//   - only TCP is tracked here; UDP and QUIC rely on DNS-driven entry refresh.
-//
-// Existing connections survive these gaps through conntrack. A successful
-// observation renews the entry for the full timeout, and the final observation
-// after close provides the same bounded grace period for reconnects.
+// Renewal is best-effort: a connection that starts and closes between polls
+// is never observed (needs a later DNS lookup), an entry expired before its
+// first observation is restored on the next poll, and nft failures extend the
+// gap. Only TCP is tracked; UDP and QUIC rely on DNS-driven refresh. Existing
+// connections survive these gaps through conntrack, and the final observation
+// after close provides the bounded reconnect grace period.
 func (m *Manager) StartConnectionRefresh(ctx context.Context) {
 	m.tracker.start(ctx, m.opts.ConnectionRefreshInterval, m)
 }

--- a/components/egress/pkg/startup/hook.go
+++ b/components/egress/pkg/startup/hook.go
@@ -39,22 +39,6 @@ func Register(h Hook) {
 	hooks = append(hooks, h)
 }
 
-func RegisterFunc(name string, fn func(ctx context.Context) error) {
-	if fn == nil {
-		return
-	}
-	Register(funcHook{name: name, fn: fn})
-}
-
-type funcHook struct {
-	name string
-	fn   func(context.Context) error
-}
-
-func (f funcHook) Name() string { return f.name }
-
-func (f funcHook) Run(ctx context.Context) error { return f.fn(ctx) }
-
 func RunPost(ctx context.Context) error {
 	mu.Lock()
 	list := append([]Hook(nil), hooks...)

--- a/components/egress/pkg/telemetry/metrics.go
+++ b/components/egress/pkg/telemetry/metrics.go
@@ -104,20 +104,12 @@ func registerEgressMetrics() error {
 		"egress.dns.query.duration",
 		metric.WithDescription("DNS forward latency"),
 		metric.WithUnit("s"),
-		// Explicit boundaries: this instrument records seconds, but the SDK default
-		// boundaries are the spec's millisecond ladder (0, 5, 10, ... 10000), so every
-		// realistic DNS latency lands in the same bucket and the quantiles are noise.
-		//
-		// The head spans a cache hit (sub-ms) to one upstream timeout
-		// (DefaultDNSUpstreamTimeoutSec = 5s). The coarse tail covers the retry chain:
-		// forward() walks the resolvers serially, each with the full timeout, and the
-		// recorded duration is the whole chain — so a query can legitimately take
-		// timeout x len(upstreams), and a late *success* lands there too, not just an
-		// exhausted failure. 15s is three resolvers at the default; 600s covers the 120s
-		// per-exchange cap across a handful of them. The chain has no finite worst case
-		// (OPENSANDBOX_EGRESS_DNS_UPSTREAM takes an unbounded resolver list), so past the
-		// last boundary quantile resolution is lost by construction and _count is what
-		// remains — a configuration that gets there has bigger problems than a percentile.
+		// Explicit boundaries: the instrument records seconds, but the SDK default
+		// boundaries are the spec's millisecond ladder, which would collapse every
+		// realistic latency into one bucket. The head covers a cache hit up to one
+		// upstream timeout (5s); the tail must reach past a serial retry chain of
+		// timeout x len(upstreams) — including late successes — hence 600s. See
+		// docs/opentelemetry.md for the full rationale.
 		metric.WithExplicitBucketBoundaries(
 			0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
 			15, 30, 60, 120, 300, 600,

--- a/components/egress/pkg/telemetry/metrics_test.go
+++ b/components/egress/pkg/telemetry/metrics_test.go
@@ -26,31 +26,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/alibaba/opensandbox/egress/pkg/constants"
-	inttelemetry "github.com/alibaba/opensandbox/internal/telemetry"
 )
-
-func TestAppendMetricAttrsFromKeyValuePairs(t *testing.T) {
-	var base []attribute.KeyValue
-	out := inttelemetry.AppendAttrsFromKeyValuePairs(base, "a=b")
-	assert.Len(t, out, 1)
-	assert.Equal(t, "a", string(out[0].Key))
-	assert.Equal(t, "b", out[0].Value.AsString())
-
-	out = inttelemetry.AppendAttrsFromKeyValuePairs(nil, "  foo=bar  , baz=qux ")
-	assert.Len(t, out, 2)
-	assert.Equal(t, "foo", string(out[0].Key))
-	assert.Equal(t, "bar", out[0].Value.AsString())
-	assert.Equal(t, "baz", string(out[1].Key))
-	assert.Equal(t, "qux", out[1].Value.AsString())
-
-	out = inttelemetry.AppendAttrsFromKeyValuePairs(nil, "k=v=x")
-	assert.Len(t, out, 1)
-	assert.Equal(t, "k", string(out[0].Key))
-	assert.Equal(t, "v=x", out[0].Value.AsString())
-
-	out = inttelemetry.AppendAttrsFromKeyValuePairs(nil, "novalue=,=bad,nokv")
-	assert.Len(t, out, 0)
-}
 
 // The instrument records seconds, so it needs boundaries on a seconds ladder. With the
 // SDK default (the spec's millisecond ladder) every realistic DNS latency collapses into

--- a/components/egress/telemetry_allow.go
+++ b/components/egress/telemetry_allow.go
@@ -23,15 +23,12 @@ import (
 // telemetryAllowRules returns an always-allow egress rule for the OTLP
 // destination the exporter will dial, so metric export works under the default
 // deny-all policy without operator-provided allowlist rules. The destination
-// is the endpoint env var
-// (OTEL_EXPORTER_OTLP_METRICS_ENDPOINT / OTEL_EXPORTER_OTLP_ENDPOINT, URL form
-// as required by otlpmetrichttp) or, only when neither is set, the exporter
-// fallback node IP (HOST_IP / /etc/hostinfo). A set-but-unparseable endpoint
-// is not treated as unset: the exporter never falls back to the node IP in
-// that case, so no rule is injected. The rule targets the host (any port),
-// matching the egress rule model. Operators can still block the target via
-// deny.always, which takes precedence. Returns nil when no OTLP destination
-// is configured.
+// is the endpoint env URL (OTEL_EXPORTER_OTLP_METRICS_ENDPOINT /
+// OTEL_EXPORTER_OTLP_ENDPOINT, as required by otlpmetrichttp) or, only when
+// neither is set, the exporter fallback node IP (HOST_IP / /etc/hostinfo). A
+// set-but-unparseable endpoint never falls back to the node IP, so no rule is
+// injected. Operators can still block the target via deny.always, which takes
+// precedence. Returns nil when no OTLP destination is configured.
 func telemetryAllowRules() []policy.EgressRule {
 	host, port, ok := inttelemetry.OTLPEndpointHostPort()
 	if !ok {

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -81,7 +81,7 @@ Optional advanced features:
 - Denied hostname webhook: `OPENSANDBOX_EGRESS_DENY_WEBHOOK` (server injects `OPENSANDBOX_EGRESS_SANDBOX_ID` automatically; not user-settable)
 - DoH/DoT controls: `OPENSANDBOX_EGRESS_BLOCK_DOH_443`, `OPENSANDBOX_EGRESS_DOH_BLOCKLIST`
 - Custom DNS upstream: `OPENSANDBOX_EGRESS_DNS_UPSTREAM` (comma-separated IPs, optional `:port`), `OPENSANDBOX_EGRESS_DNS_UPSTREAM_TIMEOUT` (default `5` seconds)
-- DNS upstream health probe: `OPENSANDBOX_EGRESS_DNS_UPSTREAM_PROBE` (enable), `OPENSANDBOX_EGRESS_DNS_UPSTREAM_PROBE_INTERVAL_SEC`
+- DNS upstream health probe: `OPENSANDBOX_EGRESS_DNS_UPSTREAM_PROBE` (probe name; default is root IN NS, set an FQDN your resolvers always answer), `OPENSANDBOX_EGRESS_DNS_UPSTREAM_PROBE_INTERVAL_SEC` (default `30`)
 - Credential vault: `OPENSANDBOX_EGRESS_CREDENTIAL_VAULT_REQUIRE_TLS`, `OPENSANDBOX_EGRESS_CREDENTIAL_VAULT_TRUSTED_PROXY_CIDRS`, `OPENSANDBOX_CREDENTIAL_PROXY_SOCKET` (default `/run/opensandbox/credential-proxy/active.sock`)
 - Metrics: `OPENSANDBOX_EGRESS_METRICS_EXTRA_ATTRS` (extra key=value attributes for OTLP metrics and structured log fields)
 
@@ -93,7 +93,7 @@ Static rule files under `/var/egress/rules/` are loaded at startup and take prio
 |------|---------|
 | `/var/egress/rules/deny.always` | Domains always denied, overrides user and allow rules |
 | `/var/egress/rules/allow.always` | Domains always allowed, overrides user rules |
-| `/var/egress/rules/log_skip.always` | Domain patterns whose DNS blocks are not logged (noise reduction) |
+| `/var/egress/rules/log_skip.always` | Domain patterns whose successful outbound DNS resolutions are not logged (noise reduction); failed/denied lookups are still logged |
 
 Format: one domain per line (supports wildcards like `*.example.com`). Lines starting with `#` are comments. Missing files are silently ignored.
 


### PR DESCRIPTION
## What

Code hygiene pass over `components/egress`, reviewed against the monorepo guidelines (no generated output touched, spec/SDK surface unchanged):

### Dead code removed
- `dnsproxy.Proxy.UpstreamHost()` — zero callers
- `startup.RegisterFunc` + `funcHook` — zero callers (only a doc comment mentioned it)
- `nftables.NewManager()` — zero callers

### Doc drift fixed
- **Dockerfile**: comments claimed `cleanup.sh` "intentionally does NOT touch iptables/nft rules", contradicting the script (it removes stale DNS REDIRECT rules and `opensandbox_dns_redirect` tables; only the `inet opensandbox` policy table is left alone)
- **docs/components/egress.md**: `log_skip.always` was described as suppressing "DNS blocks" logging; it actually suppresses the successful-outbound log line (denied/failed still logged). `OPENSANDBOX_EGRESS_DNS_UPSTREAM_PROBE` was mislabeled "(enable)" — it is the probe name
- `hooks/doc.go` reference to the removed `RegisterFunc`

### Verbose comments trimmed
`launchTagged` (10→5 lines), `restartCh` buffer (5→2), `exitEvent`, `restartWithBackoff`, `Config` doc, `StartConnectionRefresh` (15→9), metric bucket-boundary comment (14→6, points at `docs/opentelemetry.md`), `PurgeStaleExportedCA`, `telemetryAllowRules`.

### Tests
- Removed `TestAppendMetricAttrsFromKeyValuePairs` — verbatim duplicate of `components/internal/telemetry`'s own test
- Removed a copy-pasted duplicate assertion in `TestShouldFailoverAfterResponse`
- Removed dead capture vars in `TestSetOnResolved`
- `TestBroadcasterDropsWhenSubscriberBackedUp` now actually asserts the drop instead of running the path silently

## Verification
- `gofmt -l` clean, `go vet ./...`, `go build ./...`, `go test ./...` all pass
- Touched packages (`events`, `dnsproxy`, `startup`, `nftables`) also pass with `-race -count=3`