### PR TITLE
fix(execd): validate cwd with request environment

### DIFF
--- a/components/execd/pkg/runtime/workingdir.go
+++ b/components/execd/pkg/runtime/workingdir.go
@@ -24,10 +24,14 @@ import (
 )
 
 func ValidateWorkingDir(cwd string) error {
+	return ValidateWorkingDirWithEnv(cwd, nil)
+}
+
+func ValidateWorkingDirWithEnv(cwd string, envOverrides map[string]string) error {
 	if cwd == "" {
 		return nil
 	}
-	resolvedCwd, err := pathutil.ExpandPath(cwd)
+	resolvedCwd, err := pathutil.ExpandPathWithEnv(cwd, envOverrides)
 	if err != nil {
 		return fmt.Errorf("cannot resolve working directory %q: %w", cwd, err)
 	}

--- a/components/execd/pkg/runtime/workingdir_test.go
+++ b/components/execd/pkg/runtime/workingdir_test.go
@@ -57,3 +57,51 @@ func TestValidateWorkingDir_ExpandsHome(t *testing.T) {
 
 	require.NoError(t, ValidateWorkingDir("~/workspace"))
 }
+
+func TestValidateWorkingDirWithEnv(t *testing.T) {
+	const (
+		requestOnlyKey = "OPENSANDBOX_TEST_REQUEST_ONLY_CWD"
+		overrideKey    = "OPENSANDBOX_TEST_OVERRIDE_CWD"
+		missingKey     = "OPENSANDBOX_TEST_MISSING_CWD"
+	)
+
+	unsetEnvForTest(t, requestOnlyKey)
+	requestDir := t.TempDir()
+	require.NoError(t, ValidateWorkingDirWithEnv("$"+requestOnlyKey, map[string]string{
+		requestOnlyKey: requestDir,
+	}))
+
+	processFile := filepath.Join(t.TempDir(), "process-file")
+	require.NoError(t, os.WriteFile(processFile, []byte("x"), 0o600))
+	t.Setenv(overrideKey, processFile)
+	require.NoError(t, ValidateWorkingDirWithEnv("$"+overrideKey, map[string]string{
+		overrideKey: t.TempDir(),
+	}))
+
+	unsetEnvForTest(t, missingKey)
+	err := ValidateWorkingDirWithEnv("$"+missingKey, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "undefined environment variables")
+
+	nonexistent := filepath.Join(t.TempDir(), "missing")
+	err = ValidateWorkingDirWithEnv("$TARGET", map[string]string{"TARGET": nonexistent})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not exist")
+
+	err = ValidateWorkingDirWithEnv("$TARGET", map[string]string{"TARGET": processFile})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a directory")
+}
+
+func unsetEnvForTest(t *testing.T, key string) {
+	t.Helper()
+	previous, existed := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if existed {
+			require.NoError(t, os.Setenv(key, previous))
+			return
+		}
+		require.NoError(t, os.Unsetenv(key))
+	})
+}

--- a/components/execd/pkg/web/model/codeinterpreting.go
+++ b/components/execd/pkg/web/model/codeinterpreting.go
@@ -69,7 +69,7 @@ func (r *RunCommandRequest) Validate() error {
 	if r.Gid != nil && r.Uid == nil {
 		return errors.New("uid is required when gid is provided")
 	}
-	return runtime.ValidateWorkingDir(r.Cwd)
+	return runtime.ValidateWorkingDirWithEnv(r.Cwd, r.Envs)
 }
 
 type ServerStreamEventType string

--- a/components/execd/pkg/web/model/codeinterpreting_test.go
+++ b/components/execd/pkg/web/model/codeinterpreting_test.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -59,6 +60,69 @@ func TestRunCommandRequestValidateCwd(t *testing.T) {
 	err := req.Validate()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "working directory")
+}
+
+func TestRunCommandRequestValidateCwdFromRequestEnv(t *testing.T) {
+	const (
+		requestOnlyKey = "OPENSANDBOX_TEST_MODEL_REQUEST_ONLY_CWD"
+		overrideKey    = "OPENSANDBOX_TEST_MODEL_OVERRIDE_CWD"
+		missingKey     = "OPENSANDBOX_TEST_MODEL_MISSING_CWD"
+	)
+
+	unsetModelEnvForTest(t, requestOnlyKey)
+	for _, background := range []bool{false, true} {
+		req := RunCommandRequest{
+			Command:    "pwd",
+			Cwd:        "$" + requestOnlyKey,
+			Background: background,
+			Envs:       map[string]string{requestOnlyKey: t.TempDir()},
+		}
+		require.NoError(t, req.Validate())
+	}
+
+	processFile := filepath.Join(t.TempDir(), "process-file")
+	require.NoError(t, os.WriteFile(processFile, []byte("x"), 0o600))
+	t.Setenv(overrideKey, processFile)
+	req := RunCommandRequest{
+		Command: "pwd",
+		Cwd:     "$" + overrideKey,
+		Envs:    map[string]string{overrideKey: t.TempDir()},
+	}
+	require.NoError(t, req.Validate())
+
+	unsetModelEnvForTest(t, missingKey)
+	req = RunCommandRequest{Command: "pwd", Cwd: "$" + missingKey}
+	err := req.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "undefined environment variables")
+
+	nonexistent := filepath.Join(t.TempDir(), "missing")
+	req = RunCommandRequest{
+		Command: "pwd",
+		Cwd:     "$TARGET",
+		Envs:    map[string]string{"TARGET": nonexistent},
+	}
+	err = req.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not exist")
+
+	req.Envs["TARGET"] = processFile
+	err = req.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a directory")
+}
+
+func unsetModelEnvForTest(t *testing.T, key string) {
+	t.Helper()
+	previous, existed := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if existed {
+			require.NoError(t, os.Setenv(key, previous))
+			return
+		}
+		require.NoError(t, os.Unsetenv(key))
+	})
 }
 
 func ptr32(v uint32) *uint32 { return &v }


### PR DESCRIPTION
# Summary

- validate command working directories with request-scoped environment variables
- preserve the existing request-over-process precedence already used during command execution
- keep session validation behavior and invalid-path rejection unchanged

This allows foreground and background `/command` requests to use a `cwd` variable supplied in their own `envs` map instead of rejecting the request before execution.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests: focused and full model/runtime/controller packages
- [x] Integration tests: real foreground/background controller requests execute in the request-env directory
- [x] e2e / manual verification: exact-main request returned 400 before the fix and 200 SSE after it

Additional checks: focused model/runtime race, full controller race, `go vet ./...`, `golangci-lint run -v ./...`, gofmt, and `git diff --check`.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed): not needed; the request schema and execution precedence are unchanged
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
