### PR TITLE
fix(execd): make bootstrap readable by non-root users

### DIFF
--- a/components/execd/Dockerfile
+++ b/components/execd/Dockerfile
@@ -155,7 +155,8 @@ COPY components/execd/install.bat ./install.bat
 
 # Defensive: force execd-related files executable for all users regardless
 # of source checkout permissions.
-RUN chmod a+x ./execd ./execd.exe ./execd-ebpf ./opensandbox-supervisor ./bootstrap.sh \
+RUN chmod 0755 ./bootstrap.sh && \
+    chmod a+x ./execd ./execd.exe ./execd-ebpf ./opensandbox-supervisor \
     /usr/local/bin/bwrap \
     /usr/local/libexec/opensandbox-session-gate \
     /opt/opensandbox/opensandbox-session-gate \

--- a/components/execd/Dockerfile
+++ b/components/execd/Dockerfile
@@ -153,10 +153,15 @@ COPY --from=ebpf-builder /build/execd-ebpf ./execd-ebpf
 COPY components/execd/bootstrap.sh ./bootstrap.sh
 COPY components/execd/install.bat ./install.bat
 
-# Defensive: force execd-related files executable for all users regardless
-# of source checkout permissions.
-RUN chmod 0755 ./bootstrap.sh && \
-    chmod a+x ./execd ./execd.exe ./execd-ebpf ./opensandbox-supervisor \
+# Defensive: normalize execd-related file modes regardless of source checkout
+# permissions or the builder's umask.
+RUN chmod 0755 \
+    ./execd \
+    ./execd.exe \
+    ./execd-ebpf \
+    ./opensandbox-supervisor \
+    ./bootstrap.sh \
+    ./install.bat \
     /usr/local/bin/bwrap \
     /usr/local/libexec/opensandbox-session-gate \
     /opt/opensandbox/opensandbox-session-gate \

--- a/components/execd/tests/init_container.sh
+++ b/components/execd/tests/init_container.sh
@@ -23,6 +23,7 @@
 #   - with [hardening] enabled, the entrypoint keeps bootstrap env
 #     (JUPYTER_TOKEN) while execd's credential (EXECD_ACCESS_TOKEN) is
 #     stripped by the launcher
+#   - bootstrap.sh remains readable and executable by non-root workloads
 #   - on a non-PID-1 topology execd degrades to subreaper and says so
 #   - while preStart is blocked, /ping stays ready and both the entrypoint
 #     and periodic hooks wait; lifecycle transport is stripped from user code
@@ -111,6 +112,35 @@ else
     . >/dev/null
   echo ">> Image built."
 fi
+
+# -------------------------------------------------------------------
+# Test 0: bootstrap.sh is usable by non-root workload images.
+# -------------------------------------------------------------------
+echo ""
+echo ">> Test 0: non-root bootstrap permissions"
+
+if ! BOOTSTRAP_PERMISSIONS=$(docker run --rm \
+  --user 65534:65534 \
+  --entrypoint /bin/sh \
+  "${IMAGE}" \
+  -c '
+    set -e
+    [ -e /bootstrap.sh ] || { echo "bootstrap.sh is missing" >&2; exit 2; }
+    mode=$(stat -c %a /bootstrap.sh)
+    readable=no
+    executable=no
+    if [ -r /bootstrap.sh ]; then readable=yes; fi
+    if [ -x /bootstrap.sh ]; then executable=yes; fi
+    printf "%s %s %s\n" "$mode" "$readable" "$executable"
+  '); then
+  fail "test 0: failed to inspect bootstrap.sh in the image"
+fi
+read -r BOOTSTRAP_MODE BOOTSTRAP_READABLE BOOTSTRAP_EXECUTABLE <<< "$BOOTSTRAP_PERMISSIONS"
+[ "$BOOTSTRAP_MODE" = "755" ] \
+  || fail "test 0: bootstrap.sh mode is ${BOOTSTRAP_MODE}, expected 755"
+[ "$BOOTSTRAP_READABLE" = "yes" ] && [ "$BOOTSTRAP_EXECUTABLE" = "yes" ] \
+  || fail "test 0: non-root workload cannot read and execute bootstrap.sh"
+echo "PASS: non-root workload can read and execute bootstrap.sh"
 
 # -------------------------------------------------------------------
 # Test 1: execd is PID 1, workload is its child, orphans are reaped,
@@ -330,5 +360,5 @@ echo "========================================="
 echo " Init-mode container regression PASSED"
 echo "========================================="
 echo "  image: ${IMAGE}"
-echo "  cases: pid1 handoff / reaping / signal shield /"
-echo "         env inheritance / subreaper / lifecycle hooks"
+echo "  cases: non-root bootstrap / pid1 handoff / reaping /"
+echo "         signal shield / env inheritance / subreaper / lifecycle hooks"

--- a/components/execd/tests/init_container.sh
+++ b/components/execd/tests/init_container.sh
@@ -23,7 +23,7 @@
 #   - with [hardening] enabled, the entrypoint keeps bootstrap env
 #     (JUPYTER_TOKEN) while execd's credential (EXECD_ACCESS_TOKEN) is
 #     stripped by the launcher
-#   - bootstrap.sh remains readable and executable by non-root workloads
+#   - packaged executables and scripts have stable 0755 permissions
 #   - on a non-PID-1 topology execd degrades to subreaper and says so
 #   - while preStart is blocked, /ping stays ready and both the entrypoint
 #     and periodic hooks wait; lifecycle transport is stripped from user code
@@ -114,33 +114,43 @@ else
 fi
 
 # -------------------------------------------------------------------
-# Test 0: bootstrap.sh is usable by non-root workload images.
+# Test 0: packaged executables and scripts have stable permissions.
 # -------------------------------------------------------------------
 echo ""
-echo ">> Test 0: non-root bootstrap permissions"
+echo ">> Test 0: packaged executable and script permissions"
 
-if ! BOOTSTRAP_PERMISSIONS=$(docker run --rm \
+if ! docker run --rm \
   --user 65534:65534 \
   --entrypoint /bin/sh \
   "${IMAGE}" \
   -c '
     set -e
-    [ -e /bootstrap.sh ] || { echo "bootstrap.sh is missing" >&2; exit 2; }
-    mode=$(stat -c %a /bootstrap.sh)
-    readable=no
-    executable=no
-    if [ -r /bootstrap.sh ]; then readable=yes; fi
-    if [ -x /bootstrap.sh ]; then executable=yes; fi
-    printf "%s %s %s\n" "$mode" "$readable" "$executable"
-  '); then
-  fail "test 0: failed to inspect bootstrap.sh in the image"
+    for path in \
+      /execd \
+      /execd.exe \
+      /execd-ebpf \
+      /opensandbox-supervisor \
+      /bootstrap.sh \
+      /install.bat \
+      /usr/local/bin/bwrap \
+      /usr/local/libexec/opensandbox-session-gate \
+      /opt/opensandbox/opensandbox-session-gate \
+      /usr/local/libexec/opensandbox-launcher \
+      /opt/opensandbox/opensandbox-launcher; do
+      mode=$(stat -c %a "$path")
+      [ "$mode" = 755 ] || {
+        echo "$path mode is $mode, expected 755" >&2
+        exit 1
+      }
+      [ -r "$path" ] && [ -x "$path" ] || {
+        echo "$path is not readable and executable by a non-root user" >&2
+        exit 1
+      }
+    done
+  '; then
+  fail "test 0: packaged executable or script permissions are invalid"
 fi
-read -r BOOTSTRAP_MODE BOOTSTRAP_READABLE BOOTSTRAP_EXECUTABLE <<< "$BOOTSTRAP_PERMISSIONS"
-[ "$BOOTSTRAP_MODE" = "755" ] \
-  || fail "test 0: bootstrap.sh mode is ${BOOTSTRAP_MODE}, expected 755"
-[ "$BOOTSTRAP_READABLE" = "yes" ] && [ "$BOOTSTRAP_EXECUTABLE" = "yes" ] \
-  || fail "test 0: non-root workload cannot read and execute bootstrap.sh"
-echo "PASS: non-root workload can read and execute bootstrap.sh"
+echo "PASS: packaged executables and scripts are mode 0755"
 
 # -------------------------------------------------------------------
 # Test 1: execd is PID 1, workload is its child, orphans are reaped,
@@ -360,5 +370,5 @@ echo "========================================="
 echo " Init-mode container regression PASSED"
 echo "========================================="
 echo "  image: ${IMAGE}"
-echo "  cases: non-root bootstrap / pid1 handoff / reaping /"
+echo "  cases: packaged permissions / pid1 handoff / reaping /"
 echo "         signal shield / env inheritance / subreaper / lifecycle hooks"


### PR DESCRIPTION
## Summary

- normalize `/bootstrap.sh` to mode `0755` in the execd image instead of only adding execute bits
- add an init-container regression that verifies the built image as UID/GID 65534

## Root cause

A real sandbox using a workload image whose default user is `admin` entered `CrashLoopBackOff` before lifecycle hooks ran. The deployed execd image contained `/bootstrap.sh` as `0751 root:root`; the existing root-based E2E could execute it, but the non-root workload could not read it.

## Validation

- `bash -n components/execd/tests/init_container.sh`
- the new regression fails against `execd:v1.0.23.test.2` with `bootstrap.sh mode is 751, expected 755`
- `git diff --check`
- The actionable diagnostic issue was fixed
- full local execd image build and init-container suite are still running and are not represented as complete here