### PR TITLE
fix(execd): remove command SSE tail delay

### DIFF
--- a/components/execd/pkg/web/controller/command.go
+++ b/components/execd/pkg/web/controller/command.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alibaba/opensandbox/execd/pkg/flag"
 	"github.com/alibaba/opensandbox/execd/pkg/jupyter/execute"
 	"github.com/alibaba/opensandbox/execd/pkg/runtime"
 	"github.com/alibaba/opensandbox/execd/pkg/telemetry"
@@ -113,12 +112,6 @@ func (c *CodeInterpretingController) RunCommand() {
 	}
 
 	waitForExecutionComplete(ctx, completeCh)
-
-	// Keep the SSE connection alive briefly so clients can read all
-	// buffered events and downstream components (e.g. egress sidecar)
-	// have time to synchronise state changes that were triggered
-	// during command execution.
-	time.Sleep(flag.ApiGracefulShutdownTimeout)
 }
 
 // InterruptCommand stops a running shell command session.

--- a/components/execd/pkg/web/controller/command_test.go
+++ b/components/execd/pkg/web/controller/command_test.go
@@ -20,7 +20,9 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/alibaba/opensandbox/execd/pkg/flag"
 	"github.com/alibaba/opensandbox/execd/pkg/runtime"
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
 	"github.com/stretchr/testify/require"
@@ -55,6 +57,34 @@ func TestBuildExecuteCommandRequestForwardsEnvsBackground(t *testing.T) {
 
 	require.Equal(t, runtime.BackgroundCommand, execReq.Language)
 	require.True(t, reflect.DeepEqual(execReq.Envs, envs), "expected envs to be forwarded")
+}
+
+func TestRunCommandReturnsBeforeGracefulShutdownTimeoutAfterCompletion(t *testing.T) {
+	previousRunner := codeRunner
+	previousTimeout := flag.ApiGracefulShutdownTimeout
+	codeRunner = &fakeCodeRunner{
+		execute: func(request *runtime.ExecuteCodeRequest) error {
+			request.Hooks.OnExecuteComplete(time.Millisecond)
+			return nil
+		},
+	}
+	flag.ApiGracefulShutdownTimeout = 200 * time.Millisecond
+	t.Cleanup(func() {
+		codeRunner = previousRunner
+		flag.ApiGracefulShutdownTimeout = previousTimeout
+	})
+
+	body := []byte(`{"command":"true","timeout":0}`)
+	ctx, w := newTestContext(http.MethodPost, "/command", body)
+	ctrl := NewCodeInterpretingController(ctx)
+
+	start := time.Now()
+	ctrl.RunCommand()
+	elapsed := time.Since(start)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Type"), "text/event-stream")
+	require.Less(t, elapsed, flag.ApiGracefulShutdownTimeout/2)
 }
 
 func setupCommandController(method, path string) (*CodeInterpretingController, *httptest.ResponseRecorder) {


### PR DESCRIPTION
## Summary\n- remove the redundant graceful-shutdown sleep after RunCommand has already observed the terminal SSE callback\n- add a regression test that asserts completed commands return before the full graceful-shutdown timeout\n\nwaitForExecutionComplete already waits for the terminal callback (with the graceful timeout as its fallback). The second unconditional sleep added a fixed tail delay to every completed command.\n\n## Testing\n- [x] gofmt\n- [x] git diff --check\n- [x] go vet ./pkg/web/controller\n- [x] go test ./pkg/web/controller -run 'TestRunCommand|TestBuildExecuteCommandRequest|TestGetCommand|TestGetBackgroundCommand' -count=1\n- [x] golangci-lint run ./pkg/web/controller/... --new-from-rev=HEAD\n- [ ] go test ./pkg/web/controller -count=1 — two pre-existing failures remain: TestBackgroundRun_HTTPFlow and TestGetRunLogs_RejectsMalformedCursor both fail with context not found on this branch and on a clean worktree at base commit 1928050.\n- [ ] Linux bwrap integration tests and -race are left to CI: this local Windows environment has no Linux runtime, and its execution policy blocks the race-built test binary after compilation.\n\nCloses #1277.