### PR TITLE
fix(kotlin): send an empty egress array instead of null

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
@@ -347,7 +347,7 @@ class NetworkPolicy private constructor(
         fun build(): NetworkPolicy {
             return NetworkPolicy(
                 defaultAction = defaultAction,
-                egress = if (egress.isEmpty()) null else egress.toList(),
+                egress = egress.toList(),
             )
         }
     }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
@@ -188,6 +188,58 @@ class SandboxesAdapterTest {
     }
 
     @Test
+    fun `createSandbox should send an empty egress array when the policy carries no rules`() {
+        // A policy with no rules is the natural shape when the platform enforces the
+        // real rules itself and the caller only needs the sidecar injected. Serializing
+        // the empty list as null made the server reject the request with 422.
+        val responseBody =
+            """
+            {
+                "id": "no-rule-policy-sandbox",
+                "status": { "state": "Running" },
+                "platform": { "os": "linux", "arch": "amd64" },
+                "expiresAt": "2023-01-01T11:00:00Z",
+                "createdAt": "2023-01-01T10:00:00Z",
+                "entrypoint": ["bash"]
+            }
+            """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(201))
+
+        val networkPolicy =
+            NetworkPolicy.builder()
+                .defaultAction(NetworkPolicy.DefaultAction.ALLOW)
+                .build()
+        assertEquals(emptyList<NetworkRule>(), networkPolicy.egress)
+
+        sandboxesAdapter.createSandbox(
+            spec = SandboxImageSpec.builder().image("ubuntu:latest").build(),
+            entrypoint = listOf("bash"),
+            env = emptyMap(),
+            metadata = emptyMap(),
+            timeout = Duration.ofSeconds(600),
+            resource = emptyMap(),
+            platform = null,
+            networkPolicy = networkPolicy,
+            extensions = emptyMap(),
+            volumes = null,
+            secureAccess = false,
+            credentialProxy = null,
+        )
+
+        val request = mockWebServer.takeRequest()
+        val payload = Json.parseToJsonElement(request.body.readUtf8()).jsonObject
+        val gotNetworkPolicy = payload["networkPolicy"]!!.jsonObject
+        assertEquals("allow", gotNetworkPolicy["defaultAction"]!!.jsonPrimitive.content)
+
+        val gotEgress = gotNetworkPolicy["egress"]!!
+        assertTrue(
+            gotEgress !is JsonNull,
+            "egress must not serialize to null: the server declares it a plain list and rejects null with 422",
+        )
+        assertEquals(0, gotEgress.jsonArray.size)
+    }
+
+    @Test
     fun `createSandbox should forward windows platform in request`() {
         val responseBody =
             """


### PR DESCRIPTION
# Summary

Closes #1629.

`NetworkPolicy.Builder.build()` mapped an empty rule list to `null`:

```kotlin
egress = if (egress.isEmpty()) null else egress.toList(),
```

so a policy built without any rule went on the wire as `"egress": null` and the server answered 422:

```
{"detail":[{"type":"list_type","loc":["body","networkPolicy","egress"],
            "msg":"Input should be a valid list","input":null}]}
```

That shape is not an edge case — it is the natural one for platform-enforced egress, where the operator keeps the real rules in the sidecar's `deny.always` and the caller only needs *a* policy so the sidecar is injected at all. Until now the workaround was injecting a filler rule, which has its own trap: the filler has to be a `deny`, since an `allow` would silently widen a `defaultAction: deny` whitelist.

The fix keeps the list as built:

```kotlin
egress = egress.toList(),
```

An empty list and an absent field are the same thing to the server, so this changes nothing for callers that do pass rules. It only stops emitting the one form the schema never advertised, and makes `egress(emptyList())` behave as written.

# Why this layer

The issue traces the bug through three layers; this fixes the first one only.

| layer | state |
|---|---|
| `Builder.build()` mapping empty → `null` | **fixed here** |
| generated `api.models.NetworkPolicy.egress: List<NetworkRule>? = null` | unchanged — generated output |
| generated `Json` with `encodeDefaults = true`, `explicitNulls` left at the kotlinx default | unchanged |

Fixing layer 1 is sufficient: `NetworkPolicy`'s constructor is `private` and the builder is the only way to construct one, so no `null` ever reaches layers 2 and 3. `ApiNetworkPolicy.toDomainNetworkPolicy()` routes through the same builder, so both directions are covered by the one change.

The `explicitNulls = false` option the issue raises as a broader fix is deliberately **not** included. It is global, and it should first be checked against any endpoint that relies on an explicit `null` to mean "clear this value" — the egress policy `PATCH` surface being the likeliest. Worth its own issue.

# Testing

- [x] Unit tests

One regression test in `SandboxesAdapterTest`, reproducing the issue through `MockWebServer` and asserting the **actual request body**:

```kotlin
val gotEgress = gotNetworkPolicy["egress"]!!
assertTrue(gotEgress !is JsonNull, "egress must not serialize to null: …rejects null with 422")
assertEquals(0, gotEgress.jsonArray.size)
```

It asserts the wire format rather than the builder return value on purpose. `egress = egress.toList()` is self-evidently correct in isolation; what broke was the JSON three layers down, and since layers 2 and 3 still emit explicit nulls for a nullable field, a regenerated API client or a change to the domain→API converter could silently bring the 422 back with nothing visible in the diff. This test is the thing that would catch it.

`./gradlew spotlessCheck :sandbox:test` — 362 tests, 0 failures.

One note in case CI shows it too: `PoolWarmupLoggingTest.periodic summary reports delayed readiness without scanning tasks` failed once during a full run and passed on three consecutive reruns. It exercises log rate-limiting and timing, is unrelated to this change, and is flaky independently of it.

# Breaking Changes

- [x] None

`[]` and `null` are semantically identical for this field, and the server accepts only the former. Callers passing rules are unaffected.

# Checklist

- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed) — no user-facing doc describes this mapping
- [x] Added/updated tests (if needed)
- [x] Security impact considered — see below
- [x] Backward compatibility considered

On security: the previous workaround pushed callers toward adding a filler egress rule to keep the list non-empty. An `allow` filler widens a `defaultAction: deny` policy by exactly one target. Removing the need for a filler removes that footgun.

# Other SDKs

Checked; none share the mapping. The Go SDK declares `Egress []NetworkRule \`json:"egress,omitempty"\`` — an empty slice is simply omitted, which the server accepts. Python and JavaScript do not translate empty to null either.
