### PR TITLE
fix(execd): force execd files executable in image build

### DIFF
--- a/components/execd/Dockerfile
+++ b/components/execd/Dockerfile
@@ -141,11 +141,11 @@ RUN CGO_ENABLED=0 go build -tags ebpf -trimpath -buildvcs=false \
 
 FROM alpine:latest
 
-COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/bwrap/bwrap /usr/local/bin/bwrap
-COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-session-gate /usr/local/libexec/opensandbox-session-gate
-COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-session-gate /opt/opensandbox/opensandbox-session-gate
-COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-launcher /usr/local/libexec/opensandbox-launcher
-COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-launcher /opt/opensandbox/opensandbox-launcher
+COPY --from=bwrap-builder --chown=0:0 /build/bwrap/bwrap /usr/local/bin/bwrap
+COPY --from=bwrap-builder --chown=0:0 /build/opensandbox-session-gate /usr/local/libexec/opensandbox-session-gate
+COPY --from=bwrap-builder --chown=0:0 /build/opensandbox-session-gate /opt/opensandbox/opensandbox-session-gate
+COPY --from=bwrap-builder --chown=0:0 /build/opensandbox-launcher /usr/local/libexec/opensandbox-launcher
+COPY --from=bwrap-builder --chown=0:0 /build/opensandbox-launcher /opt/opensandbox/opensandbox-launcher
 COPY --from=builder /build/execd .
 COPY --from=builder /build/execd.exe ./execd.exe
 COPY --from=builder /build/opensandbox-supervisor ./opensandbox-supervisor
@@ -155,6 +155,11 @@ COPY components/execd/install.bat ./install.bat
 
 # Defensive: force execd-related files executable for all users regardless
 # of source checkout permissions.
-RUN chmod a+x ./execd ./execd.exe ./execd-ebpf ./opensandbox-supervisor ./bootstrap.sh
+RUN chmod a+x ./execd ./execd.exe ./execd-ebpf ./opensandbox-supervisor ./bootstrap.sh \
+    /usr/local/bin/bwrap \
+    /usr/local/libexec/opensandbox-session-gate \
+    /opt/opensandbox/opensandbox-session-gate \
+    /usr/local/libexec/opensandbox-launcher \
+    /opt/opensandbox/opensandbox-launcher
 
 ENTRYPOINT ["./execd"]

--- a/components/execd/Dockerfile
+++ b/components/execd/Dockerfile
@@ -141,7 +141,7 @@ RUN CGO_ENABLED=0 go build -tags ebpf -trimpath -buildvcs=false \
 
 FROM alpine:latest
 
-COPY --from=bwrap-builder /build/bwrap/bwrap /usr/local/bin/bwrap
+COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/bwrap/bwrap /usr/local/bin/bwrap
 COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-session-gate /usr/local/libexec/opensandbox-session-gate
 COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-session-gate /opt/opensandbox/opensandbox-session-gate
 COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-launcher /usr/local/libexec/opensandbox-launcher
@@ -152,5 +152,9 @@ COPY --from=builder /build/opensandbox-supervisor ./opensandbox-supervisor
 COPY --from=ebpf-builder /build/execd-ebpf ./execd-ebpf
 COPY components/execd/bootstrap.sh ./bootstrap.sh
 COPY components/execd/install.bat ./install.bat
+
+# Defensive: force execd-related files executable for all users regardless
+# of source checkout permissions.
+RUN chmod a+x ./execd ./execd.exe ./execd-ebpf ./opensandbox-supervisor ./bootstrap.sh
 
 ENTRYPOINT ["./execd"]


### PR DESCRIPTION
## Summary

Add a defensive layer to the execd image build so execd-related files are always executable for all users, regardless of source checkout permissions.

## Changes

- `components/execd/Dockerfile`:
  - `RUN chmod a+x` on `execd`, `execd.exe`, `execd-ebpf`, `opensandbox-supervisor`, `bootstrap.sh`
  - Add `--chmod=0555` to the `bwrap` COPY (session-gate/launcher already had it)

## Background

`components/execd/bootstrap.sh` has always been `100755` in git history (no commit ever changed its permission), but checkout environments/filesystems may drop the exec bit, which can break image builds or runtime launches. This hardens the image build against that.