### PR TITLE
fix(docs): repair guide image paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ docs/
 ### Docs conventions
 
 - Engine: VitePress. Config is a static `config.mts` with no build-time code generation.
-- All images go in `docs/public/images/`, referenced as `/images/filename` in markdown.
+- All images go in `docs/public/images/`. Reference them with a document-relative path to that directory (for example, `../public/images/filename` from `docs/guides/`) so they render in both repository previews and VitePress.
 - Every page must have YAML frontmatter with `title` and `description`.
 - Internal links use VitePress absolute paths (e.g., `/sdks/python`, `/guides/credential-vault`).
 - Links to source code or specs use full GitHub URLs.

--- a/docs/guides/client-pool.md
+++ b/docs/guides/client-pool.md
@@ -33,7 +33,7 @@ amplification. The pool evicts its shared pool on shutdown; a user-provided
 pool is never touched. Python and Go pools do not share HTTP connections
 across sandboxes today.
 
-![Client pool architecture](/images/client-pool-architecture.svg)
+![Client pool architecture](../public/images/client-pool-architecture.svg)
 
 Two flows happen concurrently:
 
@@ -56,7 +56,7 @@ and pods.
 The warmup path — the leader-only replenish flow above — is worth zooming in on
 because it is the only part of the pool that is gated by a distributed lock:
 
-![Warmup reconcile sequence](/images/client-pool-warmup-sequence.svg)
+![Warmup reconcile sequence](../public/images/client-pool-warmup-sequence.svg)
 
 ### Lifecycle model
 
@@ -78,7 +78,7 @@ behavior. A failed create is recorded and the next periodic tick may admit repla
 work. This exception applies only to pool warmup creates; normal `Sandbox` creation and
 `AcquirePolicy.DIRECT_CREATE` keep the caller's configured retry policy.
 
-![Client pool lifecycle state machine](/images/client-pool-lifecycle.svg)
+![Client pool lifecycle state machine](../public/images/client-pool-lifecycle.svg)
 
 ### There is no `release()`
 
@@ -102,7 +102,7 @@ its readiness check, `FAIL_FAST` raises and `DIRECT_CREATE` falls back to creati
 brand-new sandbox via the lifecycle API. A failed candidate still pays up to
 `acquire_ready_timeout`.
 
-![Acquire decision flow](/images/client-pool-acquire-decision.svg)
+![Acquire decision flow](../public/images/client-pool-acquire-decision.svg)
 
 ## Configuration
 
@@ -174,7 +174,7 @@ for health-check / prepare capacity.
   multi-pod deployments. All nodes in one logical pool must share the same `pool_name`
   and Redis `key_prefix`, and each process must use a **unique** `owner_id`.
 
-![Single-node vs distributed pool topology](/images/client-pool-topology.svg)
+![Single-node vs distributed pool topology](../public/images/client-pool-topology.svg)
 
 ### Rules that apply to every deployment
 

--- a/docs/guides/lifecycle-hooks.md
+++ b/docs/guides/lifecycle-hooks.md
@@ -16,7 +16,7 @@ Lifecycle hooks let a sandbox run declarative commands at defined points in its 
 
 Both hooks run inside the sandbox with the sandbox environment. Commands are argument arrays and are executed directly. To use shell syntax such as pipes, redirects, or variable expansion, invoke a shell explicitly, for example `['sh', '-c', 'command > file']`.
 
-![Lifecycle hook timing in bootstrap and execd-as-init modes](/images/lifecycle-hooks-startup.png)
+![Lifecycle hook timing in bootstrap and execd-as-init modes](../public/images/lifecycle-hooks-startup.png)
 
 The ordering is the same in both startup modes:
 

--- a/docs/guides/secure-access.md
+++ b/docs/guides/secure-access.md
@@ -26,7 +26,7 @@ Normative design: [OSEP-0011](https://github.com/opensandbox-group/OpenSandbox/b
 
 ## How It Works
 
-![Secure Access request flow](/images/secure-access.svg)
+![Secure Access request flow](../public/images/secure-access.svg)
 
 On the **control plane**, creating a sandbox with `secureAccess: true` and
 calling `GetEndpoint` yields a per-sandbox opaque `SecureAccessToken`.


### PR DESCRIPTION
# Summary

- Replace root-relative guide image URLs with document-relative paths into `docs/public/images/`.
- Keep the images working in repository Markdown previews as well as VitePress deployments.
- Update the repository documentation convention to prevent new guide pages from reintroducing the broken preview paths.

# Testing

- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

Verified all 10 image references under `docs/guides/` resolve to existing files with matching case. Built the docs with VitePress 1.6.4 for both `DOCS_BASE=/` and `DOCS_BASE=/OpenSandbox/`, then checked that every generated guide image URL has a corresponding output asset.

The unmodified full `pnpm docs:build` check is currently blocked by the pre-existing dead link in `docs/components/egress.md` to `../../components/egress/docs/policy-traffic-vault-flow.md`; this PR does not change that unrelated link.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (not needed for this documentation-only path fix)
- [x] Security impact considered
- [x] Backward compatibility considered
