### PR TITLE
chore(python): bump sandbox SDK to 0.1.16

### DIFF
--- a/sdks/sandbox/python/pyproject.toml
+++ b/sdks/sandbox/python/pyproject.toml
@@ -69,7 +69,7 @@ source = "vcs"
 root = "../../.."
 tag_regex = "^python/sandbox/v(?P<version>\\d+\\.\\d+\\.\\d+(?:[\\.\\w\\+\\-]*)?)$"
 git_describe_command = 'git describe --dirty --tags --long --match "python/sandbox/v*"'
-fallback_version = "0.1.15"
+fallback_version = "0.1.16"
 
 [tool.hatch.build]
 include = [

--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -67,7 +67,7 @@ class ConnectionConfig(BaseModel):
         default=False, description="Enable debug logging for HTTP requests"
     )
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.15", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.16", description="User agent string"
     )
     headers: dict[str, str] = Field(
         default_factory=dict, description="User defined headers"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -55,7 +55,7 @@ class ConnectionConfigSync(BaseModel):
     )
     debug: bool = Field(default=False, description="Enable debug logging for HTTP requests")
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.15", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.16", description="User agent string"
     )
     headers: dict[str, str] = Field(default_factory=dict, description="User defined headers")
 

--- a/sdks/sandbox/python/tests/test_connection_config.py
+++ b/sdks/sandbox/python/tests/test_connection_config.py
@@ -22,8 +22,8 @@ from opensandbox.config import ConnectionConfig, ConnectionConfigSync
 # Regression: the default User-Agent version is hand-maintained and must be
 # bumped together with the package version. Update this expectation when releasing.
 def test_default_user_agent_matches_package_version() -> None:
-    assert ConnectionConfig().user_agent == "OpenSandbox-Python-SDK/0.1.15"
-    assert ConnectionConfigSync().user_agent == "OpenSandbox-Python-SDK/0.1.15"
+    assert ConnectionConfig().user_agent == "OpenSandbox-Python-SDK/0.1.16"
+    assert ConnectionConfigSync().user_agent == "OpenSandbox-Python-SDK/0.1.16"
 
 
 def test_protocol_validation() -> None:


### PR DESCRIPTION
## Summary

- bump the Python Sandbox SDK fallback package version to `0.1.16`
- bump the async and sync default `User-Agent` headers to `OpenSandbox-Python-SDK/0.1.16`
- update the regression expectation that keeps the header aligned with the package version

## Verification

- `git diff --check`
- full SDK validation is covered by the required PR checks