### PR TITLE
feat(server): merge template volumeMounts by container name

### DIFF
--- a/docs/architecture/network-isolation.md
+++ b/docs/architecture/network-isolation.md
@@ -71,7 +71,51 @@ Common example values:
 
 Supported target types: IP addresses (e.g., `10.0.0.5`), CIDR ranges (e.g., `10.0.0.0/8`), or domain names (e.g., `internal.service.local`, with `*.` wildcard prefix support).
 
-#### 3. Build a Custom Image Based on the Official Egress Image
+#### 3. Deliver the Rule File to the Sidecar
+
+The sidecar reads `deny.always` from `/var/egress/rules/` inside its own container. There are two ways to put it there.
+
+##### Option A: Mount It from a ConfigMap (recommended on Kubernetes)
+
+Pod CIDR, Service CIDR and node CIDR are properties of the cluster, so keeping them in a ConfigMap lets you change them with `kubectl apply` alone.
+
+Create the ConfigMap in the namespace where sandbox pods run:
+
+```bash
+kubectl create configmap opensandbox-egress-rules \
+  --from-file=deny.always \
+  -n opensandbox
+```
+
+Then declare the volume and the sidecar mount in the BatchSandbox template referenced by `kubernetes.batchsandbox_template_file`:
+
+```yaml
+spec:
+  template:
+    spec:
+      volumes:
+        - name: egress-rules
+          configMap:
+            name: opensandbox-egress-rules
+      containers:
+        - name: egress
+          volumeMounts:
+            - name: egress-rules
+              mountPath: /var/egress/rules
+              readOnly: true
+```
+
+Template containers are matched to sandbox pod containers by name, so a `containers` entry named `egress` contributes mounts to the egress sidecar without having to describe the rest of it. See [BatchSandbox template merge](https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md#batchsandbox-template-merge) for what a template can and cannot change.
+
+The template is read at server startup, so this one-time edit needs a server restart. After that, changing the rules is a single `kubectl apply` on the ConfigMap: no image rebuild, no server config change, no restart. Existing sandboxes pick the change up on the sidecar's next reload; allow for the kubelet's ConfigMap refresh interval on top of that.
+
+::: tip Available with the BatchSandbox provider
+The template merge described here applies to `kubernetes.workload_provider = "batchsandbox"` (the default). With the `agent-sandbox` provider, use Option B.
+:::
+
+##### Option B: Bake It into a Custom Egress Image
+
+Use this when there is no BatchSandbox template to extend — the Docker runtime, or the `agent-sandbox` provider.
 
 Create a `Dockerfile` that embeds the `deny.always` file into the image:
 
@@ -88,9 +132,7 @@ docker build -t registry.example.com/opensandbox/egress:hardened .
 docker push registry.example.com/opensandbox/egress:hardened
 ```
 
-#### 4. Update the Server Configuration
-
-In the OpenSandbox server configuration, point the `[egress]` `image` to the custom image:
+Then point the `[egress]` `image` at the custom image in the server configuration:
 
 ```toml
 [egress]
@@ -98,9 +140,7 @@ image = "registry.example.com/opensandbox/egress:hardened"
 mode = "dns+nft"
 ```
 
-After this configuration is applied, all newly created sandboxes will use the egress sidecar image that includes the `deny.always` rules. No changes to individual sandbox creation requests are needed.
-
-> Note: the `deny.always` file is hot-reloaded every minute. To change the rules (e.g., after a cluster CIDR change), update the `deny.always` file, rebuild the image, and perform a rolling update of the server configuration.
+Changing the rules means editing the file, rebuilding the image, pushing it, and rolling out the new tag in the server configuration.
 
 ### Effects
 
@@ -170,7 +210,7 @@ sandbox = await Sandbox.create(
 |-----------|---------------------|---------------------------|
 | Enforcement | Yes (user cannot override) | No (user can modify policy) |
 | User awareness | Transparent (platform-level) | Requires explicit declaration |
-| Operational cost | Low (one-time image build, global effect) | High (declare per sandbox) |
+| Operational cost | Low (one-time setup, global effect; rule changes are a `kubectl apply` when the file comes from a ConfigMap) | High (declare per sandbox) |
 | Cluster CIDR exposure | Not exposed to users | Must be exposed to users |
 | Use case | Platform-wide default isolation, recommended | Whitelist mode, fine-grained control |
 

--- a/docs/architecture/network-isolation.md
+++ b/docs/architecture/network-isolation.md
@@ -107,6 +107,8 @@ spec:
 
 Template containers are matched to sandbox pod containers by name, so a `containers` entry named `egress` contributes mounts to the egress sidecar without having to describe the rest of it. See [BatchSandbox template merge](https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md#batchsandbox-template-merge) for what a template can and cannot change.
 
+The ConfigMap becomes the whole content of `/var/egress/rules`, so every rule file the sidecar should read has to be a key in it — add `allow.always` and `log_skip.always` to the same ConfigMap if you use them.
+
 The template is read at server startup, so this one-time edit needs a server restart. After that, changing the rules is a single `kubectl apply` on the ConfigMap: no image rebuild, no server config change, no restart. Existing sandboxes pick the change up on the sidecar's next reload; allow for the kubelet's ConfigMap refresh interval on top of that.
 
 ::: tip Available with the BatchSandbox provider

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -101,6 +101,8 @@ Rule precedence: `deny.always` > `allow.always` > user policy (API/env).
 
 Always-rules are hot-reloaded: the sidecar polls the files once per minute and applies changes without restart.
 
+On Kubernetes, these files can be supplied from a ConfigMap mounted into the sidecar rather than baked into the egress image, so platform-wide rules change with `kubectl apply`. See [Network Isolation](/architecture/network-isolation).
+
 ### Service Mesh Compatibility
 
 ::: warning Not Supported with Transparent Mesh Sidecars

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -128,7 +128,7 @@ If `runtime.type = "kubernetes"` and the `[kubernetes]` table is absent, the ser
 | `kubeconfig_path` | string \| omitted | `null` | Path to kubeconfig (expandable, e.g. `~/.kube/config`). In-cluster configs often leave this unset and rely on in-cluster credentials. |
 | `namespace` | string \| omitted | `null` | Namespace for sandbox workloads. |
 | `workload_provider` | string \| omitted | `null` | One of: **`batchsandbox`**, **`agent-sandbox`**. If omitted, the **first registered** provider is used (currently **`batchsandbox`**). |
-| `batchsandbox_template_file` | string \| omitted | `null` | Path to **BatchSandbox** CR YAML template when `workload_provider = "batchsandbox"`. |
+| `batchsandbox_template_file` | string \| omitted | `null` | Path to **BatchSandbox** CR YAML template when `workload_provider = "batchsandbox"`. See [BatchSandbox template merge](#batchsandbox-template-merge). |
 | `image_pull_policy` | string \| omitted | `"IfNotPresent"` | Image pull policy for the BatchSandbox main container. Values: **`Always`**, **`IfNotPresent`**, **`Never`**. |
 | `sandbox_create_timeout_seconds` | integer | `60` | Max time to wait for a new sandbox to become ready (e.g. IP assigned), in seconds. |
 | `pool_acquisition_timeout_seconds` | integer | `30` | Max cumulative time to wait while Pool capacity prevents allocation. This does not extend `sandbox_create_timeout_seconds`. |
@@ -155,6 +155,22 @@ Kubernetes workloads are created by a **workload provider**. There is **no** `[b
 | Extra TOML table | None | **`[agent_sandbox]`** is required (see below) |
 
 **BatchSandbox-only config keys in `config.py`:** `batchsandbox_template_file` and `image_pull_policy` on `KubernetesRuntimeConfig`. Everything else in the `[kubernetes]` table (namespace, kubeconfig, informer, API QPS, `sandbox_create_*`, `execd_init_resources`, …) applies to **whichever** provider you select.
+
+### BatchSandbox template merge
+
+The file at `kubernetes.batchsandbox_template_file` is a partial **BatchSandbox** CR merged into every sandbox manifest. The server owns the pod's containers, so a template does not replace them — three pieces are read out of it and merged in:
+
+| Template field | Merged into |
+|---|---|
+| `spec.template.spec.volumes` | the pod's `volumes` |
+| `spec.template.spec.containers[].volumeMounts` | the **same-named** pod container's `volumeMounts` |
+| `spec.template.spec.containers[].securityContext` | the main container's `securityContext` (main container only) |
+
+Container entries are matched **by name**: `sandbox` is the container running the sandbox image, `egress` is the egress sidecar (present only when a network policy is requested). An entry with no `name` describes the main container. An entry naming a container the pod does not have is ignored.
+
+Merging is additive and never overwrites: an entry whose `name` the pod already declares is skipped, and the runtime's own value wins on conflicting `securityContext` leaves. Everything else in a template container entry — `image`, `env`, `resources`, probes — is **not** applied; the same goes for template `initContainers`.
+
+Top-level fields the server does not set itself (`tolerations`, `nodeSelector`, `affinity`, `restartPolicy`, …) merge normally. The file is read at startup, so changes to it need a server restart.
 
 ### `kubernetes.execd_init_resources`
 

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -170,7 +170,9 @@ Container entries are matched **by name**: `sandbox` is the container running th
 
 Merging is additive and never overwrites: an entry whose `name` the pod already declares is skipped, and the runtime's own value wins on conflicting `securityContext` leaves. Everything else in a template container entry — `image`, `env`, `resources`, probes — is **not** applied; the same goes for template `initContainers`.
 
-Top-level fields the server does not set itself (`tolerations`, `nodeSelector`, `affinity`, `restartPolicy`, …) merge normally. The file is read at startup, so changes to it need a server restart.
+Volume names declared in the template are reserved for the whole fleet: a sandbox creation request that asks for a volume of the same name is rejected, so a request cannot substitute its own storage behind a mount the template set up.
+
+Top-level fields the server does not set itself (`tolerations`, `restartPolicy`, `priorityClassName`, …) merge normally. `nodeSelector` and `affinity` merge too, but a request asking for a `platform` that the template's own scheduling constraints rule out is rejected rather than merged. The file is read at startup, so changes to it need a server restart.
 
 ### `kubernetes.execd_init_resources`
 

--- a/server/opensandbox_server/examples/example.batchsandbox-template.yaml
+++ b/server/opensandbox_server/examples/example.batchsandbox-template.yaml
@@ -16,3 +16,18 @@ spec:
       restartPolicy: Never
       tolerations:
         - operator: "Exists"
+      # Pod-level volumes and per-container volumeMounts declared here are merged
+      # into every sandbox pod. Template containers are matched to pod containers
+      # by name ("sandbox" runs the sandbox image, "egress" is the egress sidecar),
+      # so the entry below adds a mount to the sidecar - for example to supply
+      # always-rules from a ConfigMap instead of a custom image.
+      # volumes:
+      #   - name: egress-rules
+      #     configMap:
+      #       name: opensandbox-egress-rules
+      # containers:
+      #   - name: egress
+      #     volumeMounts:
+      #       - name: egress-rules
+      #         mountPath: /var/egress/rules
+      #         readOnly: true

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -42,6 +42,7 @@ from opensandbox_server.services.k8s.egress_helper import apply_egress_to_spec
 from opensandbox_server.services.validators import ensure_egress_runtime_compatible
 from opensandbox_server.services.k8s.provider_common import (
     DEFAULT_ENTRYPOINT,
+    MAIN_CONTAINER_NAME,
     _build_execd_init_container,
     _build_main_container,
     _container_to_dict,
@@ -93,6 +94,25 @@ def _merge_security_context(
         else:
             merged[key] = runtime_value
     return merged
+
+
+def _append_unique_by_name(
+    owner: Dict[str, Any], key: str, extras: list[Dict[str, Any]]
+) -> None:
+    """Append template entries under ``key``, skipping names ``owner`` already declares."""
+    items = owner.get(key) or []
+    if not isinstance(items, list) or not extras:
+        return
+    existing = {item.get("name") for item in items if isinstance(item, dict)}
+    for extra in extras:
+        if not isinstance(extra, dict):
+            continue
+        name = extra.get("name")
+        if not name or name in existing:
+            continue
+        items.append(extra)
+        existing.add(name)
+    owner[key] = items
 
 
 class BatchSandboxProvider(WorkloadProvider):
@@ -462,40 +482,44 @@ class BatchSandboxProvider(WorkloadProvider):
 
     def _extract_template_pod_extras(
         self,
-    ) -> tuple[list[Dict[str, Any]], list[Dict[str, Any]], Optional[Dict[str, Any]]]:
-        """Extract extra template volumes, mounts, and container securityContext for runtime merge."""
+    ) -> tuple[
+        list[Dict[str, Any]],
+        Dict[str, list[Dict[str, Any]]],
+        Optional[Dict[str, Any]],
+    ]:
+        """Extract template volumes, per-container mounts, and the main container securityContext.
+
+        Template containers are matched to pod containers by name, so an entry can
+        also add mounts to a container the template does not otherwise describe. An
+        entry without a name describes the main container. securityContext is taken
+        from the main container only.
+        """
         template = self.template_manager.get_base_template()
         spec = template.get("spec", {}) if isinstance(template, dict) else {}
         template_spec = spec.get("template", {}).get("spec", {})
-        extra_volumes = template_spec.get("volumes", []) or []
-
-        extra_mounts: list[Dict[str, Any]] = []
-        extra_security_context: Optional[Dict[str, Any]] = None
-        containers = template_spec.get("containers", []) or []
-        if containers:
-            target = None
-            for container in containers:
-                if container.get("name") == "sandbox":
-                    target = container
-                    break
-            if target is None:
-                target = containers[0]
-            extra_mounts = target.get("volumeMounts", []) or []
-            security_context = target.get("securityContext")
-            if isinstance(security_context, dict):
-                extra_security_context = security_context
-
+        extra_volumes = template_spec.get("volumes") or []
         if not isinstance(extra_volumes, list):
             extra_volumes = []
-        if not isinstance(extra_mounts, list):
-            extra_mounts = []
+
+        extra_mounts: Dict[str, list[Dict[str, Any]]] = {}
+        extra_security_context: Optional[Dict[str, Any]] = None
+        for container in template_spec.get("containers") or []:
+            name = container.get("name") or MAIN_CONTAINER_NAME
+            mounts = container.get("volumeMounts") or []
+            if isinstance(mounts, list) and mounts:
+                extra_mounts[name] = mounts
+            if name == MAIN_CONTAINER_NAME:
+                security_context = container.get("securityContext")
+                if isinstance(security_context, dict):
+                    extra_security_context = security_context
+
         return extra_volumes, extra_mounts, extra_security_context
 
     def _merge_pod_spec_extras(
         self,
         batchsandbox: Dict[str, Any],
         extra_volumes: list[Dict[str, Any]],
-        extra_mounts: list[Dict[str, Any]],
+        extra_mounts: Dict[str, list[Dict[str, Any]]],
         extra_security_context: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Merge template-provided volumes, mounts, and securityContext into runtime pod spec."""
@@ -504,18 +528,7 @@ class BatchSandboxProvider(WorkloadProvider):
         except KeyError:
             return
 
-        volumes = spec.get("volumes", []) or []
-        if isinstance(volumes, list) and extra_volumes:
-            existing = {v.get("name") for v in volumes if isinstance(v, dict)}
-            for vol in extra_volumes:
-                if not isinstance(vol, dict):
-                    continue
-                name = vol.get("name")
-                if not name or name in existing:
-                    continue
-                volumes.append(vol)
-                existing.add(name)
-            spec["volumes"] = volumes
+        _append_unique_by_name(spec, "volumes", extra_volumes)
 
         containers = spec.get("containers", []) or []
         if not containers or not isinstance(containers, list):
@@ -533,18 +546,10 @@ class BatchSandboxProvider(WorkloadProvider):
                 )
             else:
                 main_container["securityContext"] = extra_security_context
-        mounts = main_container.get("volumeMounts", []) or []
-        if isinstance(mounts, list) and extra_mounts:
-            existing = {m.get("name") for m in mounts if isinstance(m, dict)}
-            for mnt in extra_mounts:
-                if not isinstance(mnt, dict):
-                    continue
-                name = mnt.get("name")
-                if not name or name in existing:
-                    continue
-                mounts.append(mnt)
-                existing.add(name)
-            main_container["volumeMounts"] = mounts
+        for container in containers:
+            _append_unique_by_name(
+                container, "volumeMounts", extra_mounts.get(container.get("name"), [])
+            )
 
     def _build_task_template(
         self,

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -269,6 +269,10 @@ class BatchSandboxProvider(WorkloadProvider):
             "containers": containers,
             "volumes": pod_volumes,
         }
+        # Add the template's volumes before the request's own, so a request cannot
+        # take a template volume name and have the template's source dropped as a
+        # duplicate while template mounts keep pointing at that name.
+        _append_unique_by_name(pod_spec, "volumes", extra_volumes)
         if windows_profile:
             apply_windows_profile_overrides(
                 pod_spec=pod_spec,
@@ -278,15 +282,9 @@ class BatchSandboxProvider(WorkloadProvider):
                 disable_ipv6_for_egress=disable_ipv6_for_egress,
                 resource_requests=resource_requests or None,
             )
-            template = self.template_manager.get_base_template()
-            template_spec = (
-                template.get("spec", {})
-                .get("template", {})
-                .get("spec", {})
-            )
             apply_windows_profile_arch_selector(
                 pod_spec=pod_spec,
-                template_spec=template_spec if isinstance(template_spec, dict) else {},
+                template_spec=self._template_pod_spec(),
                 platform=platform,
             )
         else:
@@ -343,9 +341,7 @@ class BatchSandboxProvider(WorkloadProvider):
             batchsandbox["spec"].pop("expireTime", None)
         else:
             batchsandbox["spec"]["expireTime"] = expires_at.isoformat()
-        self._merge_pod_spec_extras(
-            batchsandbox, extra_volumes, extra_mounts, extra_security_context
-        )
+        self._merge_pod_spec_extras(batchsandbox, extra_mounts, extra_security_context)
         merged_pod_spec = batchsandbox.get("spec", {}).get("template", {}).get("spec", {})
         ensure_egress_runtime_compatible(
             network_policy,
@@ -404,15 +400,9 @@ class BatchSandboxProvider(WorkloadProvider):
         if platform is None:
             return
 
-        template = self.template_manager.get_base_template()
-        template_spec = (
-            template.get("spec", {})
-            .get("template", {})
-            .get("spec", {})
-        )
         WorkloadProvider.apply_platform_node_selector(
             pod_spec=pod_spec,
-            template_spec=template_spec if isinstance(template_spec, dict) else {},
+            template_spec=self._template_pod_spec(),
             platform=platform,
         )
 
@@ -480,6 +470,19 @@ class BatchSandboxProvider(WorkloadProvider):
             "kind": "BatchSandbox",
         }
 
+    def _template_pod_spec(self) -> Dict[str, Any]:
+        """Return the template's pod spec, treating absent and explicit-null alike.
+
+        ``or {}`` instead of ``.get(key, {})``: a key written with no value (a bare
+        ``spec:`` line) parses as None, which ``.get`` would hand back unchanged.
+        """
+        template = self.template_manager.get_base_template()
+        if not isinstance(template, dict):
+            return {}
+        spec = template.get("spec") or {}
+        pod_spec = (spec.get("template") or {}).get("spec") or {}
+        return pod_spec if isinstance(pod_spec, dict) else {}
+
     def _extract_template_pod_extras(
         self,
     ) -> tuple[
@@ -494,20 +497,21 @@ class BatchSandboxProvider(WorkloadProvider):
         entry without a name describes the main container. securityContext is taken
         from the main container only.
         """
-        template = self.template_manager.get_base_template()
-        spec = template.get("spec", {}) if isinstance(template, dict) else {}
-        template_spec = spec.get("template", {}).get("spec", {})
+        template_spec = self._template_pod_spec()
         extra_volumes = template_spec.get("volumes") or []
         if not isinstance(extra_volumes, list):
             extra_volumes = []
 
         extra_mounts: Dict[str, list[Dict[str, Any]]] = {}
         extra_security_context: Optional[Dict[str, Any]] = None
-        for container in template_spec.get("containers") or []:
+        containers = template_spec.get("containers") or []
+        for container in containers if isinstance(containers, list) else []:
+            if not isinstance(container, dict):
+                continue
             name = container.get("name") or MAIN_CONTAINER_NAME
             mounts = container.get("volumeMounts") or []
             if isinstance(mounts, list) and mounts:
-                extra_mounts[name] = mounts
+                extra_mounts.setdefault(name, []).extend(mounts)
             if name == MAIN_CONTAINER_NAME:
                 security_context = container.get("securityContext")
                 if isinstance(security_context, dict):
@@ -518,23 +522,28 @@ class BatchSandboxProvider(WorkloadProvider):
     def _merge_pod_spec_extras(
         self,
         batchsandbox: Dict[str, Any],
-        extra_volumes: list[Dict[str, Any]],
         extra_mounts: Dict[str, list[Dict[str, Any]]],
         extra_security_context: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Merge template-provided volumes, mounts, and securityContext into runtime pod spec."""
+        """Merge template-provided mounts and securityContext into runtime pod spec."""
         try:
             spec = batchsandbox["spec"]["template"]["spec"]
         except KeyError:
             return
 
-        _append_unique_by_name(spec, "volumes", extra_volumes)
-
-        containers = spec.get("containers", []) or []
-        if not containers or not isinstance(containers, list):
+        containers = spec.get("containers") or []
+        if not isinstance(containers, list) or not containers:
             return
-        main_container = containers[0]
-        if extra_security_context and isinstance(main_container, dict):
+        main_container = next(
+            (
+                container
+                for container in containers
+                if isinstance(container, dict)
+                and container.get("name") == MAIN_CONTAINER_NAME
+            ),
+            None,
+        )
+        if extra_security_context and main_container is not None:
             # The template's container securityContext is a base default: merge it
             # into the runtime container's own securityContext (runtime leaves win,
             # nested dicts merge so template members like capabilities.add survive),
@@ -547,9 +556,11 @@ class BatchSandboxProvider(WorkloadProvider):
             else:
                 main_container["securityContext"] = extra_security_context
         for container in containers:
-            _append_unique_by_name(
-                container, "volumeMounts", extra_mounts.get(container.get("name"), [])
-            )
+            if not isinstance(container, dict):
+                continue
+            name = container.get("name")
+            if isinstance(name, str):
+                _append_unique_by_name(container, "volumeMounts", extra_mounts.get(name, []))
 
     def _build_task_template(
         self,

--- a/server/opensandbox_server/services/k8s/provider_common.py
+++ b/server/opensandbox_server/services/k8s/provider_common.py
@@ -44,6 +44,10 @@ from opensandbox_server.services.k8s.security_context import (
 # Default entrypoint auto-filled by the SDK when user does not provide one.
 DEFAULT_ENTRYPOINT = ["tail", "-f", "/dev/null"]
 
+# Name of the container running the user's sandbox image. Operators match against
+# it in pod templates, so treat it as a stable name rather than an internal detail.
+MAIN_CONTAINER_NAME = "sandbox"
+
 _GPU_RESOURCE_LIMIT_KEY = "gpu"
 # Canonical extended-resource name advertised by the NVIDIA device plugin.
 # Hardcoded for parity with the Docker runtime fix (#775), which targets
@@ -221,7 +225,7 @@ def _build_main_container(
         )
 
     return V1Container(
-        name="sandbox",
+        name=MAIN_CONTAINER_NAME,
         image=image_spec.uri,
         image_pull_policy=image_pull_policy,
         command=["/opt/opensandbox/bootstrap.sh"] + entrypoint,

--- a/server/opensandbox_server/services/k8s/snapshot_runtime.py
+++ b/server/opensandbox_server/services/k8s/snapshot_runtime.py
@@ -26,6 +26,7 @@ from uuid import UUID
 
 from kubernetes.client import ApiException
 
+from opensandbox_server.services.k8s.provider_common import MAIN_CONTAINER_NAME
 from opensandbox_server.services.snapshot_models import SnapshotState
 from opensandbox_server.services.snapshot_runtime import SnapshotRuntimeStatus
 
@@ -41,7 +42,6 @@ PUBLIC_SNAPSHOT_SCOPE_LABEL = "opensandbox.io/snapshot-scope"
 PUBLIC_SNAPSHOT_ID_LABEL = "opensandbox.io/snapshot-id"
 PUBLIC_SNAPSHOT_SOURCE_SANDBOX_ID_LABEL = "opensandbox.io/source-sandbox-id"
 PUBLIC_SNAPSHOT_SCOPE_VALUE = "public"
-MAIN_CONTAINER_NAME = "sandbox"
 DEFAULT_WAIT_TIMEOUT_SECONDS = 15 * 60
 DEFAULT_POLL_INTERVAL_SECONDS = 2.0
 

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -773,6 +773,68 @@ spec:
         assert "egress-rules" in [m["name"] for m in sidecar["volumeMounts"]]
         assert "egress-rules" not in [m["name"] for m in main["volumeMounts"]]
 
+    def test_create_workload_rejects_request_volume_taking_a_template_volume_name(
+        self, mock_k8s_client, tmp_path
+    ):
+        """A request may not claim a template volume name.
+
+        Otherwise the template's own source is dropped as a duplicate while the
+        template's mount stays, handing the sidecar's rules directory to storage the
+        request controls.
+        """
+        from opensandbox_server.api.schema import Volume, Host
+
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            """
+spec:
+  template:
+    spec:
+      volumes:
+        - name: egress-rules
+          configMap:
+            name: opensandbox-egress-rules
+      containers:
+        - name: egress
+          volumeMounts:
+            - name: egress-rules
+              mountPath: /var/egress/rules
+              readOnly: true
+"""
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "sandbox-test", "uid": "uid"}
+        }
+
+        with pytest.raises(ValueError, match="conflicts with an internal volume"):
+            provider.create_workload(
+                sandbox_id="test-id",
+                namespace="test-ns",
+                image_spec=ImageSpec(uri="python:3.11"),
+                entrypoint=["/bin/bash"],
+                env={},
+                resource_limits={},
+                labels={},
+                expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+                execd_image="execd:latest",
+                network_policy=NetworkPolicy(
+                    egress=[NetworkRule(action="allow", target="example.com")]
+                ),
+                egress_image="opensandbox/egress:v1.1.7",
+                volumes=[
+                    Volume(
+                        name="egress-rules",
+                        host=Host(path="/tmp/attacker"),
+                        mount_path="/mnt/rules",
+                    )
+                ],
+            )
+
+        mock_k8s_client.create_custom_object.assert_not_called()
+
     def test_create_workload_treats_unnamed_template_container_as_main(
         self, mock_k8s_client, tmp_path
     ):

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -648,6 +648,227 @@ spec:
         assert mount_names.count("opensandbox-bin") == 1
         assert "sandbox-shared-data" in mount_names
 
+    def test_create_workload_merges_template_mounts_into_egress_sidecar(
+        self, mock_k8s_client, tmp_path
+    ):
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            """
+spec:
+  template:
+    spec:
+      volumes:
+        - name: egress-rules
+          configMap:
+            name: opensandbox-egress-rules
+      containers:
+        - name: sandbox
+          volumeMounts:
+            - name: sandbox-only
+              mountPath: /data
+        - name: egress
+          volumeMounts:
+            - name: egress-rules
+              mountPath: /var/egress/rules
+              readOnly: true
+"""
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "sandbox-test", "uid": "uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+            network_policy=NetworkPolicy(egress=[NetworkRule(action="allow", target="example.com")]),
+            egress_image="opensandbox/egress:v1.1.7",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        spec = body["spec"]["template"]["spec"]
+
+        assert "egress-rules" in [v["name"] for v in spec["volumes"]]
+
+        sidecar = next(c for c in spec["containers"] if c["name"] == "egress")
+        assert {
+            "name": "egress-rules",
+            "mountPath": "/var/egress/rules",
+            "readOnly": True,
+        } in sidecar["volumeMounts"]
+        # The runtime mount the sidecar already declares is preserved.
+        assert {
+            "name": OPENSANDBOX_RUNTIME_VOLUME_NAME,
+            "mountPath": OPENSANDBOX_RUNTIME_MOUNT_PATH,
+        } in sidecar["volumeMounts"]
+        # Sidecar mounts do not leak into the main container, and vice versa.
+        main = next(c for c in spec["containers"] if c["name"] == "sandbox")
+        main_mount_names = [m["name"] for m in main["volumeMounts"]]
+        assert "egress-rules" not in main_mount_names
+        assert "sandbox-only" in main_mount_names
+        assert "sandbox-only" not in [m["name"] for m in sidecar["volumeMounts"]]
+
+    def test_create_workload_merges_egress_only_template_into_sidecar(
+        self, mock_k8s_client, tmp_path
+    ):
+        """A template naming only the sidecar must not feed the main container.
+
+        This is the template shipped in docs/architecture/network-isolation.md: it
+        declares no ``sandbox`` entry at all, so nothing may fall back to treating
+        the ``egress`` entry as the main container.
+        """
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            """
+spec:
+  template:
+    spec:
+      volumes:
+        - name: egress-rules
+          configMap:
+            name: opensandbox-egress-rules
+      containers:
+        - name: egress
+          volumeMounts:
+            - name: egress-rules
+              mountPath: /var/egress/rules
+              readOnly: true
+"""
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "sandbox-test", "uid": "uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+            network_policy=NetworkPolicy(egress=[NetworkRule(action="allow", target="example.com")]),
+            egress_image="opensandbox/egress:v1.1.7",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        containers = body["spec"]["template"]["spec"]["containers"]
+
+        sidecar = next(c for c in containers if c["name"] == "egress")
+        main = next(c for c in containers if c["name"] == "sandbox")
+        assert "egress-rules" in [m["name"] for m in sidecar["volumeMounts"]]
+        assert "egress-rules" not in [m["name"] for m in main["volumeMounts"]]
+
+    def test_create_workload_treats_unnamed_template_container_as_main(
+        self, mock_k8s_client, tmp_path
+    ):
+        """A template container with no name still describes the main container."""
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            """
+spec:
+  template:
+    spec:
+      volumes:
+        - name: sandbox-shared-data
+          emptyDir: {}
+      containers:
+        - image: ubuntu:latest
+          volumeMounts:
+            - name: sandbox-shared-data
+              mountPath: /data
+          securityContext:
+            runAsUser: 1000
+"""
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "sandbox-test", "uid": "uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        main = body["spec"]["template"]["spec"]["containers"][0]
+
+        assert main["name"] == "sandbox"
+        assert "sandbox-shared-data" in [m["name"] for m in main["volumeMounts"]]
+        assert main["securityContext"]["runAsUser"] == 1000
+
+    def test_create_workload_ignores_template_mounts_for_absent_container(
+        self, mock_k8s_client, tmp_path
+    ):
+        """A template entry for a container the runtime does not create is a no-op.
+
+        Here no egress sidecar is requested, so the ``egress`` entry matches nothing
+        and must not fall through onto the main container.
+        """
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            """
+spec:
+  template:
+    spec:
+      containers:
+        - name: egress
+          volumeMounts:
+            - name: egress-rules
+              mountPath: /var/egress/rules
+"""
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "sandbox-test", "uid": "uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        containers = body["spec"]["template"]["spec"]["containers"]
+
+        assert [c["name"] for c in containers] == ["sandbox"]
+        assert "egress-rules" not in [
+            m["name"] for m in containers[0].get("volumeMounts", [])
+        ]
+
     def test_create_workload_applies_template_container_security_context(self, mock_k8s_client, tmp_path):
         template_file = tmp_path / "template.yaml"
         template_file.write_text(


### PR DESCRIPTION
# Summary

Closes #1625.

Enforcing platform-wide egress rules currently means baking a `deny.always` file into a custom egress image, which routes *cluster configuration* (Pod CIDR, Service CIDR, node CIDR) through an *image release* pipeline. It also largely neutralizes the sidecar's once-per-minute always-rules reload — the file cannot change without a new image.

The BatchSandbox template gets halfway there: `_extract_template_pod_extras` already picks up pod-level `volumes`, so a ConfigMap volume can reach the pod. But `volumeMounts` were only ever read from the `sandbox` container and applied to `containers[0]`, and the egress sidecar is appended afterwards — so nothing could mount that volume into it.

This implements **Option A** from the issue: match template containers to pod containers **by name**.

```yaml
spec:
  template:
    spec:
      volumes:
        - name: egress-rules
          configMap:
            name: opensandbox-egress-rules
      containers:
        - name: egress
          volumeMounts:
            - name: egress-rules
              mountPath: /var/egress/rules
              readOnly: true
```

Changing the rules afterwards is `kubectl apply` on the ConfigMap alone. No new configuration surface — this reuses the template mechanism operators already use for the main container.

Rules of the merge, now documented under [BatchSandbox template merge](https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md#batchsandbox-template-merge):

- Container entries match **by name** (`sandbox`, `egress`); an entry with no `name` describes the main container.
- `securityContext` is still taken from the main container only.
- Merging stays additive: a `name` the pod already declares is skipped, and the runtime wins on conflicting `securityContext` leaves.

# Breaking Changes

- [x] **Yes**

Template container entries are now matched strictly by name. Previously, if no entry was named `sandbox`, `containers[0]` was treated as the main container regardless of its name. **That implicit fallback is removed** — an entry must be named `sandbox` (or omit `name`) to reach the main container.

Removing it is not optional. The fallback ignores names, so it claims a `- name: egress` entry just as readily as a `- name: app` one — which is precisely why the template shown above mounted its ConfigMap onto the **sandbox** container instead of the sidecar. A positional fallback and name matching cannot coexist.

| template entry | before | after |
|---|---|---|
| `- name: sandbox` | → `sandbox` | → `sandbox` |
| `- name: egress` | → `sandbox` ❌ | → `egress` ✅ |
| `- name: app` | → `sandbox` | not applied ⚠️ |

Basis for judging the impact acceptable: the fallback is undocumented, has no test coverage, and every template example in the repository uses `- name: sandbox`.

**If you know of downstream templates that rely on it, say so** — I can add a warning when an entry matches nothing *and* no entry matched the main container, or fix the sidecar case a different way. This is your call, not mine; I picked the option that leaves one coherent rule.

# Security fix included

The second commit fixes a privilege-escalation path **that this feature would otherwise introduce**, which is why it belongs in this PR rather than a separate one.

Template volumes were merged into the pod *after* the request's own. A create request could therefore claim a template volume name: its source passed `apply_volumes_to_pod_spec`'s internal-volume check (which only knew the runtime's own volumes), the template's source was then dropped as a duplicate, and the template's mounts kept pointing at that name.

Reproduced against the feature commit — a request asking for `volumes: [{name: "egress-rules", host: {path: "/tmp/attacker"}, mountPath: "/mnt/x"}]` against the template above yields:

```
pod volume 'egress-rules' source = hostPath   (template's ConfigMap silently dropped)
sidecar mounts it read-only at /var/egress/rules
```

The sandbox then writes its own `deny.always` / `allow.always`, the sidecar hot-reloads within a minute, and platform-enforced CIDR isolation is gone.

The ordering bug predates this PR, but on `main` it is not an escalation: template mounts can only reach the main container there, so a request substitutes its own storage inside its own sandbox. The sidecar path — and with it the escalation — exists only once this feature lands. Not filed as a security advisory for that reason; happy to move it if you'd rather.

Fix: template volumes are merged into the pod spec *before* `apply_volumes_to_pod_spec`, so a colliding request hits the existing conflict check and is rejected. Template volume names are effectively reserved fleet-wide, which is now documented.

The same commit hardens the template reader against operator-authored YAML, all reproduced before fixing:

| input | before |
|---|---|
| a bare `spec:` / `spec.template.spec:` (explicit YAML null) | `AttributeError` on **every** sandbox create |
| `containers: [- "egress"]` (indentation slip) | `AttributeError` on every create |
| `containers: egress` (not a list) | crash |
| two entries resolving to one container | the first entry's mounts silently dropped |

Also: the main container is now located by name for `securityContext` too (it was still positional), and the duplicate `MAIN_CONTAINER_NAME` in `snapshot_runtime.py` now imports the `provider_common` definition.

# Testing

- [x] Unit tests

`uv run pytest` — 1531 passed. New cases:

- template mounts reach the egress sidecar, with no leakage in either direction
- the egress-only template above (the regression that motivated the by-name rule)
- an unnamed template container is treated as the main container
- an entry naming a container the pod does not have is a no-op
- a request claiming a template volume name is rejected

`uv run ruff check` clean. `uv run pyright` on the touched files is back to the single pre-existing error. `cd docs && pnpm docs:build` completes with zero errors.

Not run: Kind e2e. The change is confined to manifest construction and is covered by provider unit tests asserting the emitted BatchSandbox body.

# Docs

- `docs/architecture/network-isolation.md` — Approach 1 now leads with the ConfigMap mount, keeping the custom-image build for the Docker runtime and the `agent-sandbox` provider. Notes that the ConfigMap becomes the entire contents of `/var/egress/rules`, so `allow.always` / `log_skip.always` must be keys in it.
- `server/configuration.md` — new **BatchSandbox template merge** section owning the contract (what is merged, what is discarded, volume-name reservation). Also corrects an inaccurate claim that `nodeSelector` / `affinity` merge plainly — a `platform` request conflicting with template scheduling constraints is rejected.
- `docs/components/egress.md` — always-rules section points at it.
- `example.batchsandbox-template.yaml` — commented example of the sidecar mount.

# Not covered

The `agent-sandbox` provider has no template extras merging at all (its template is deep-merged, so runtime lists replace template lists wholesale), so this does not reach it. Option B's `[egress] volume_mounts` config key would have — worth a follow-up if that provider needs the same capability.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
