### PR TITLE
docs: fix dead link breaking Pages docs build

### DIFF
--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -277,7 +277,7 @@ unchanged; both profiles are mutually exclusive deployment forms.
 
 For how policy is applied, how outbound traffic flows through the nftables
 dispatch, and how the credential vault works in the fleet profile, see
-[policy, traffic flow, and credential vault](../../components/egress/docs/policy-traffic-vault-flow.md).
+[policy, traffic flow, and credential vault](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/egress/docs/policy-traffic-vault-flow.md).
 
 ## Build & Run
 


### PR DESCRIPTION
## What

Fixes the failing `Deploy Docs Pages` build (run #613, job 97784703936).

`docs/components/egress.md:280` linked to `../../components/egress/docs/policy-traffic-vault-flow.md`, a relative path that escapes the VitePress docs root — VitePress flags it as a dead link and fails the build.

## Why

The link was introduced in #1595. Per docs convention (`AGENTS.md`), links to source/specs outside `docs/` must use full GitHub URLs (as the same file already does at line 240 for `opentelemetry.md`).

## Verification

`pnpm docs:build` passes locally (build complete in ~10s).