### PR TITLE
fix(server): generate unique proxy operation IDs

### DIFF
--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -562,10 +562,6 @@ async def _proxy_websocket_request(
         await _fail_client_websocket(websocket, status.WS_1011_INTERNAL_ERROR, "")
 
 
-@router.api_route(
-    "/sandboxes/{sandbox_id}/proxy/{port}",
-    methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
-)
 async def proxy_sandbox_endpoint_root(
     request: Request,
     sandbox_id: str,
@@ -575,10 +571,6 @@ async def proxy_sandbox_endpoint_root(
     return await _proxy_http_request(request, sandbox_id, port, "")
 
 
-@router.api_route(
-    "/sandboxes/{sandbox_id}/proxy/{port}/{full_path:path}",
-    methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
-)
 async def proxy_sandbox_endpoint_request(
     request: Request,
     sandbox_id: str,
@@ -587,6 +579,39 @@ async def proxy_sandbox_endpoint_request(
 ):
     """Proxy HTTP requests to sandbox-backed services."""
     return await _proxy_http_request(request, sandbox_id, port, full_path)
+
+
+_PROXY_HTTP_METHODS = ("GET", "POST", "PUT", "DELETE", "PATCH")
+
+# Keep the multi-method route first for runtime dispatch so 405 responses retain
+# the complete Allow header. The method-specific routes provide unique OpenAPI IDs.
+router.add_api_route(
+    "/sandboxes/{sandbox_id}/proxy/{port}",
+    proxy_sandbox_endpoint_root,
+    methods=list(_PROXY_HTTP_METHODS),
+    include_in_schema=False,
+)
+
+for _method in _PROXY_HTTP_METHODS:
+    router.add_api_route(
+        "/sandboxes/{sandbox_id}/proxy/{port}",
+        proxy_sandbox_endpoint_root,
+        methods=[_method],
+    )
+
+router.add_api_route(
+    "/sandboxes/{sandbox_id}/proxy/{port}/{full_path:path}",
+    proxy_sandbox_endpoint_request,
+    methods=list(_PROXY_HTTP_METHODS),
+    include_in_schema=False,
+)
+
+for _method in _PROXY_HTTP_METHODS:
+    router.add_api_route(
+        "/sandboxes/{sandbox_id}/proxy/{port}/{full_path:path}",
+        proxy_sandbox_endpoint_request,
+        methods=[_method],
+    )
 
 
 @router.websocket("/sandboxes/{sandbox_id}/proxy/{port}")

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import gzip
+import warnings
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -149,6 +150,66 @@ class _FakeWebSocketConnector:
                 return False
 
         return _ContextManager()
+
+
+def test_proxy_openapi_operation_ids_are_unique(client: TestClient) -> None:
+    app = cast(Any, client.app)
+    app.openapi_schema = None
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        schema = app.openapi()
+
+    proxy_paths = {
+        "/sandboxes/{sandbox_id}/proxy/{port}",
+        "/sandboxes/{sandbox_id}/proxy/{port}/{full_path}",
+        "/v1/sandboxes/{sandbox_id}/proxy/{port}",
+        "/v1/sandboxes/{sandbox_id}/proxy/{port}/{full_path}",
+    }
+    proxy_methods = {"get", "post", "put", "delete", "patch"}
+    operation_ids = [
+        schema["paths"][path][method]["operationId"]
+        for path in proxy_paths
+        for method in proxy_methods
+    ]
+    duplicate_warnings = [
+        str(item.message)
+        for item in caught
+        if "Duplicate Operation ID" in str(item.message)
+        and "proxy_sandbox_endpoint" in str(item.message)
+    ]
+
+    assert len(operation_ids) == 20
+    assert len(set(operation_ids)) == len(operation_ids)
+    assert duplicate_warnings == []
+
+
+@pytest.mark.parametrize(
+    "request_path",
+    [
+        "/sandboxes/sbx-123/proxy/44772",
+        "/sandboxes/sbx-123/proxy/44772/nested/path",
+        "/v1/sandboxes/sbx-123/proxy/44772",
+        "/v1/sandboxes/sbx-123/proxy/44772/nested/path",
+    ],
+)
+def test_proxy_method_not_allowed_lists_all_supported_methods(
+    client: TestClient,
+    auth_headers: dict,
+    request_path: str,
+) -> None:
+    response = client.options(
+        request_path,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 405
+    assert set(response.headers["allow"].split(", ")) == {
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+    }
 
 
 def test_proxy_forwards_filtered_headers_and_query(


### PR DESCRIPTION
# Summary
- Generate a unique and deterministic OpenAPI `operationId` for every HTTP method exposed by the Server Proxy routes.
- Preserve the existing runtime dispatch, authentication, response forwarding, and complete `405 Allow` behavior.

## Problem
The root and full-path Proxy handlers each register `GET`, `POST`, `PUT`, `DELETE`, and `PATCH` on one FastAPI `APIRoute`. After the router is mounted at both the root and `/v1` prefixes, the generated schema exposes 20 HTTP operations but only 4 unique operation IDs and emits 16 `Duplicate Operation ID` warnings.

The generated suffix is also process-dependent because FastAPI 0.137.2 derives it from `list(route.methods)[0]`.

## Minimal reproduction
1. Import the Server app and call `app.openapi()`.
2. Inspect the five methods under each of the four Proxy path variants.
3. Observe 20 operations, 4 unique operation IDs, and 16 duplicate-ID warnings.

## Root cause
FastAPI generates one `unique_id` per `APIRoute`. A single route that contains five methods therefore reuses the same ID for all five OpenAPI operations.

## Change
- Keep one hidden multi-method route per Proxy path for runtime dispatch.
- Register method-specific schema routes after it while reusing the same existing handlers.
- Add regression coverage for unique operation IDs, duplicate warnings, all route variants, and the complete `405 Allow` header.

The hidden route is registered first so runtime requests continue to use the original multi-method dispatch semantics. No handler or proxy business logic is duplicated.

## Testing
- [ ] Not run
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Results:
- `cd server && uv run pytest tests/test_routes_proxy.py`: 30 passed
- `cd server && uv run pytest`: 1531 passed
- `cd server && uv run ruff check`: passed
- Targeted Pyright for both changed files: 0 errors
- `./scripts/verify-license.sh`: passed
- `git diff --check` and sensitive-data scan: passed

Full Server Pyright was also attempted and reports the existing main baseline of 1413 errors; targeted checks for both modified files pass. Ruff format check also has existing whole-file baseline differences in both upstream files, so no unrelated full-file formatting was included.

## Compatibility and security impact
Runtime paths, supported methods, authentication, request forwarding, response forwarding, and the complete `405 Allow` header remain unchanged. No dependency, configuration, or security-boundary changes are introduced.

Generated Proxy operation IDs intentionally change from duplicate and process-dependent values to per-method unique values. Generated clients should be regenerated from the corrected schema.

## Existing Issue
Related to #1632 and the operation-ID evidence in https://github.com/opensandbox-group/OpenSandbox/issues/1632#issuecomment-5419581775. This PR does not close #1632 because that Issue also tracks transparent upstream response metadata.

# Breaking Changes
- [ ] None
- [x] Yes: generated Proxy operation IDs become stable and method-specific; runtime API behavior is unchanged.

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (not needed: runtime behavior and user-facing API paths are unchanged)
- [x] Added/updated tests
- [x] Security impact considered
- [x] Backward compatibility considered