### PR TITLE
fix(lifecycle): raise pre-start timeout limit

### DIFF
--- a/components/execd/pkg/lifecycle/config.go
+++ b/components/execd/pkg/lifecycle/config.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -33,9 +34,9 @@ const (
 	ConfigEnv     = "OPENSANDBOX_LIFECYCLE"
 	ConfigPathEnv = "EXECD_LIFECYCLE_CONFIG"
 
-	defaultTimeout        = 60 * time.Second
-	maxHookTimeoutSeconds = 300
-	configVersion         = 1
+	defaultTimeout            = 60 * time.Second
+	maxTimeoutDurationSeconds = math.MaxInt64 / int64(time.Second)
+	configVersion             = 1
 )
 
 // Config is the creation-time sandbox lifecycle configuration consumed by
@@ -198,8 +199,8 @@ func validateHook(name string, hook Hook) error {
 	if hook.TimeoutSeconds < 0 {
 		return fmt.Errorf("%s timeoutSeconds must not be negative", name)
 	}
-	if hook.TimeoutSeconds > maxHookTimeoutSeconds {
-		return fmt.Errorf("%s timeoutSeconds must not exceed %d", name, maxHookTimeoutSeconds)
+	if int64(hook.TimeoutSeconds) > maxTimeoutDurationSeconds {
+		return fmt.Errorf("%s timeoutSeconds must not exceed %d", name, maxTimeoutDurationSeconds)
 	}
 	return nil
 }

--- a/components/execd/pkg/lifecycle/config_test.go
+++ b/components/execd/pkg/lifecycle/config_test.go
@@ -159,25 +159,17 @@ func TestDecodeConfigRejectsTimezoneWithoutSchedule(t *testing.T) {
 	require.ErrorContains(t, err, `periodic hook "sync" has invalid schedule`)
 }
 
-func TestDecodeConfigEnforcesMaximumHookTimeout(t *testing.T) {
-	for _, test := range []struct {
-		name string
-		raw  string
-	}{
-		{name: "preStart", raw: `{"preStart":{"command":["true"],"timeoutSeconds":301}}`},
-		{name: "periodic", raw: `{"periodic":[{"name":"sync","schedule":"@hourly","command":["true"],"timeoutSeconds":301}]}`},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			_, err := decodeConfig([]byte(test.raw))
-			require.ErrorContains(t, err, "timeoutSeconds must not exceed 300")
-		})
-	}
-
+func TestDecodeConfigAcceptsTimeoutsAboveServerLimits(t *testing.T) {
 	_, err := decodeConfig([]byte(`{
-  "preStart": {"command": ["true"], "timeoutSeconds": 300},
-  "periodic": [{"name": "sync", "schedule": "@hourly", "command": ["true"], "timeoutSeconds": 300}]
+  "preStart": {"command": ["true"], "timeoutSeconds": 10801},
+  "periodic": [{"name": "sync", "schedule": "@hourly", "command": ["true"], "timeoutSeconds": 301}]
 }`))
 	require.NoError(t, err)
+}
+
+func TestDecodeConfigRejectsTimeoutDurationOverflow(t *testing.T) {
+	_, err := decodeConfig([]byte(`{"preStart":{"command":["true"],"timeoutSeconds":9223372037}}`))
+	require.ErrorContains(t, err, "timeoutSeconds must not exceed 9223372036")
 }
 
 func TestLoadConfigRejectsInvalidPersistedConfig(t *testing.T) {

--- a/docs/guides/lifecycle-hooks.md
+++ b/docs/guides/lifecycle-hooks.md
@@ -61,7 +61,7 @@ Lifecycle hooks are part of the sandbox creation request:
 | Field | Required | Description |
 |---|---:|---|
 | `command` | Yes | Non-empty command and argument array |
-| `timeoutSeconds` | No | When omitted, defaults to 60 seconds; explicit values must be from 1 through 300 seconds |
+| `timeoutSeconds` | No | When omitted, defaults to 60 seconds; explicit values must be from 1 through 10800 seconds (3 hours) |
 
 `preStart` runs on each container start. Make the command idempotent so retrying or restarting a sandbox does not corrupt its state.
 

--- a/docs/sdks/csharp.md
+++ b/docs/sdks/csharp.md
@@ -96,7 +96,7 @@ await using var sandbox = await Sandbox.CreateAsync(new SandboxCreateOptions
 });
 ```
 
-The Server validates `TimeoutSeconds`; when omitted it defaults to 60 seconds. See [Lifecycle Hooks](/guides/lifecycle-hooks) for timing, failure behavior, and provider limitations.
+The Server validates `TimeoutSeconds`; `PreStart` accepts 1–10800 seconds, while `Periodic` accepts 1–300 seconds. Both default to 60 seconds when omitted. See [Lifecycle Hooks](/guides/lifecycle-hooks) for timing, failure behavior, and provider limitations.
 
 ## Usage Examples
 

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -328,7 +328,7 @@ sandbox, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreate
 })
 ```
 
-The Server validates `TimeoutSeconds`; when omitted it defaults to 60 seconds. See [Lifecycle Hooks](/guides/lifecycle-hooks) for timing, failure behavior, and provider limitations.
+The Server validates `TimeoutSeconds`; `PreStart` accepts 1–10800 seconds, while `Periodic` accepts 1–300 seconds. Both default to 60 seconds when omitted. See [Lifecycle Hooks](/guides/lifecycle-hooks) for timing, failure behavior, and provider limitations.
 
 ## API Reference
 

--- a/docs/sdks/javascript.md
+++ b/docs/sdks/javascript.md
@@ -95,7 +95,7 @@ const sandbox = await Sandbox.create({
 });
 ```
 
-The Server validates `timeoutSeconds`; when omitted it defaults to 60 seconds. See [Lifecycle Hooks](/guides/lifecycle-hooks) for timing, failure behavior, and provider limitations.
+The Server validates `timeoutSeconds`; `preStart` accepts 1–10800 seconds, while `periodic` accepts 1–300 seconds. Both default to 60 seconds when omitted. See [Lifecycle Hooks](/guides/lifecycle-hooks) for timing, failure behavior, and provider limitations.
 
 ## Usage Examples
 

--- a/docs/sdks/kotlin.md
+++ b/docs/sdks/kotlin.md
@@ -106,7 +106,7 @@ Sandbox sandbox = Sandbox.builder()
     .build();
 ```
 
-The Server validates `timeoutSeconds`; when omitted it defaults to 60 seconds. See [Lifecycle Hooks](/guides/lifecycle-hooks) for timing, failure behavior, and provider limitations.
+The Server validates `timeoutSeconds`; `preStart` accepts 1–10800 seconds, while `periodic` accepts 1–300 seconds. Both default to 60 seconds when omitted. See [Lifecycle Hooks](/guides/lifecycle-hooks) for timing, failure behavior, and provider limitations.
 
 ## Usage Examples
 

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -288,7 +288,7 @@ sandbox = await Sandbox.create(
 )
 ```
 
-The Server validates `timeout_seconds`; when omitted it defaults to 60 seconds. See [Lifecycle Hooks](/guides/lifecycle-hooks) for timing, failure behavior, and provider limitations.
+The Server validates `timeout_seconds`; `pre_start` accepts 1–10800 seconds, while `periodic` accepts 1–300 seconds. Both default to 60 seconds when omitted. See [Lifecycle Hooks](/guides/lifecycle-hooks) for timing, failure behavior, and provider limitations.
 
 ## Usage Examples
 

--- a/oseps/0020-sandbox-lifecycle-hooks.md
+++ b/oseps/0020-sandbox-lifecycle-hooks.md
@@ -4,7 +4,7 @@ authors:
   - "@Pangjiping"
   - "@peijianping"
 creation-date: 2026-08-17
-last-updated: 2026-08-21
+last-updated: 2026-08-26
 status: implementing
 ---
 
@@ -86,7 +86,7 @@ Related: [#1458](https://github.com/opensandbox-group/OpenSandbox/issues/1458) (
 | R1 | Hooks declared in `CreateSandboxRequest.lifecycle`; all optional |
 | R2 | `preStart` executes in-sandbox before the entrypoint, with no server round trip; not PATCHable |
 | R3 | `prePause`/`postResume` are triggered by an event-only server POST (`/v1/lifecycle/run`); `preTerminate` runs in-sandbox on SIGTERM; `periodic` runs on an execd ticker |
-| R4 | `timeoutSeconds` (1–300, default 60) per hook. `failurePolicy`: `Abort` default for `prePause`/`postResume`; `preTerminate`/`periodic` fixed `Continue` (`Abort` rejected) |
+| R4 | `timeoutSeconds` defaults to 60. `preStart` accepts 1–10800 seconds; all other hooks accept 1–300 seconds. `failurePolicy`: `Abort` default for `prePause`/`postResume`; `preTerminate`/`periodic` fixed `Continue` (`Abort` rejected) |
 | R5 | Abort: hook failure/timeout, lifecycle startup failure, or required execd lifecycle status being unreachable aborts the transition, leaving the pre-transition state with a machine-readable reason |
 | R6 | Hooks never block **termination**: `preTerminate` runs only while `Running`; `Paused`/`Failed` sandboxes skip hooks (no SIGTERM handler / no pod) |
 | R7 | `periodic` runs on cron inside execd without server liveness dependency; in-flight run of the same `name` skips the tick (no queueing) |

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
@@ -931,7 +931,7 @@ public class LifecycleHook
     public required IReadOnlyList<string> Command { get; set; }
 
     /// <summary>
-    /// Gets or sets the execution timeout in seconds. The maximum is 300 seconds.
+    /// Gets or sets the execution timeout in seconds. The maximum is 3 hours (10800 seconds).
     /// </summary>
     [JsonPropertyName("timeoutSeconds")]
     public int? TimeoutSeconds { get; set; }

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -1086,7 +1086,7 @@ export interface components {
         LifecycleHook: {
             /** @description Command and arguments to execute. */
             command: string[];
-            /** @description Maximum execution time in seconds, up to 300. The server defaults to 60 when omitted. */
+            /** @description Maximum execution time in seconds, up to 3 hours (10800 seconds) for `preStart`. The server defaults to 60 when omitted. */
             timeoutSeconds?: number;
         };
         /** @description A named lifecycle command scheduled inside the sandbox by execd. */

--- a/sdks/sandbox/javascript/src/models/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/models/sandboxes.ts
@@ -470,7 +470,7 @@ export interface SandboxInfo extends Record<string, unknown> {
 export interface LifecycleHook extends Record<string, unknown> {
   /** Command and arguments executed without implicit shell expansion. */
   command: string[];
-  /** Maximum execution time in seconds, up to 300. Defaults to 60. */
+  /** Maximum execution time in seconds, up to 3 hours (10800 seconds). Defaults to 60. */
   timeoutSeconds?: number;
 }
 

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/lifecycle_hook.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/lifecycle_hook.py
@@ -34,8 +34,8 @@ class LifecycleHook:
 
         Attributes:
             command (list[str]): Command and arguments to execute.
-            timeout_seconds (int | Unset): Maximum execution time in seconds, up to 300. The server defaults to 60 when
-                omitted.
+            timeout_seconds (int | Unset): Maximum execution time in seconds, up to 3 hours (10800 seconds) for `preStart`.
+                The server defaults to 60 when omitted.
     """
 
     command: list[str]

--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -143,7 +143,7 @@ class LifecycleHook(BaseModel):
     """Command executed by execd before the user entrypoint starts."""
 
     command: List[str] = Field(..., min_length=1)
-    timeout_seconds: Optional[int] = Field(None, alias="timeoutSeconds", ge=1, le=300)
+    timeout_seconds: Optional[int] = Field(None, alias="timeoutSeconds", ge=1, le=10800)
 
     @model_validator(mode="after")
     def validate_command(self) -> "LifecycleHook":

--- a/server/tests/test_schema.py
+++ b/server/tests/test_schema.py
@@ -89,38 +89,44 @@ class TestSandboxLifecycle:
             )
 
     @pytest.mark.parametrize(
-        "hook",
+        ("hook", "expected"),
         [
-            LifecycleHook(command=["true"], timeoutSeconds=300),
-            PeriodicLifecycleHook(
-                name="sync",
-                schedule="@hourly",
-                command=["true"],
-                timeoutSeconds=300,
+            (LifecycleHook(command=["true"], timeoutSeconds=10800), 10800),
+            (
+                PeriodicLifecycleHook(
+                    name="sync",
+                    schedule="@hourly",
+                    command=["true"],
+                    timeoutSeconds=300,
+                ),
+                300,
             ),
         ],
     )
-    def test_lifecycle_accepts_maximum_timeout(self, hook):
-        assert hook.timeout_seconds == 300
+    def test_lifecycle_accepts_maximum_timeout(self, hook, expected):
+        assert hook.timeout_seconds == expected
 
     @pytest.mark.parametrize(
-        "payload",
+        ("payload", "maximum"),
         [
-            {"preStart": {"command": ["true"], "timeoutSeconds": 301}},
-            {
-                "periodic": [
-                    {
-                        "name": "sync",
-                        "schedule": "@hourly",
-                        "command": ["true"],
-                        "timeoutSeconds": 301,
-                    }
-                ]
-            },
+            ({"preStart": {"command": ["true"], "timeoutSeconds": 10801}}, 10800),
+            (
+                {
+                    "periodic": [
+                        {
+                            "name": "sync",
+                            "schedule": "@hourly",
+                            "command": ["true"],
+                            "timeoutSeconds": 301,
+                        }
+                    ]
+                },
+                300,
+            ),
         ],
     )
-    def test_lifecycle_rejects_timeout_above_maximum(self, payload):
-        with pytest.raises(ValidationError, match="less than or equal to 300"):
+    def test_lifecycle_rejects_timeout_above_maximum(self, payload, maximum):
+        with pytest.raises(ValidationError, match=f"less than or equal to {maximum}"):
             SandboxLifecycle.model_validate(payload)
 
     @pytest.mark.parametrize("duplicate_name", ["sync", " sync "])

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -1285,8 +1285,8 @@ components:
         timeoutSeconds:
           type: integer
           minimum: 1
-          maximum: 300
-          description: Maximum execution time in seconds, up to 300. The server defaults to 60 when omitted.
+          maximum: 10800
+          description: Maximum execution time in seconds, up to 3 hours (10800 seconds) for `preStart`. The server defaults to 60 when omitted.
       additionalProperties: false
     PeriodicLifecycleHook:
       type: object


### PR DESCRIPTION
# Summary
- Raise the Server and OpenAPI `preStart.timeoutSeconds` limit from 300 seconds to 10800 seconds (3 hours).
- Keep the Server-side `periodic.timeoutSeconds` limit at 300 seconds.
- Remove product policy upper bounds from execd so future policy changes remain Server-only, while retaining a technical guard against `time.Duration` overflow.
- Regenerate affected SDK API descriptions and update lifecycle, SDK, and OSEP documentation.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
  - `go test ./pkg/lifecycle`
  - execd golangci-lint v1.64.8
  - Server full suite: 1526 passed
  - Python SDK ruff, pyright, and tests
  - TypeScript SDK lint, typecheck, build, and 104 tests
  - Aone Server targeted lifecycle tests: 38 passed
- [ ] Integration tests
- [ ] e2e / manual verification
- Docs build: passed

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered