### PR TITLE
fix(egress): fail closed when active vault lookup fails

### DIFF
--- a/components/egress/mitmscripts/system.py
+++ b/components/egress/mitmscripts/system.py
@@ -99,6 +99,10 @@ class ActiveVault:
         self.redactions = redactions
 
 
+class ActiveVaultLookupError(RuntimeError):
+    """The credential proxy could not determine the active vault state."""
+
+
 _vault_cache: ActiveVault | None = None
 _vault_cache_loaded_at = 0.0
 
@@ -172,18 +176,11 @@ def _load_active_vault() -> ActiveVault | None:
             _vault_cache_loaded_at = now
             return None
         if response.status != 200:
-            ctx.log.warn(
-                f"credential proxy: active vault lookup failed with HTTP {response.status}"
-            )
-            _vault_cache = None
-            _vault_cache_loaded_at = now
-            return None
+            raise ActiveVaultLookupError(f"HTTP {response.status}")
         payload = json.loads(body.decode("utf-8"))
-    except Exception as exc:  # noqa: BLE001 - mitm addon must not crash traffic handling
+    except Exception as exc:  # noqa: BLE001 - all lookup failures must fail closed
         ctx.log.warn(f"credential proxy: active vault lookup failed: {exc}")
-        _vault_cache = None
-        _vault_cache_loaded_at = now
-        return None
+        raise ActiveVaultLookupError("active vault lookup failed") from exc
     finally:
         connection.close()
 
@@ -377,7 +374,7 @@ def _request_may_be_streamed(flow: http.HTTPFlow) -> bool:
     return "transfer-encoding" in flow.request.headers
 
 
-def _reject_request(flow: http.HTTPFlow, body: bytes) -> None:
+def _reject_request(flow: http.HTTPFlow, body: bytes, status: int = 403) -> None:
     """Terminate a request before it is forwarded upstream.
 
     mitmproxy 11.0.2 refuses to serve a locally-set response while a request
@@ -393,7 +390,7 @@ def _reject_request(flow: http.HTTPFlow, body: bytes) -> None:
         if flow.killable:
             flow.kill()
         return
-    flow.response = http.Response.make(403, body, {"content-type": "text/plain"})
+    flow.response = http.Response.make(status, body, {"content-type": "text/plain"})
 
 
 def _flow_rejected(flow: http.HTTPFlow) -> bool:
@@ -638,7 +635,12 @@ def requestheaders(flow: http.HTTPFlow) -> None:
     made: with ``stream_large_bodies=1m`` the ``request`` hook fires only
     after a body above 1 MiB has been streamed upstream.
     """
-    vault = _load_active_vault()
+    try:
+        vault = _load_active_vault()
+    except ActiveVaultLookupError:
+        _reject_request(flow, b"credential proxy temporarily unavailable\n", status=503)
+        ctx.log.warn("credential proxy: rejected request because active vault lookup failed")
+        return
     if vault is None:
         return
 

--- a/components/egress/tests/test_mitmscripts_system.py
+++ b/components/egress/tests/test_mitmscripts_system.py
@@ -201,6 +201,125 @@ class SystemAddonRedactionTest(unittest.TestCase):
         self.assertEqual(("request", "GET", system.ACTIVE_VAULT_PATH), calls[1])
         self.assertEqual(("close", None, None), calls[-1])
 
+    def test_active_vault_timeout_rejects_request_without_upstream_forwarding(self) -> None:
+        system = _load_system_module()
+
+        class TimeoutConnection:
+            def __init__(self, socket_path: str, timeout: float) -> None:
+                pass
+
+            def request(self, method: str, path: str) -> None:
+                raise TimeoutError("timed out")
+
+            def close(self) -> None:
+                pass
+
+        system.UnixSocketHTTPConnection = TimeoutConnection
+        flow = _Flow()
+        flow.response = None
+
+        system.requestheaders(flow)
+
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(503, flow.response.status_code)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
+    def test_expired_vault_cache_is_not_reused_after_lookup_failure(self) -> None:
+        system = _load_system_module()
+        system._vault_cache = system.ActiveVault(
+            1,
+            [
+                {
+                    "name": "gitlab-api",
+                    "match": {"hosts": ["code.example.com"]},
+                    "headers": [{"name": "Private-Token", "value": "stale-secret"}],
+                }
+            ],
+            ["stale-secret"],
+        )
+        system._vault_cache_loaded_at = 0.0
+
+        class TimeoutConnection:
+            def __init__(self, socket_path: str, timeout: float) -> None:
+                pass
+
+            def request(self, method: str, path: str) -> None:
+                raise TimeoutError("timed out")
+
+            def close(self) -> None:
+                pass
+
+        system.UnixSocketHTTPConnection = TimeoutConnection
+        flow = _Flow()
+        flow.response = None
+
+        system.requestheaders(flow)
+
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(503, flow.response.status_code)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
+    def test_active_vault_http_error_rejects_request_without_upstream_forwarding(self) -> None:
+        system = _load_system_module()
+
+        class ErrorResponse:
+            status = 500
+
+            def read(self) -> bytes:
+                return b""
+
+        class ErrorConnection:
+            def __init__(self, socket_path: str, timeout: float) -> None:
+                pass
+
+            def request(self, method: str, path: str) -> None:
+                pass
+
+            def getresponse(self) -> ErrorResponse:
+                return ErrorResponse()
+
+            def close(self) -> None:
+                pass
+
+        system.UnixSocketHTTPConnection = ErrorConnection
+        flow = _Flow()
+        flow.response = None
+
+        system.requestheaders(flow)
+
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(503, flow.response.status_code)
+
+    def test_missing_active_vault_remains_an_authoritative_pass_through(self) -> None:
+        system = _load_system_module()
+
+        class MissingResponse:
+            status = 404
+
+            def read(self) -> bytes:
+                return b""
+
+        class MissingConnection:
+            def __init__(self, socket_path: str, timeout: float) -> None:
+                pass
+
+            def request(self, method: str, path: str) -> None:
+                pass
+
+            def getresponse(self) -> MissingResponse:
+                return MissingResponse()
+
+            def close(self) -> None:
+                pass
+
+        system.UnixSocketHTTPConnection = MissingConnection
+        flow = _Flow()
+        flow.response = None
+
+        system.requestheaders(flow)
+
+        self.assertIsNone(flow.response)
+
     def test_request_injection_log_does_not_include_secret_value(self) -> None:
         system = _load_system_module()
         flow = _Flow()


### PR DESCRIPTION
## Summary

- distinguish an authoritative 404 (no active vault) from credential-proxy lookup failures
- fail closed with HTTP 503 on timeout, 5xx, malformed responses, and other lookup errors
- never reuse an expired cached vault after a failed refresh, since revocation may have occurred

## Why

The credential-injection proxy currently treats Unix-socket timeouts and non-200 responses as if no vault were active. The request is then forwarded upstream with unresolved credential placeholders, producing misleading provider authentication failures and allowing traffic to bypass the credential-vault enforcement path.

A 404 remains the explicit no-vault result and continues to pass through unchanged. All operational lookup failures now stop the request locally.

## Tests

`python3 -m unittest components.egress.tests.test_mitmscripts_system` (54 tests)

Please include this fix in the next official `opensandbox/egress` release so downstream deployments can update their pinned multi-architecture digest.