### PR TITLE
ci: stop auto-applying sdks label on PRs

### DIFF
--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -144,7 +144,6 @@ jobs:
               // SDK — layout: sdks/{sandbox,code-interpreter,mcp}/{go,python,...};
               // Kotlin code-interpreter lives under sdks/sandbox/kotlin/code-interpreter.
               if (dirs.has("sdks")) {
-                s.push("sdks");
                 const langMap = {
                   go: "sdk/go",
                   kotlin: "sdk/java",


### PR DESCRIPTION
Removes the generic `sdks` label from the PR auto-label workflow. Language-specific labels (`sdk/go`, `sdk/python`, `sdk/js`, etc.) are kept.