### PR TITLE
fix(execd): drop fsync from the task-create critical path

### DIFF
--- a/kubernetes/internal/task-executor/storage/file_store.go
+++ b/kubernetes/internal/task-executor/storage/file_store.go
@@ -227,18 +227,18 @@ func (s *fileStore) writeTaskFile(taskDir string, task *types.Task) error {
 		return fmt.Errorf("failed to write temp file: %w", err)
 	}
 
-	f, err := os.Open(tmpFile)
-	if err != nil {
-		os.Remove(tmpFile)
-		return fmt.Errorf("failed to open temp file for sync: %w", err)
-	}
-	if err := f.Sync(); err != nil {
-		f.Close()
-		os.Remove(tmpFile)
-		return fmt.Errorf("failed to sync temp file: %w", err)
-	}
-	f.Close()
-
+	// Publish atomically: rename(2) is atomic, so a reader never observes a
+	// partially written task file. That is the invariant callers rely on.
+	//
+	// Deliberately no fsync before the rename. fsync would only add durability
+	// across a machine crash (power loss / kernel panic), and this runs on the
+	// critical path of taskManager.Create, ahead of executor.Start -- on a
+	// congested device it was measured blocking sandbox process start by more
+	// than 6s, and it also ran every ReconcileInterval under the manager-wide
+	// lock. That durability was not actually being obtained either: the parent
+	// directory was never synced, so the rename itself was never durable. Losing
+	// this file is recoverable -- the controller re-issues setTask on its next
+	// reconcile. See #1613.
 	if err := os.Rename(tmpFile, taskFile); err != nil {
 		os.Remove(tmpFile)
 		return fmt.Errorf("failed to rename temp file: %w", err)

--- a/kubernetes/internal/task-executor/storage/file_store_test.go
+++ b/kubernetes/internal/task-executor/storage/file_store_test.go
@@ -220,3 +220,70 @@ func TestFileStore_Concurrency(t *testing.T) {
 		<-done
 	}
 }
+
+// TestFileStore_AtomicPublish locks in the guarantee writeTaskFile actually owes
+// its callers: task.json is published by an atomic rename, so a reader never sees
+// a partial file and no temp file is left behind. This is the invariant that must
+// survive independently of whether the write is fsynced.
+func TestFileStore_AtomicPublish(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewFileStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	ctx := context.Background()
+	task := &types.Task{
+		Name: "atomic-task",
+		Process: &api.Process{
+			Command: []string{"echo", "hello"},
+		},
+	}
+
+	taskDir := filepath.Join(tmpDir, task.Name)
+	taskFile := filepath.Join(taskDir, "task.json")
+	tmpFile := taskFile + ".tmp"
+
+	if err := store.Create(ctx, task); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if _, err := os.Stat(taskFile); err != nil {
+		t.Fatalf("task.json missing after Create: %v", err)
+	}
+	if _, err := os.Stat(tmpFile); !os.IsNotExist(err) {
+		t.Error("temp file left behind after Create")
+	}
+
+	// Update must publish through the same rename, leaving no temp file either.
+	now := time.Now()
+	task.DeletionTimestamp = &now
+	if err := store.Update(ctx, task); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if _, err := os.Stat(tmpFile); !os.IsNotExist(err) {
+		t.Error("temp file left behind after Update")
+	}
+	got, err := store.Get(ctx, task.Name)
+	if err != nil {
+		t.Fatalf("Get after update failed: %v", err)
+	}
+	if got.DeletionTimestamp == nil {
+		t.Error("Update did not persist DeletionTimestamp")
+	}
+
+	// A temp file stranded by a writer that died mid-write must not be visible to
+	// readers: they only ever resolve task.json.
+	if err := os.WriteFile(tmpFile, []byte("{ truncated"), 0644); err != nil {
+		t.Fatalf("failed to plant stale temp file: %v", err)
+	}
+	if _, err := store.Get(ctx, task.Name); err != nil {
+		t.Errorf("Get must ignore a stale temp file, got: %v", err)
+	}
+	tasks, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].Name != task.Name {
+		t.Errorf("List must ignore a stale temp file, got %d tasks", len(tasks))
+	}
+}


### PR DESCRIPTION
# Summary

Removes the `f.Sync()` from `fileStore.writeTaskFile`, keeping `WriteFile` → `rename`.

That fsync sits on the critical path of `taskManager.Create`, ahead of `executor.Start` — so it runs *before* the sandbox's first process is launched. On a node whose block device was congested we measured it blocking sandbox startup for **6.26 s**, against **3–5 ms** on healthy nodes of the same instance type. `store.Update` uses the same helper and is called every `ReconcileInterval` (500 ms) while holding the manager-wide `m.mu`, so the stall also recurs on the periodic path.

The fsync was not buying what it cost:

- **Atomicity is unchanged** — it comes from `rename(2)`, which stays. Readers still never observe a partial file.
- **The durability was never actually obtained.** The parent directory was never fsynced, so the `rename` itself was not durable. The cost was paid without the guarantee.
- **The file cannot outlive the crash it protects against.** `DataDir` defaults to `/var/lib/sandbox/tasks`, which in the pooled Kubernetes deployment lives on the container's writable layer — no volume is mounted there — and `task-executor` runs as PID 1, so it cannot restart without the container restarting onto a fresh snapshot.
- **A lost record self-heals.** The controller re-issues `setTask` on its next 3 s reconcile.

Full measurements and the rejected alternatives are in #1613.

# Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification
- [ ] Not run (explain why)

`go test ./internal/task-executor/...` passes (manager, runtime, server, storage, utils). `gofmt` and `go vet` clean.

Adds `TestFileStore_AtomicPublish`, which pins the invariant that must survive this change: `task.json` is published by an atomic rename, no temp file is left behind by either `Create` or `Update`, and a temp file stranded by a writer that died mid-write is invisible to `Get`/`List`.

The test was mutation-checked — replacing the `rename` with a direct `WriteFile` to the destination makes it fail:

```
--- FAIL: TestFileStore_AtomicPublish (0.00s)
    file_store_test.go:254: temp file left behind after Create
    file_store_test.go:264: temp file left behind after Update
```

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

Behaviour on the read path is identical. The only semantic change is that a task record written immediately before a power loss or kernel panic may be absent after reboot instead of present — a case the deployment could not preserve anyway (see above), and which the controller re-drives.

# Checklist

- [x] Linked Issue or clearly described motivation — #1613
- [ ] Added/updated docs (if needed) — no user-facing behaviour or configuration changed
- [x] Added/updated tests (if needed)
- [x] Security impact considered — none; no change to file permissions, paths, or trust boundaries
- [x] Backward compatibility considered — on-disk format and API unchanged

Closes #1613
