### PR TITLE
feat(server): merge template mounts into the egress sidecar

### DIFF
--- a/docs/architecture/network-isolation.md
+++ b/docs/architecture/network-isolation.md
@@ -71,7 +71,51 @@ Common example values:
 
 Supported target types: IP addresses (e.g., `10.0.0.5`), CIDR ranges (e.g., `10.0.0.0/8`), or domain names (e.g., `internal.service.local`, with `*.` wildcard prefix support).
 
-#### 3. Build a Custom Image Based on the Official Egress Image
+#### 3. Deliver the Rule File to the Sidecar
+
+The sidecar reads `deny.always` from `/var/egress/rules/` inside its own container. There are two ways to put it there.
+
+##### Option A: Mount It from a ConfigMap (recommended on Kubernetes)
+
+Pod CIDR, Service CIDR and node CIDR are properties of the cluster, so keeping them in a ConfigMap lets you change them with `kubectl apply` alone.
+
+Create the ConfigMap in the namespace where sandbox pods run:
+
+```bash
+kubectl create configmap opensandbox-egress-rules \
+  --from-file=deny.always \
+  -n opensandbox
+```
+
+Then declare the volume and the sidecar mount in the BatchSandbox template referenced by `kubernetes.batchsandbox_template_file`:
+
+```yaml
+spec:
+  template:
+    spec:
+      volumes:
+        - name: egress-rules
+          configMap:
+            name: opensandbox-egress-rules
+      containers:
+        - name: egress
+          volumeMounts:
+            - name: egress-rules
+              mountPath: /var/egress/rules
+              readOnly: true
+```
+
+Template containers are matched to sandbox pod containers by name, so a `containers` entry named `egress` contributes mounts to the egress sidecar without having to describe the rest of it. Mounts the sidecar already declares are kept; only new volume names are added.
+
+The template is read at server startup, so this one-time edit needs a server restart. After that, changing the rules is a single `kubectl apply` on the ConfigMap: no image rebuild, no server config change, no restart. Existing sandboxes pick the change up on the sidecar's next reload; allow for the kubelet's ConfigMap refresh interval on top of that.
+
+::: tip Available with the BatchSandbox provider
+The template merge described here applies to `kubernetes.workload_provider = "batchsandbox"` (the default). With the `agent-sandbox` provider, use Option B.
+:::
+
+##### Option B: Bake It into a Custom Egress Image
+
+Use this when there is no BatchSandbox template to extend — the Docker runtime, or the `agent-sandbox` provider.
 
 Create a `Dockerfile` that embeds the `deny.always` file into the image:
 
@@ -88,9 +132,7 @@ docker build -t registry.example.com/opensandbox/egress:hardened .
 docker push registry.example.com/opensandbox/egress:hardened
 ```
 
-#### 4. Update the Server Configuration
-
-In the OpenSandbox server configuration, point the `[egress]` `image` to the custom image:
+Then point the `[egress]` `image` at the custom image in the server configuration:
 
 ```toml
 [egress]
@@ -98,9 +140,7 @@ image = "registry.example.com/opensandbox/egress:hardened"
 mode = "dns+nft"
 ```
 
-After this configuration is applied, all newly created sandboxes will use the egress sidecar image that includes the `deny.always` rules. No changes to individual sandbox creation requests are needed.
-
-> Note: the `deny.always` file is hot-reloaded every minute. To change the rules (e.g., after a cluster CIDR change), update the `deny.always` file, rebuild the image, and perform a rolling update of the server configuration.
+Changing the rules means editing the file, rebuilding the image, pushing it, and rolling out the new tag in the server configuration.
 
 ### Effects
 
@@ -170,7 +210,7 @@ sandbox = await Sandbox.create(
 |-----------|---------------------|---------------------------|
 | Enforcement | Yes (user cannot override) | No (user can modify policy) |
 | User awareness | Transparent (platform-level) | Requires explicit declaration |
-| Operational cost | Low (one-time image build, global effect) | High (declare per sandbox) |
+| Operational cost | Low (one-time setup, global effect; rule changes are a `kubectl apply` when the file comes from a ConfigMap) | High (declare per sandbox) |
 | Cluster CIDR exposure | Not exposed to users | Must be exposed to users |
 | Use case | Platform-wide default isolation, recommended | Whitelist mode, fine-grained control |
 

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -101,6 +101,8 @@ Rule precedence: `deny.always` > `allow.always` > user policy (API/env).
 
 Always-rules are hot-reloaded: the sidecar polls the files once per minute and applies changes without restart.
 
+On Kubernetes, these files can be supplied from a ConfigMap mounted into the sidecar rather than baked into the egress image, so platform-wide rules change with `kubectl apply`. See [Network Isolation](/architecture/network-isolation).
+
 ### Service Mesh Compatibility
 
 ::: warning Not Supported with Transparent Mesh Sidecars

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -128,7 +128,7 @@ If `runtime.type = "kubernetes"` and the `[kubernetes]` table is absent, the ser
 | `kubeconfig_path` | string \| omitted | `null` | Path to kubeconfig (expandable, e.g. `~/.kube/config`). In-cluster configs often leave this unset and rely on in-cluster credentials. |
 | `namespace` | string \| omitted | `null` | Namespace for sandbox workloads. |
 | `workload_provider` | string \| omitted | `null` | One of: **`batchsandbox`**, **`agent-sandbox`**. If omitted, the **first registered** provider is used (currently **`batchsandbox`**). |
-| `batchsandbox_template_file` | string \| omitted | `null` | Path to **BatchSandbox** CR YAML template when `workload_provider = "batchsandbox"`. |
+| `batchsandbox_template_file` | string \| omitted | `null` | Path to **BatchSandbox** CR YAML template when `workload_provider = "batchsandbox"`. Pod-level `volumes` and per-container `volumeMounts` declared in it are merged into every sandbox pod; template containers are matched to pod containers **by name**. |
 | `image_pull_policy` | string \| omitted | `"IfNotPresent"` | Image pull policy for the BatchSandbox main container. Values: **`Always`**, **`IfNotPresent`**, **`Never`**. |
 | `sandbox_create_timeout_seconds` | integer | `60` | Max time to wait for a new sandbox to become ready (e.g. IP assigned), in seconds. |
 | `pool_acquisition_timeout_seconds` | integer | `30` | Max cumulative time to wait while Pool capacity prevents allocation. This does not extend `sandbox_create_timeout_seconds`. |

--- a/server/opensandbox_server/examples/example.batchsandbox-template.yaml
+++ b/server/opensandbox_server/examples/example.batchsandbox-template.yaml
@@ -16,3 +16,17 @@ spec:
       restartPolicy: Never
       tolerations:
         - operator: "Exists"
+      # Pod-level volumes and per-container volumeMounts declared here are merged
+      # into every sandbox pod. Template containers are matched to pod containers
+      # by name, so the entry below adds a mount to the egress sidecar — for
+      # example to supply always-rules from a ConfigMap instead of a custom image.
+      # volumes:
+      #   - name: egress-rules
+      #     configMap:
+      #       name: opensandbox-egress-rules
+      # containers:
+      #   - name: egress
+      #     volumeMounts:
+      #       - name: egress-rules
+      #         mountPath: /var/egress/rules
+      #         readOnly: true

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -95,6 +95,25 @@ def _merge_security_context(
     return merged
 
 
+def _append_volume_mounts(
+    container: Dict[str, Any], extra_mounts: list[Dict[str, Any]]
+) -> None:
+    """Append template mounts to a container, skipping names it already mounts."""
+    mounts = container.get("volumeMounts", []) or []
+    if not isinstance(mounts, list) or not extra_mounts:
+        return
+    existing = {m.get("name") for m in mounts if isinstance(m, dict)}
+    for mnt in extra_mounts:
+        if not isinstance(mnt, dict):
+            continue
+        name = mnt.get("name")
+        if not name or name in existing:
+            continue
+        mounts.append(mnt)
+        existing.add(name)
+    container["volumeMounts"] = mounts
+
+
 class BatchSandboxProvider(WorkloadProvider):
     """Workload provider for BatchSandbox CRDs."""
     
@@ -197,7 +216,12 @@ class BatchSandboxProvider(WorkloadProvider):
                 annotations=annotations,
             )
 
-        extra_volumes, extra_mounts, extra_security_context = self._extract_template_pod_extras()
+        (
+            extra_volumes,
+            extra_mounts,
+            extra_security_context,
+            extra_sidecar_mounts,
+        ) = self._extract_template_pod_extras()
 
         if windows_profile:
             validate_windows_profile_resource_limits(resource_limits)
@@ -324,7 +348,11 @@ class BatchSandboxProvider(WorkloadProvider):
         else:
             batchsandbox["spec"]["expireTime"] = expires_at.isoformat()
         self._merge_pod_spec_extras(
-            batchsandbox, extra_volumes, extra_mounts, extra_security_context
+            batchsandbox,
+            extra_volumes,
+            extra_mounts,
+            extra_security_context,
+            extra_sidecar_mounts,
         )
         merged_pod_spec = batchsandbox.get("spec", {}).get("template", {}).get("spec", {})
         ensure_egress_runtime_compatible(
@@ -462,8 +490,18 @@ class BatchSandboxProvider(WorkloadProvider):
 
     def _extract_template_pod_extras(
         self,
-    ) -> tuple[list[Dict[str, Any]], list[Dict[str, Any]], Optional[Dict[str, Any]]]:
-        """Extract extra template volumes, mounts, and container securityContext for runtime merge."""
+    ) -> tuple[
+        list[Dict[str, Any]],
+        list[Dict[str, Any]],
+        Optional[Dict[str, Any]],
+        Dict[str, list[Dict[str, Any]]],
+    ]:
+        """Extract extra template volumes, mounts, and container securityContext for runtime merge.
+
+        Mounts declared on template containers other than the main one are returned
+        keyed by container name, so a template entry can also add mounts to a
+        runtime sidecar the template itself does not describe.
+        """
         template = self.template_manager.get_base_template()
         spec = template.get("spec", {}) if isinstance(template, dict) else {}
         template_spec = spec.get("template", {}).get("spec", {})
@@ -471,6 +509,7 @@ class BatchSandboxProvider(WorkloadProvider):
 
         extra_mounts: list[Dict[str, Any]] = []
         extra_security_context: Optional[Dict[str, Any]] = None
+        extra_sidecar_mounts: Dict[str, list[Dict[str, Any]]] = {}
         containers = template_spec.get("containers", []) or []
         if containers:
             target = None
@@ -484,12 +523,19 @@ class BatchSandboxProvider(WorkloadProvider):
             security_context = target.get("securityContext")
             if isinstance(security_context, dict):
                 extra_security_context = security_context
+            for container in containers:
+                if container is target or not isinstance(container, dict):
+                    continue
+                name = container.get("name")
+                mounts = container.get("volumeMounts", []) or []
+                if name and isinstance(mounts, list) and mounts:
+                    extra_sidecar_mounts[name] = mounts
 
         if not isinstance(extra_volumes, list):
             extra_volumes = []
         if not isinstance(extra_mounts, list):
             extra_mounts = []
-        return extra_volumes, extra_mounts, extra_security_context
+        return extra_volumes, extra_mounts, extra_security_context, extra_sidecar_mounts
 
     def _merge_pod_spec_extras(
         self,
@@ -497,6 +543,7 @@ class BatchSandboxProvider(WorkloadProvider):
         extra_volumes: list[Dict[str, Any]],
         extra_mounts: list[Dict[str, Any]],
         extra_security_context: Optional[Dict[str, Any]] = None,
+        extra_sidecar_mounts: Optional[Dict[str, list[Dict[str, Any]]]] = None,
     ) -> None:
         """Merge template-provided volumes, mounts, and securityContext into runtime pod spec."""
         try:
@@ -533,18 +580,16 @@ class BatchSandboxProvider(WorkloadProvider):
                 )
             else:
                 main_container["securityContext"] = extra_security_context
-        mounts = main_container.get("volumeMounts", []) or []
-        if isinstance(mounts, list) and extra_mounts:
-            existing = {m.get("name") for m in mounts if isinstance(m, dict)}
-            for mnt in extra_mounts:
-                if not isinstance(mnt, dict):
-                    continue
-                name = mnt.get("name")
-                if not name or name in existing:
-                    continue
-                mounts.append(mnt)
-                existing.add(name)
-            main_container["volumeMounts"] = mounts
+        _append_volume_mounts(main_container, extra_mounts)
+
+        if not extra_sidecar_mounts:
+            return
+        for container in containers[1:]:
+            if not isinstance(container, dict):
+                continue
+            name = container.get("name")
+            if isinstance(name, str):
+                _append_volume_mounts(container, extra_sidecar_mounts.get(name, []))
 
     def _build_task_template(
         self,

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -648,6 +648,121 @@ spec:
         assert mount_names.count("opensandbox-bin") == 1
         assert "sandbox-shared-data" in mount_names
 
+    def test_create_workload_merges_template_mounts_into_egress_sidecar(
+        self, mock_k8s_client, tmp_path
+    ):
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            """
+spec:
+  template:
+    spec:
+      volumes:
+        - name: egress-rules
+          configMap:
+            name: opensandbox-egress-rules
+      containers:
+        - name: sandbox
+          volumeMounts:
+            - name: sandbox-only
+              mountPath: /data
+        - name: egress
+          volumeMounts:
+            - name: egress-rules
+              mountPath: /var/egress/rules
+              readOnly: true
+"""
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "sandbox-test", "uid": "uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+            network_policy=NetworkPolicy(egress=[NetworkRule(action="allow", target="example.com")]),
+            egress_image="opensandbox/egress:v1.1.7",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        spec = body["spec"]["template"]["spec"]
+
+        assert "egress-rules" in [v["name"] for v in spec["volumes"]]
+
+        sidecar = next(c for c in spec["containers"] if c["name"] == "egress")
+        assert {
+            "name": "egress-rules",
+            "mountPath": "/var/egress/rules",
+            "readOnly": True,
+        } in sidecar["volumeMounts"]
+        # The runtime mount the sidecar already declares is preserved.
+        assert {
+            "name": OPENSANDBOX_RUNTIME_VOLUME_NAME,
+            "mountPath": OPENSANDBOX_RUNTIME_MOUNT_PATH,
+        } in sidecar["volumeMounts"]
+        # Sidecar mounts do not leak into the main container, and vice versa.
+        main = next(c for c in spec["containers"] if c["name"] == "sandbox")
+        main_mount_names = [m["name"] for m in main["volumeMounts"]]
+        assert "egress-rules" not in main_mount_names
+        assert "sandbox-only" in main_mount_names
+        assert "sandbox-only" not in [m["name"] for m in sidecar["volumeMounts"]]
+
+    def test_create_workload_ignores_template_mounts_for_absent_container(
+        self, mock_k8s_client, tmp_path
+    ):
+        """A template entry for a container the runtime does not create is a no-op."""
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            """
+spec:
+  template:
+    spec:
+      containers:
+        - name: sandbox
+          volumeMounts: []
+        - name: egress
+          volumeMounts:
+            - name: egress-rules
+              mountPath: /var/egress/rules
+"""
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "sandbox-test", "uid": "uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        containers = body["spec"]["template"]["spec"]["containers"]
+
+        assert [c["name"] for c in containers] == ["sandbox"]
+        assert "egress-rules" not in [
+            m["name"] for m in containers[0].get("volumeMounts", [])
+        ]
+
     def test_create_workload_applies_template_container_security_context(self, mock_k8s_client, tmp_path):
         template_file = tmp_path / "template.yaml"
         template_file.write_text(


### PR DESCRIPTION
Closes #1625

## Problem

Enforcing platform-wide egress rules means putting a `deny.always` file at `/var/egress/rules/deny.always` in the sidecar, and today the only documented way to get it there is baking it into a custom egress image. That routes *cluster configuration* (Pod CIDR, Service CIDR, node CIDR) through an *image release* pipeline, and it largely neutralizes the sidecar's once-per-minute always-rules reload — the file can't change without a new image.

The BatchSandbox template gets halfway there: `_extract_template_pod_extras` already picks up pod-level `volumes`, so a ConfigMap volume can reach the pod. But `volumeMounts` were only ever read from the `sandbox` container and applied to `containers[0]`. The egress sidecar is appended afterwards and is never `containers[0]`, so nothing could mount that volume into it.

## Change

Implements **Option A** from the issue: match template containers to pod containers **by name** instead of assuming index 0. A template entry named `egress` now contributes its `volumeMounts` to the sidecar:

```yaml
spec:
  template:
    spec:
      volumes:
        - name: egress-rules
          configMap:
            name: opensandbox-egress-rules
      containers:
        - name: egress
          volumeMounts:
            - name: egress-rules
              mountPath: /var/egress/rules
              readOnly: true
```

Changing the rules afterwards is `kubectl apply` on the ConfigMap alone. No new configuration surface — this reuses the template mechanism operators already use for the main container.

Main-container behavior is unchanged: the `sandbox`-or-`containers[0]` target still supplies mounts and `securityContext` to `containers[0]`, and the existing name-dedup semantics (mounts the runtime already declares win) now apply per container via a shared `_append_volume_mounts` helper.

## Docs

- `docs/architecture/network-isolation.md` — Approach 1 now presents the ConfigMap mount as the recommended route on Kubernetes, with the custom-image build kept as the option for the Docker runtime and the `agent-sandbox` provider.
- `docs/components/egress.md` — the always-rules section points at it.
- `server/configuration.md` — `batchsandbox_template_file` documents the by-name merge.
- `example.batchsandbox-template.yaml` — commented example of the sidecar mount.

## Verification

- `uv run pytest` (server): 1528 passed — includes two new cases covering the sidecar merge and a template entry for a container the runtime does not create.
- `uv run ruff check`: clean.
- `uv run pyright` on the changed module: back to its pre-change baseline (1 pre-existing error).
- `pnpm docs:build`: completes with zero errors.

## Not covered

The `agent-sandbox` provider has no template extras merging at all (its template is deep-merged, so runtime lists replace template lists wholesale), so this does not reach it. Option B's `[egress] volume_mounts` config key would have — worth a follow-up if that provider needs the same capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)