### PR TITLE
fix(server): map completed agent-sandbox pods to terminal states

### DIFF
--- a/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
@@ -446,6 +446,12 @@ class AgentSandboxProvider(WorkloadProvider):
             state = "Running"
         elif reason == "SandboxExpired":
             state = "Terminated"
+        elif reason == "PodSucceeded":
+            state = "Terminated"
+            message = message or "Sandbox pod completed successfully."
+        elif reason == "PodFailed":
+            state = "Failed"
+            message = message or "Sandbox pod failed."
         elif cond_status == "False" and self.is_platform_unschedulable(
             reason,
             message,

--- a/server/tests/k8s/test_agent_sandbox_provider.py
+++ b/server/tests/k8s/test_agent_sandbox_provider.py
@@ -484,6 +484,50 @@ spec:
         assert result["state"] == "Terminated"
         assert result["reason"] == "SandboxExpired"
 
+    def test_get_status_pod_succeeded_maps_to_terminated(self):
+        provider = AgentSandboxProvider(MagicMock())
+        workload = {
+            "status": {
+                "conditions": [
+                    {
+                        "type": "Ready",
+                        "status": "False",
+                        "reason": "PodSucceeded",
+                        "message": "Pod completed successfully",
+                        "lastTransitionTime": "2025-12-31T10:00:00Z",
+                    }
+                ]
+            },
+            "metadata": {"creationTimestamp": "2025-12-31T09:00:00Z"},
+        }
+
+        result = provider.get_status(workload)
+
+        assert result["state"] == "Terminated"
+        assert result["reason"] == "PodSucceeded"
+
+    def test_get_status_pod_failed_maps_to_failed(self):
+        provider = AgentSandboxProvider(MagicMock())
+        workload = {
+            "status": {
+                "conditions": [
+                    {
+                        "type": "Ready",
+                        "status": "False",
+                        "reason": "PodFailed",
+                        "message": "Pod failed",
+                        "lastTransitionTime": "2025-12-31T10:00:00Z",
+                    }
+                ]
+            },
+            "metadata": {"creationTimestamp": "2025-12-31T09:00:00Z"},
+        }
+
+        result = provider.get_status(workload)
+
+        assert result["state"] == "Failed"
+        assert result["reason"] == "PodFailed"
+
     def test_get_status_falls_back_to_pod_state(self, mock_k8s_client):
         provider = AgentSandboxProvider(mock_k8s_client)
         mock_k8s_client.list_pods.return_value = [


### PR DESCRIPTION
# Summary

- When a Sandbox pod reaches a terminal phase, the agent-sandbox controller reports it on the Ready condition with reason `PodSucceeded`/`PodFailed` (and adds a `Finished` condition). `get_status` only special-cased `SandboxExpired`, so a completed sandbox fell through to the generic `Ready=False` branch and was reported as `Pending` indefinitely — clients polling for a terminal state never see one.
- Map `PodSucceeded` → `Terminated` and `PodFailed` → `Failed`, mirroring the docker runtime's exited/dead handling (exit 0 → Terminated, non-zero → Failed). The upstream condition reason is passed through.

Closes #1641

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

Unit tests: two new cases in `server/tests/k8s/test_agent_sandbox_provider.py` mirroring the existing `SandboxExpired` case; full server K8s suite passes.

Manual verification on a live cluster: a Sandbox whose pod completed (pod phase `Succeeded`, `Ready=False/PodSucceeded`, `Finished=True`) reported `state=Pending reason=PodSucceeded` indefinitely on main; with this patch the same CR reports `state=Terminated`. Repeated with a non-zero exit (pod phase `Failed`, `Ready=False/PodFailed`): the patched server reports `state=Failed`.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

Completed sandboxes that previously stayed `Pending` forever now surface a terminal state — the intended fix, aligned with the documented lifecycle states.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered