### PR TITLE
feat(helm): allow configuring the server Service type

### DIFF
--- a/docs/kubernetes/deployment.md
+++ b/docs/kubernetes/deployment.md
@@ -114,9 +114,10 @@ curl --fail http://127.0.0.1:8080/health
 | `server.env` | Additional container environment variables | Use it with `secretKeyRef` for `OPENSANDBOX_SERVER_API_KEY`. |
 | `configToml` | Complete server configuration | Mounted at `/etc/opensandbox/config.toml`; overriding it replaces the complete default TOML, including the workload namespace. |
 | `server.gateway.enabled` | Deploy the ingress gateway with the server | Defaults to `false`. |
+| `server.service.type` | Service type for the server | Defaults to `ClusterIP`. Use `NodePort` or `LoadBalancer` for access from outside the cluster; pin the port with `server.service.nodePort`. |
 | `namespaceOverride` | Namespace used by chart resources | Defaults to `opensandbox-system`. |
 
-The server container and its `ClusterIP` Service use port `80`. Keep `[server].port = 80` when replacing `configToml` unless the chart templates are also updated to use a different port.
+The server container and its Service use port `80`. Keep `[server].port = 80` when replacing `configToml` unless the chart templates are also updated to use a different port. The Service is `ClusterIP` by default; set `server.service.type` to reach the server from outside the cluster.
 
 ### Upgrade
 

--- a/kubernetes/charts/opensandbox-server/README.md
+++ b/kubernetes/charts/opensandbox-server/README.md
@@ -156,6 +156,8 @@ The following table lists the configurable parameters of the chart and their def
 | server.priorityClassName | string | `""` | Priority class name for the server pod. |
 | server.replicaCount | int | `2` | Number of server replicas |
 | server.resources | object | `{"limits":{"cpu":"2","memory":"8Gi"},"requests":{"cpu":"1","memory":"4Gi"}}` | Resource requests and limits |
+| server.service.nodePort | string | `""` | Node port to bind when type is not ClusterIP. Empty lets Kubernetes allocate one from the cluster node-port range. |
+| server.service.type | string | `"ClusterIP"` | Service type for the server. Set to NodePort or LoadBalancer to reach the server from outside the cluster. |
 | server.tolerations | list | `[]` | Tolerations for the server pod. |
 | server.topologySpreadConstraints | list | `[]` | Topology spread constraints for the server pod. |
 | server.volumeMounts | list | `[]` | Additional volume mounts for the server container. |
@@ -173,7 +175,7 @@ Versioning note:
 
 **Gateway**: When `server.gateway.enabled=true`, the chart writes `[ingress] mode = "gateway"` in config.toml and deploys **components/ingress** Deployment/Service/RBAC; gateway `--mode` matches config. External access must be configured separately.
 
-Set `[kubernetes].namespace` in config for the sandbox workload namespace and create that namespace before submitting workloads. Configure `OPENSANDBOX_SERVER_API_KEY` from a Secret in production. The container and `ClusterIP` Service use port `80`; keep `[server].port = 80` when replacing `configToml`.
+Set `[kubernetes].namespace` in config for the sandbox workload namespace and create that namespace before submitting workloads. Configure `OPENSANDBOX_SERVER_API_KEY` from a Secret in production. The container and its Service use port `80`; keep `[server].port = 80` when replacing `configToml`. The Service is `ClusterIP` unless `server.service.type` says otherwise.
 
 ## Upgrade and uninstall
 

--- a/kubernetes/charts/opensandbox-server/README.md.gotmpl
+++ b/kubernetes/charts/opensandbox-server/README.md.gotmpl
@@ -121,7 +121,7 @@ Versioning note:
 
 **Gateway**: When `server.gateway.enabled=true`, the chart writes `[ingress] mode = "gateway"` in config.toml and deploys **components/ingress** Deployment/Service/RBAC; gateway `--mode` matches config. External access must be configured separately.
 
-Set `[kubernetes].namespace` in config for the sandbox workload namespace and create that namespace before submitting workloads. Configure `OPENSANDBOX_SERVER_API_KEY` from a Secret in production. The container and `ClusterIP` Service use port `80`; keep `[server].port = 80` when replacing `configToml`.
+Set `[kubernetes].namespace` in config for the sandbox workload namespace and create that namespace before submitting workloads. Configure `OPENSANDBOX_SERVER_API_KEY` from a Secret in production. The container and its Service use port `80`; keep `[server].port = 80` when replacing `configToml`. The Service is `ClusterIP` unless `server.service.type` says otherwise.
 
 ## Upgrade and uninstall
 

--- a/kubernetes/charts/opensandbox-server/templates/server.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/server.yaml
@@ -205,11 +205,14 @@ metadata:
   labels:
     {{- include "opensandbox-server.labels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.server.service.type }}
   ports:
     - port: 80
       targetPort: http
       protocol: TCP
       name: http
+      {{- if and .Values.server.service.nodePort (ne .Values.server.service.type "ClusterIP") }}
+      nodePort: {{ .Values.server.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "opensandbox-server.selectorLabels" . | nindent 4 }}

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -41,6 +41,12 @@ server:
       cpu: "1"
       memory: 4Gi
 
+  service:
+    # -- Service type for the server. Set to NodePort or LoadBalancer to reach the server from outside the cluster.
+    type: ClusterIP
+    # -- Node port to bind when type is not ClusterIP. Empty lets Kubernetes allocate one from the cluster node-port range.
+    nodePort: ""
+
   # -- Tolerations for the server pod.
   tolerations: []
   # -- Affinity for the server pod.


### PR DESCRIPTION
# Summary

The `opensandbox-server` Service hardcodes `type: ClusterIP` (`templates/server.yaml`) and `values.yaml` exposes nothing to override it. Reaching the Lifecycle API from outside the cluster today means `kubectl patch svc` by hand, which the next `helm upgrade` reverts, or standing up a second Service alongside the chart's.

This adds `server.service.type` and `server.service.nodePort`.

```yaml
server:
  service:
    type: ClusterIP   # default — unchanged behavior
    nodePort: ""      # only used when type is not ClusterIP
```

```yaml
spec:
  type: {{ .Values.server.service.type }}
  ports:
    - port: 80
      targetPort: http
      protocol: TCP
      name: http
      {{- if and .Values.server.service.nodePort (ne .Values.server.service.type "ClusterIP") }}
      nodePort: {{ .Values.server.service.nodePort }}
      {{- end }}
```

Two notes on the guard:

- `nodePort` is emitted only when the type is not `ClusterIP`. Setting it on a `ClusterIP` Service is rejected by the API server, so this keeps that mistake out of the rendered manifest instead of surfacing it at `helm install`.
- Because the condition tests "not ClusterIP" rather than "is NodePort", `LoadBalancer` honors a pinned `nodePort` too. `type` is a free-form string here with no enum, so that combination is already reachable.

**Scope kept deliberately narrow:**

- The Service `port` stays hardcoded at `80`. It is unrelated to the type, and `[server].port = 80` in `configToml` has to match it.
- The **ingress-gateway** Service is untouched. It sits behind `server.gateway.enabled`, which defaults to `false`, so its Service is not even rendered in a default install. If someone needs it exposed, that is a separate change with its own motivation.

# Testing

- [x] Manual verification (`helm template` / `helm lint`)

`helm lint` passes. Rendered output of the `opensandbox-server` Service:

| values | `type` | `nodePort` |
|---|---|---|
| *(defaults)* | `ClusterIP` | not rendered — identical to before this change |
| `type=NodePort` | `NodePort` | not rendered (cluster allocates) |
| `type=NodePort nodePort=30080` | `NodePort` | `30080` |
| `type=LoadBalancer nodePort=31000` | `LoadBalancer` | `31000` |
| `nodePort=30080` with default type | `ClusterIP` | not rendered |

Rendering both Services together with `server.gateway.enabled=true --set server.service.type=NodePort` confirms the gateway is unaffected:

```
opensandbox-ingress-gateway   type=ClusterIP   nodePort=-
opensandbox-server            type=NodePort    nodePort=30080
```

`cd docs && pnpm docs:build` completes with zero errors.

# Breaking Changes

- [x] None

Defaults reproduce the previous manifest exactly — an existing release re-renders an unchanged Service.

# Docs

- `values.yaml` — the two new keys, with `# --` descriptions for helm-docs.
- `README.md` — regenerated rows for `server.service.type` / `server.service.nodePort`.
- `README.md.gotmpl` and `docs/kubernetes/deployment.md` — both stated "the container and its `ClusterIP` Service use port `80`", which is no longer accurate once the type is configurable. Reworded to describe `ClusterIP` as the default rather than a fact, keeping the `[server].port = 80` guidance.
- `docs/kubernetes/deployment.md` — added `server.service.type` to the **Important values** table so the capability is discoverable there.

Note: `helm-docs` was not available locally, so the two `README.md` table rows were inserted by hand following its alphabetical ordering (between `server.resources` and `server.tolerations`). Worth a CI regeneration check on your side.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed) — the chart has no test suite; verified via `helm template` / `helm lint`
- [x] Security impact considered — the Service stays `ClusterIP` unless an operator opts in
- [x] Backward compatibility considered
