### PR TITLE
feat(server): add PostgreSQL snapshot store

### DIFF
--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -126,10 +126,49 @@ jobs:
         run: |
           cat server/app.log
 
+  postgresql-integration:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: opensandbox
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d opensandbox"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      OPENSANDBOX_TEST_POSTGRESQL_DSN: postgresql://postgres:postgres@127.0.0.1:5432/opensandbox
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Run PostgreSQL repository tests
+        working-directory: server
+        run: |
+          uv sync --all-groups
+          uv run python -c "import os, psycopg; psycopg.connect(os.environ['OPENSANDBOX_TEST_POSTGRESQL_DSN'], connect_timeout=10).close()"
+          uv run pytest -v tests/test_snapshot_repository_postgresql.py
+
   required:
     name: Server CI
     if: always()
-    needs: [changes, test, docker-smoke]
+    needs: [changes, test, docker-smoke, postgresql-integration]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
@@ -138,13 +177,14 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           TEST_RESULT: ${{ needs.test.result }}
           DOCKER_SMOKE_RESULT: ${{ needs.docker-smoke.result }}
+          POSTGRESQL_RESULT: ${{ needs.postgresql-integration.result }}
         run: |
           if [[ "$CHANGES_RESULT" != "success" ]]; then
             echo "Change detection failed: $CHANGES_RESULT"
             exit 1
           fi
           if [[ "$RELEVANT" == "true" ]]; then
-            [[ "$TEST_RESULT" == "success" && "$DOCKER_SMOKE_RESULT" == "success" ]]
+            [[ "$TEST_RESULT" == "success" && "$DOCKER_SMOKE_RESULT" == "success" && "$POSTGRESQL_RESULT" == "success" ]]
           else
-            [[ "$RELEVANT" == "false" && "$TEST_RESULT" == "skipped" && "$DOCKER_SMOKE_RESULT" == "skipped" ]]
+            [[ "$RELEVANT" == "false" && "$TEST_RESULT" == "skipped" && "$DOCKER_SMOKE_RESULT" == "skipped" && "$POSTGRESQL_RESULT" == "skipped" ]]
           fi

--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -162,7 +162,6 @@ jobs:
         working-directory: server
         run: |
           uv sync --all-groups
-          uv run python -c "import os, psycopg; psycopg.connect(os.environ['OPENSANDBOX_TEST_POSTGRESQL_DSN'], connect_timeout=10).close()"
           uv run pytest -v tests/test_snapshot_repository_postgresql.py
 
   required:

--- a/docs/components/server.md
+++ b/docs/components/server.md
@@ -68,7 +68,31 @@ opensandbox-server init-config ~/.sandbox.toml --example docker
 2. Edit the file for your environment. Full reference: [configuration.md](https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md) (all keys, defaults, validation, env vars).
 
    Topics covered there include: Docker `network_mode` / `host_ip` (e.g. server in Docker Compose), `[egress]` when clients send `networkPolicy`, `[ingress]`, `[secure_runtime]`, Kubernetes `workload_provider` / `batchsandbox_template_file`, `[agent_sandbox]`, TTL caps, `[renew_intent]`.
-   The server-wide persistence backend is configured under `[store]`; by default OpenSandbox uses a local SQLite database at `~/.opensandbox/opensandbox.db` for server-managed metadata such as snapshot records.
+   The server-wide persistence backend is configured under `[store]`; by default OpenSandbox uses a local SQLite database at `~/.opensandbox/opensandbox.db` for server-managed metadata such as snapshot records. PostgreSQL can be selected for externally managed persistence; see the [store configuration](https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md#store).
+
+### PostgreSQL persistence
+
+Set the backend in the TOML configuration and inject the connection string through the environment:
+
+```toml
+[store]
+type = "postgresql"
+
+[store.postgresql]
+min_pool_size = 1
+max_pool_size = 10
+```
+
+```bash
+export OPENSANDBOX_STORE_POSTGRESQL_DSN='postgresql://opensandbox:password@postgres:5432/opensandbox?sslmode=require'
+opensandbox-server
+```
+
+::: warning
+Snapshot recovery is not coordinated across server processes. Run only one active server process against a PostgreSQL database.
+:::
+
+For Kubernetes Secret and Helm values wiring, see [Kubernetes Deployment](/kubernetes/deployment#use-postgresql-for-server-persistence).
 
 ### OpenTelemetry metrics
 

--- a/docs/kubernetes/deployment.md
+++ b/docs/kubernetes/deployment.md
@@ -69,6 +69,48 @@ Use an external secret manager instead of creating the Secret manually in produc
 
 The chart installs the server into `opensandbox-system`, while the default `configToml` creates sandbox and pool resources in `opensandbox`. If you change `[kubernetes].namespace` in `configToml`, create that namespace instead of `opensandbox` before submitting workloads.
 
+### Use PostgreSQL for server persistence
+
+Create a Secret containing the PostgreSQL connection string:
+
+```bash
+read -s OPENSANDBOX_POSTGRESQL_DSN
+kubectl create secret generic opensandbox-postgresql \
+  --namespace opensandbox-system \
+  --from-literal=dsn="${OPENSANDBOX_POSTGRESQL_DSN}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+unset OPENSANDBOX_POSTGRESQL_DSN
+```
+
+In `values-server.yaml`, set `server.replicaCount` to `1`, add the Secret-backed
+environment variable below, and add the shown `[store]` tables to the complete
+`configToml` value:
+
+```yaml
+server:
+  replicaCount: 1
+  env:
+    - name: OPENSANDBOX_STORE_POSTGRESQL_DSN
+      valueFrom:
+        secretKeyRef:
+          name: opensandbox-postgresql
+          key: dsn
+
+configToml: |
+  # Keep the rest of the chart's complete server configuration here.
+  [store]
+  type = "postgresql"
+
+  [store.postgresql]
+  min_pool_size = 1
+  max_pool_size = 10
+```
+
+::: warning
+Snapshot recovery is not coordinated across server replicas. Keep
+`server.replicaCount: 1` when replicas use the same PostgreSQL database.
+:::
+
 ### Install and verify
 
 Inspect all available settings before installation:

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -275,17 +275,45 @@ the same backend.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `type` | string | `"sqlite"` | Server persistence backend type. Currently only **`sqlite`** is supported. |
+| `type` | string | `"sqlite"` | Server persistence backend type: `sqlite` or `postgresql`. |
 | `path` | string | `"~/.opensandbox/opensandbox.db"` | Filesystem path to the SQLite database file used for server-managed metadata. Parent directories are created automatically when needed. |
+| `postgresql.dsn` | string | unset | PostgreSQL connection string. Required when `type = "postgresql"`. In production, prefer the `OPENSANDBOX_STORE_POSTGRESQL_DSN` environment variable. |
+| `postgresql.min_pool_size` | integer | `1` | Minimum number of PostgreSQL connections retained by each server process. |
+| `postgresql.max_pool_size` | integer | `10` | Maximum number of PostgreSQL connections used by each server process. |
+| `postgresql.connect_timeout_seconds` | integer | `5` | Maximum time to establish the initial PostgreSQL connections. |
+| `postgresql.pool_timeout_seconds` | number | `5` | Maximum time to wait for a pooled PostgreSQL connection. |
 
 **Notes**
 
 - The default SQLite backend gives local and single-node deployments persistent
   metadata without requiring an external database service.
+- PostgreSQL provides shared metadata for multi-instance deployments. The total
+  connection limit is `server process count * postgresql.max_pool_size`.
+- `OPENSANDBOX_STORE_POSTGRESQL_DSN` overrides `postgresql.dsn`, keeping database
+  credentials out of configuration files and Kubernetes ConfigMaps.
+- Switching backends does not copy existing snapshot metadata. Start with an
+  empty PostgreSQL database or migrate existing records separately before cutover.
 - `memory` is intentionally **not** the default because server-managed snapshot
   resources must survive process restarts.
 - Higher-level components should depend on repository abstractions rather than
   importing `sqlite3` directly.
+
+Example:
+
+```toml
+[store]
+type = "postgresql"
+
+[store.postgresql]
+min_pool_size = 1
+max_pool_size = 10
+connect_timeout_seconds = 5
+pool_timeout_seconds = 5
+```
+
+```bash
+export OPENSANDBOX_STORE_POSTGRESQL_DSN='postgresql://opensandbox:password@postgres:5432/opensandbox?sslmode=require'
+```
 
 ---
 

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -287,8 +287,9 @@ the same backend.
 
 - The default SQLite backend gives local and single-node deployments persistent
   metadata without requiring an external database service.
-- PostgreSQL provides shared metadata for multi-instance deployments. The total
-  connection limit is `server process count * postgresql.max_pool_size`.
+- PostgreSQL provides externally managed persistence, but snapshot recovery is
+  not coordinated across server processes. Run only one active server process
+  against a PostgreSQL database.
 - `OPENSANDBOX_STORE_POSTGRESQL_DSN` overrides `postgresql.dsn`, keeping database
   credentials out of configuration files and Kubernetes ConfigMaps.
 - Switching backends does not copy existing snapshot metadata. Start with an
@@ -314,6 +315,8 @@ pool_timeout_seconds = 5
 ```bash
 export OPENSANDBOX_STORE_POSTGRESQL_DSN='postgresql://opensandbox:password@postgres:5432/opensandbox?sslmode=require'
 ```
+
+For Kubernetes configuration, see [Kubernetes Deployment](../docs/kubernetes/deployment.md#use-postgresql-for-server-persistence).
 
 ---
 

--- a/server/opensandbox_server/cli.py
+++ b/server/opensandbox_server/cli.py
@@ -36,6 +36,7 @@ from opensandbox_server.config import (
     RenewIntentConfig,
     RuntimeConfig,
     ServerConfig,
+    StoreConfig,
     StorageConfig,
     load_config,
 )
@@ -259,6 +260,7 @@ def render_full_config(destination: str | Path | None = None, *, force: bool = F
         ),
         _render_section("ingress", IngressConfig),
         _render_section("storage", StorageConfig),
+        _render_section("store", StoreConfig),
     ]
 
     content = "\n\n".join(sections) + "\n"

--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Any, ClassVar, Dict, Literal, Optional
 
 from kubernetes.utils.quantity import parse_quantity
-from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+from pydantic import BaseModel, Field, SecretStr, ValidationError, field_validator, model_validator
 
 try:  # Python 3.11+
     import tomllib  # type: ignore[attr-defined]
@@ -43,6 +43,7 @@ CONFIG_ENV_VAR = "SANDBOX_CONFIG_PATH"
 DEFAULT_CONFIG_PATH = Path.home() / ".sandbox.toml"
 
 API_KEY_ENV_VAR = "OPENSANDBOX_SERVER_API_KEY"
+POSTGRESQL_DSN_ENV_VAR = "OPENSANDBOX_STORE_POSTGRESQL_DSN"
 
 # OSEP-0011 secure-access keys may be injected via environment instead of the
 # [ingress.secure_access] TOML block, so key material can come from a Secret
@@ -1068,18 +1069,78 @@ class DockerConfig(BaseModel):
         return self
 
 
+class PostgreSQLStoreConfig(BaseModel):
+    """PostgreSQL connection and pool settings for server persistence."""
+
+    dsn: Optional[SecretStr] = Field(
+        default=None,
+        description=(
+            "PostgreSQL connection string. In production, inject it with "
+            f"{POSTGRESQL_DSN_ENV_VAR} instead of storing credentials in TOML."
+        ),
+    )
+    min_pool_size: int = Field(
+        default=1,
+        ge=0,
+        description="Minimum number of PostgreSQL connections retained per server process.",
+    )
+    max_pool_size: int = Field(
+        default=10,
+        ge=1,
+        description="Maximum number of PostgreSQL connections per server process.",
+    )
+    connect_timeout_seconds: int = Field(
+        default=5,
+        ge=1,
+        description="Maximum time in seconds to establish initial PostgreSQL connections.",
+    )
+    pool_timeout_seconds: float = Field(
+        default=5.0,
+        gt=0,
+        description="Maximum time in seconds to wait for a pooled PostgreSQL connection.",
+    )
+
+    @model_validator(mode="after")
+    def validate_pool_size(self) -> "PostgreSQLStoreConfig":
+        if self.min_pool_size > self.max_pool_size:
+            raise ValueError(
+                "store.postgresql.min_pool_size must be less than or equal to "
+                "store.postgresql.max_pool_size."
+            )
+        return self
+
+
 class StoreConfig(BaseModel):
     """Persistence backend for server-managed server resources."""
 
-    type: Literal["sqlite"] = Field(
+    type: Literal["sqlite", "postgresql"] = Field(
         default="sqlite",
-        description="Server persistence backend type. SQLite is the default local persistent backend.",
+        description=(
+            "Server persistence backend type. SQLite is the default local persistent backend; "
+            "PostgreSQL provides shared persistence across server instances."
+        ),
     )
     path: str = Field(
         default=str(Path.home() / ".opensandbox" / "opensandbox.db"),
         description="Filesystem path to the SQLite database used for server metadata persistence.",
         min_length=1,
     )
+    postgresql: PostgreSQLStoreConfig = Field(
+        default_factory=PostgreSQLStoreConfig,
+        description="PostgreSQL settings used when store.type is 'postgresql'.",
+    )
+
+    @model_validator(mode="after")
+    def require_postgresql_dsn(self) -> "StoreConfig":
+        if self.type != "postgresql":
+            return self
+        dsn = self.postgresql.dsn
+        if dsn is None or not dsn.get_secret_value().strip():
+            raise ValueError(
+                "store.postgresql.dsn or "
+                f"{POSTGRESQL_DSN_ENV_VAR} must be set when store.type is 'postgresql'."
+            )
+        return self
 
 
 class TenantsConfig(BaseModel):
@@ -1215,6 +1276,22 @@ def _load_toml_data(path: Path) -> dict[str, Any]:
         raise
 
 
+def _apply_raw_env_overrides(raw_data: dict[str, Any]) -> None:
+    """Apply environment overrides that must participate in model validation."""
+    postgresql_dsn = os.environ.get(POSTGRESQL_DSN_ENV_VAR)
+    if postgresql_dsn is None:
+        return
+
+    store_data = raw_data.setdefault("store", {})
+    if not isinstance(store_data, dict):
+        raise ValueError("[store] must be a TOML table.")
+    postgresql_data = store_data.setdefault("postgresql", {})
+    if not isinstance(postgresql_data, dict):
+        raise ValueError("[store.postgresql] must be a TOML table.")
+    # Wrap before validation so errors from sibling fields cannot expose credentials.
+    postgresql_data["dsn"] = SecretStr(postgresql_dsn)
+
+
 def _apply_env_overrides(config: AppConfig) -> None:
     """Apply environment variable overrides to parsed configuration."""
     if API_KEY_ENV_VAR in os.environ:
@@ -1278,6 +1355,7 @@ def load_config(path: str | Path | None = None) -> AppConfig:
 
     resolved_path = _resolve_config_path(path)
     raw_data = _load_toml_data(resolved_path)
+    _apply_raw_env_overrides(raw_data)
 
     try:
         _config = AppConfig(**raw_data)
@@ -1328,6 +1406,7 @@ __all__ = [
     "DockerConfig",
     "StorageConfig",
     "StoreConfig",
+    "PostgreSQLStoreConfig",
     "KubernetesRuntimeConfig",
     "EgressConfig",
     "EGRESS_MODE_DNS",
@@ -1335,6 +1414,7 @@ __all__ = [
     "SecureRuntimeConfig",
     "DEFAULT_CONFIG_PATH",
     "CONFIG_ENV_VAR",
+    "POSTGRESQL_DSN_ENV_VAR",
     "get_config",
     "get_config_path",
     "load_config",

--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -1117,7 +1117,7 @@ class StoreConfig(BaseModel):
         default="sqlite",
         description=(
             "Server persistence backend type. SQLite is the default local persistent backend; "
-            "PostgreSQL provides shared persistence across server instances."
+            "PostgreSQL provides external persistence."
         ),
     )
     path: str = Field(

--- a/server/opensandbox_server/examples/example.config.k8s.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.toml
@@ -55,8 +55,8 @@ volume_default_size = "1Gi"
 # SQLite is durable only when this path is backed by a PersistentVolume.
 type = "sqlite"
 path = "~/.opensandbox/opensandbox.db"
-# For multiple server replicas, use type = "postgresql" with [store.postgresql]
-# pool settings and inject OPENSANDBOX_STORE_POSTGRESQL_DSN.
+# To use PostgreSQL, set type = "postgresql", configure [store.postgresql], and
+# inject OPENSANDBOX_STORE_POSTGRESQL_DSN. Use only one active server replica.
 
 [kubernetes]
 # Path to kubeconfig file. Leave as null to use in-cluster configuration

--- a/server/opensandbox_server/examples/example.config.k8s.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.toml
@@ -51,6 +51,13 @@ allowed_host_paths = []
 # Default storage size for auto-created Kubernetes PVCs (when caller omits size).
 volume_default_size = "1Gi"
 
+[store]
+# SQLite is durable only when this path is backed by a PersistentVolume.
+type = "sqlite"
+path = "~/.opensandbox/opensandbox.db"
+# For multiple server replicas, use type = "postgresql" with [store.postgresql]
+# pool settings and inject OPENSANDBOX_STORE_POSTGRESQL_DSN.
+
 [kubernetes]
 # Path to kubeconfig file. Leave as null to use in-cluster configuration
 kubeconfig_path = "~/.kube/config"

--- a/server/opensandbox_server/examples/example.config.k8s.zh.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.zh.toml
@@ -54,8 +54,8 @@ volume_default_size = "1Gi"
 # 仅当该路径挂载了 PersistentVolume 时，SQLite 数据才会持久保留。
 type = "sqlite"
 path = "~/.opensandbox/opensandbox.db"
-# 多 Server 副本请改用 type = "postgresql"，在 [store.postgresql] 配置连接池，
-# 并通过 OPENSANDBOX_STORE_POSTGRESQL_DSN 注入连接串。
+# 如需使用 PostgreSQL，请设置 type = "postgresql"，在 [store.postgresql]
+# 配置连接池，并通过 OPENSANDBOX_STORE_POSTGRESQL_DSN 注入连接串。只能运行一个活跃 Server 副本。
 
 [kubernetes]
 # Path to kubeconfig file. Leave as null to use in-cluster configuration

--- a/server/opensandbox_server/examples/example.config.k8s.zh.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.zh.toml
@@ -50,6 +50,13 @@ allowed_host_paths = []
 # 自动创建 Kubernetes PVC 时的默认存储大小（当调用方未指定时使用）。
 volume_default_size = "1Gi"
 
+[store]
+# 仅当该路径挂载了 PersistentVolume 时，SQLite 数据才会持久保留。
+type = "sqlite"
+path = "~/.opensandbox/opensandbox.db"
+# 多 Server 副本请改用 type = "postgresql"，在 [store.postgresql] 配置连接池，
+# 并通过 OPENSANDBOX_STORE_POSTGRESQL_DSN 注入连接串。
+
 [kubernetes]
 # Path to kubeconfig file. Leave as null to use in-cluster configuration
 kubeconfig_path = "~/.kube/config"

--- a/server/opensandbox_server/examples/example.config.toml
+++ b/server/opensandbox_server/examples/example.config.toml
@@ -54,13 +54,14 @@ volume_default_size = "1Gi"
 [store]
 type = "sqlite"
 path = "~/.opensandbox/opensandbox.db"
-# For a shared PostgreSQL store, set type = "postgresql" and configure:
+# For an external PostgreSQL store, set type = "postgresql" and configure:
 # [store.postgresql]
 # min_pool_size = 1
 # max_pool_size = 10
 # connect_timeout_seconds = 5
 # pool_timeout_seconds = 5
 # Inject the DSN with OPENSANDBOX_STORE_POSTGRESQL_DSN in production.
+# Use only one active server process per PostgreSQL database.
 
 [docker]
 network_mode = "bridge"

--- a/server/opensandbox_server/examples/example.config.toml
+++ b/server/opensandbox_server/examples/example.config.toml
@@ -54,6 +54,13 @@ volume_default_size = "1Gi"
 [store]
 type = "sqlite"
 path = "~/.opensandbox/opensandbox.db"
+# For a shared PostgreSQL store, set type = "postgresql" and configure:
+# [store.postgresql]
+# min_pool_size = 1
+# max_pool_size = 10
+# connect_timeout_seconds = 5
+# pool_timeout_seconds = 5
+# Inject the DSN with OPENSANDBOX_STORE_POSTGRESQL_DSN in production.
 
 [docker]
 network_mode = "bridge"

--- a/server/opensandbox_server/examples/example.config.zh.toml
+++ b/server/opensandbox_server/examples/example.config.zh.toml
@@ -49,6 +49,13 @@ volume_default_size = "1Gi"
 [store]
 type = "sqlite"
 path = "~/.opensandbox/opensandbox.db"
+# 如需多实例共享 PostgreSQL 存储，请设置 type = "postgresql" 并配置：
+# [store.postgresql]
+# min_pool_size = 1
+# max_pool_size = 10
+# connect_timeout_seconds = 5
+# pool_timeout_seconds = 5
+# 生产环境通过 OPENSANDBOX_STORE_POSTGRESQL_DSN 注入连接串。
 
 [docker]
 # Supported values for network_mode: "host", "bridge"

--- a/server/opensandbox_server/examples/example.config.zh.toml
+++ b/server/opensandbox_server/examples/example.config.zh.toml
@@ -49,13 +49,14 @@ volume_default_size = "1Gi"
 [store]
 type = "sqlite"
 path = "~/.opensandbox/opensandbox.db"
-# 如需多实例共享 PostgreSQL 存储，请设置 type = "postgresql" 并配置：
+# 如需使用外部 PostgreSQL 存储，请设置 type = "postgresql" 并配置：
 # [store.postgresql]
 # min_pool_size = 1
 # max_pool_size = 10
 # connect_timeout_seconds = 5
 # pool_timeout_seconds = 5
 # 生产环境通过 OPENSANDBOX_STORE_POSTGRESQL_DSN 注入连接串。
+# 每个 PostgreSQL 数据库只能由一个活跃 Server 进程使用。
 
 [docker]
 # Supported values for network_mode: "host", "bridge"

--- a/server/opensandbox_server/main.py
+++ b/server/opensandbox_server/main.py
@@ -98,6 +98,7 @@ from opensandbox_server.middleware.auth import AuthMiddleware  # noqa: E402
 from opensandbox_server.middleware.date_header import DateHeaderMiddleware  # noqa: E402
 from opensandbox_server.middleware.http_metrics import HttpMetricsMiddleware  # noqa: E402
 from opensandbox_server.middleware.request_id import RequestIdMiddleware  # noqa: E402
+from opensandbox_server.repositories.snapshots.factory import close_snapshot_repository  # noqa: E402
 from opensandbox_server.services.extension_service import require_extension_service  # noqa: E402
 from opensandbox_server.services.runtime_resolver import (  # noqa: E402
     validate_secure_runtime_on_startup,
@@ -196,6 +197,7 @@ async def lifespan(app: FastAPI):
         await consumer.stop()
     shutdown_otel_metrics()
     snapshot_service.close()
+    close_snapshot_repository()
     if tenant_provider is not None:
         tenant_provider.close()
     await app.state.http_client.aclose()

--- a/server/opensandbox_server/repositories/snapshots/__init__.py
+++ b/server/opensandbox_server/repositories/snapshots/__init__.py
@@ -14,18 +14,12 @@
 
 """Snapshot persistence backends."""
 
-from opensandbox_server.repositories.snapshots.factory import (
-    close_snapshot_repository,
-    create_snapshot_repository,
-    get_snapshot_repository,
-)
+from opensandbox_server.repositories.snapshots.factory import create_snapshot_repository
 from opensandbox_server.repositories.snapshots.postgresql import PostgreSQLSnapshotRepository
 from opensandbox_server.repositories.snapshots.sqlite import SQLiteSnapshotRepository
 
 __all__ = [
     "SQLiteSnapshotRepository",
     "PostgreSQLSnapshotRepository",
-    "close_snapshot_repository",
     "create_snapshot_repository",
-    "get_snapshot_repository",
 ]

--- a/server/opensandbox_server/repositories/snapshots/__init__.py
+++ b/server/opensandbox_server/repositories/snapshots/__init__.py
@@ -14,10 +14,18 @@
 
 """Snapshot persistence backends."""
 
-from opensandbox_server.repositories.snapshots.factory import create_snapshot_repository
+from opensandbox_server.repositories.snapshots.factory import (
+    close_snapshot_repository,
+    create_snapshot_repository,
+    get_snapshot_repository,
+)
+from opensandbox_server.repositories.snapshots.postgresql import PostgreSQLSnapshotRepository
 from opensandbox_server.repositories.snapshots.sqlite import SQLiteSnapshotRepository
 
 __all__ = [
     "SQLiteSnapshotRepository",
+    "PostgreSQLSnapshotRepository",
+    "close_snapshot_repository",
     "create_snapshot_repository",
+    "get_snapshot_repository",
 ]

--- a/server/opensandbox_server/repositories/snapshots/factory.py
+++ b/server/opensandbox_server/repositories/snapshots/factory.py
@@ -18,9 +18,11 @@ Factory for selecting the configured snapshot repository backend.
 
 from __future__ import annotations
 
+from functools import cache
 from typing import Optional
 
 from opensandbox_server.config import AppConfig, get_config
+from opensandbox_server.repositories.snapshots.postgresql import PostgreSQLSnapshotRepository
 from opensandbox_server.repositories.snapshots.sqlite import SQLiteSnapshotRepository
 from opensandbox_server.services.snapshot_repository import SnapshotRepository
 
@@ -37,12 +39,41 @@ def create_snapshot_repository(
 
     if store_config.type == "sqlite":
         return SQLiteSnapshotRepository(store_config.path)
+    if store_config.type == "postgresql":
+        postgresql_config = store_config.postgresql
+        dsn = postgresql_config.dsn
+        if dsn is None:
+            raise ValueError("PostgreSQL snapshot store requires a DSN.")
+        return PostgreSQLSnapshotRepository(
+            dsn.get_secret_value(),
+            min_pool_size=postgresql_config.min_pool_size,
+            max_pool_size=postgresql_config.max_pool_size,
+            connect_timeout_seconds=postgresql_config.connect_timeout_seconds,
+            pool_timeout_seconds=postgresql_config.pool_timeout_seconds,
+        )
 
     raise ValueError(
         f"Unsupported snapshot store type: {store_config.type}"
     )
 
 
+@cache
+def get_snapshot_repository() -> SnapshotRepository:
+    """Return the repository shared by the current server process."""
+    return create_snapshot_repository()
+
+
+def close_snapshot_repository() -> None:
+    """Close and discard the repository shared by the current server process."""
+    if get_snapshot_repository.cache_info().currsize == 0:
+        return
+    repository = get_snapshot_repository()
+    get_snapshot_repository.cache_clear()
+    repository.close()
+
+
 __all__ = [
+    "close_snapshot_repository",
     "create_snapshot_repository",
+    "get_snapshot_repository",
 ]

--- a/server/opensandbox_server/repositories/snapshots/postgresql.py
+++ b/server/opensandbox_server/repositories/snapshots/postgresql.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, overload
 
 from psycopg import sql
 from psycopg.rows import dict_row
@@ -295,6 +295,14 @@ class PostgreSQLSnapshotRepository:
         }
 
     @staticmethod
+    @overload
+    def _normalize_datetime(value: None) -> None: ...
+
+    @staticmethod
+    @overload
+    def _normalize_datetime(value: datetime) -> datetime: ...
+
+    @staticmethod
     def _normalize_datetime(value: datetime | None) -> datetime | None:
         if value is None:
             return None
@@ -316,10 +324,12 @@ class PostgreSQLSnapshotRepository:
                 state=SnapshotState(row["state"]),
                 reason=row["reason"],
                 message=row["message"],
-                last_transition_at=row["last_transition_at"],
+                last_transition_at=PostgreSQLSnapshotRepository._normalize_datetime(
+                    row["last_transition_at"]
+                ),
             ),
-            created_at=row["created_at"],
-            updated_at=row["updated_at"],
+            created_at=PostgreSQLSnapshotRepository._normalize_datetime(row["created_at"]),
+            updated_at=PostgreSQLSnapshotRepository._normalize_datetime(row["updated_at"]),
         )
 
 

--- a/server/opensandbox_server/repositories/snapshots/postgresql.py
+++ b/server/opensandbox_server/repositories/snapshots/postgresql.py
@@ -1,0 +1,329 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PostgreSQL-backed snapshot repository."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from psycopg import sql
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+from psycopg_pool import ConnectionPool
+
+from opensandbox_server.services.snapshot_models import (
+    SnapshotRecord,
+    SnapshotRestoreConfig,
+    SnapshotState,
+    SnapshotStatusRecord,
+)
+from opensandbox_server.services.snapshot_repository import (
+    SnapshotListQuery,
+    SnapshotListResult,
+)
+
+POSTGRESQL_SCHEMA_LOCK_NAME = "opensandbox-server-snapshot-schema"
+
+_SELECT_COLUMNS = """
+    id,
+    source_sandbox_id,
+    namespace,
+    name,
+    description,
+    restore_config,
+    state,
+    reason,
+    message,
+    last_transition_at,
+    created_at,
+    updated_at
+"""
+
+_UPDATE_COLUMNS = """
+    source_sandbox_id = %(source_sandbox_id)s,
+    namespace = %(namespace)s,
+    name = %(name)s,
+    description = %(description)s,
+    restore_config = %(restore_config)s,
+    state = %(state)s,
+    reason = %(reason)s,
+    message = %(message)s,
+    last_transition_at = %(last_transition_at)s,
+    created_at = %(created_at)s,
+    updated_at = %(updated_at)s
+"""
+
+
+class PostgreSQLSnapshotRepository:
+    """Connection-pooled PostgreSQL repository for persisted snapshot records."""
+
+    def __init__(
+        self,
+        dsn: str,
+        *,
+        min_pool_size: int = 1,
+        max_pool_size: int = 10,
+        connect_timeout_seconds: int = 5,
+        pool_timeout_seconds: float = 5.0,
+    ) -> None:
+        self._pool = ConnectionPool(
+            conninfo=dsn,
+            min_size=min_pool_size,
+            max_size=max_pool_size,
+            timeout=pool_timeout_seconds,
+            kwargs={
+                "connect_timeout": connect_timeout_seconds,
+                "row_factory": dict_row,
+            },
+            open=False,
+        )
+        try:
+            self._pool.open(wait=True, timeout=connect_timeout_seconds)
+            self._initialize_schema()
+        except BaseException:
+            self._pool.close()
+            raise
+
+    def create(self, record: SnapshotRecord) -> SnapshotRecord:
+        with self._pool.connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO snapshots (
+                    id,
+                    source_sandbox_id,
+                    namespace,
+                    name,
+                    description,
+                    restore_config,
+                    state,
+                    reason,
+                    message,
+                    last_transition_at,
+                    created_at,
+                    updated_at
+                ) VALUES (
+                    %(id)s,
+                    %(source_sandbox_id)s,
+                    %(namespace)s,
+                    %(name)s,
+                    %(description)s,
+                    %(restore_config)s,
+                    %(state)s,
+                    %(reason)s,
+                    %(message)s,
+                    %(last_transition_at)s,
+                    %(created_at)s,
+                    %(updated_at)s
+                )
+                """,
+                self._to_db_params(record),
+            )
+        return record
+
+    def get(self, snapshot_id: str) -> SnapshotRecord | None:
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                f"SELECT {_SELECT_COLUMNS} FROM snapshots WHERE id = %s",
+                (snapshot_id,),
+            ).fetchone()
+        return self._row_to_record(row) if row is not None else None
+
+    def list(self, query: SnapshotListQuery) -> SnapshotListResult:
+        clauses: list[sql.SQL] = []
+        params: dict[str, Any] = {}
+
+        if query.namespace is not None:
+            clauses.append(sql.SQL("namespace = %(namespace)s"))
+            params["namespace"] = query.namespace
+        if query.source_sandbox_id:
+            clauses.append(sql.SQL("source_sandbox_id = %(source_sandbox_id)s"))
+            params["source_sandbox_id"] = query.source_sandbox_id
+        if query.name is not None:
+            clauses.append(sql.SQL("name = %(name)s"))
+            params["name"] = query.name
+        if query.states:
+            clauses.append(sql.SQL("state = ANY(%(states)s)"))
+            params["states"] = query.states
+
+        where_sql = (
+            sql.SQL("WHERE {}").format(sql.SQL(" AND ").join(clauses)) if clauses else sql.SQL("")
+        )
+        page = max(query.page, 1)
+        page_size = max(query.page_size, 1)
+        params["page_size"] = page_size
+        params["offset"] = (page - 1) * page_size
+
+        with self._pool.connection() as conn:
+            total_row = conn.execute(
+                sql.SQL("SELECT COUNT(*) AS total_items FROM snapshots {}").format(where_sql),
+                params,
+            ).fetchone()
+            rows = conn.execute(
+                sql.SQL("""
+                SELECT {}
+                FROM snapshots
+                {}
+                ORDER BY created_at DESC, id DESC
+                LIMIT %(page_size)s OFFSET %(offset)s
+                """).format(sql.SQL(_SELECT_COLUMNS), where_sql),
+                params,
+            ).fetchall()
+
+        return SnapshotListResult(
+            items=[self._row_to_record(row) for row in rows],
+            total_items=int(total_row["total_items"]) if total_row is not None else 0,
+        )
+
+    def update(self, record: SnapshotRecord) -> SnapshotRecord:
+        with self._pool.connection() as conn:
+            conn.execute(
+                f"""
+                UPDATE snapshots
+                SET {_UPDATE_COLUMNS}
+                WHERE id = %(id)s
+                """,
+                self._to_db_params(record),
+            )
+        return record
+
+    def update_if_state(
+        self,
+        record: SnapshotRecord,
+        expected_state: SnapshotState,
+    ) -> bool:
+        params = self._to_db_params(record)
+        params["expected_state"] = expected_state.value
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                f"""
+                UPDATE snapshots
+                SET {_UPDATE_COLUMNS}
+                WHERE id = %(id)s AND state = %(expected_state)s
+                RETURNING id
+                """,
+                params,
+            ).fetchone()
+        return row is not None
+
+    def delete(self, snapshot_id: str) -> None:
+        with self._pool.connection() as conn:
+            conn.execute("DELETE FROM snapshots WHERE id = %s", (snapshot_id,))
+
+    def close(self) -> None:
+        self._pool.close()
+
+    def _initialize_schema(self) -> None:
+        with self._pool.connection() as conn:
+            conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtext(%s))",
+                (POSTGRESQL_SCHEMA_LOCK_NAME,),
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS snapshots (
+                    id TEXT PRIMARY KEY,
+                    source_sandbox_id TEXT NOT NULL,
+                    namespace TEXT DEFAULT NULL,
+                    name TEXT,
+                    description TEXT,
+                    restore_config JSONB NOT NULL,
+                    state TEXT NOT NULL,
+                    reason TEXT,
+                    message TEXT,
+                    last_transition_at TIMESTAMPTZ,
+                    created_at TIMESTAMPTZ NOT NULL,
+                    updated_at TIMESTAMPTZ NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_snapshots_source_sandbox_id
+                    ON snapshots(source_sandbox_id)
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_snapshots_state
+                    ON snapshots(state)
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_snapshots_created_at
+                    ON snapshots(created_at DESC)
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_snapshots_name_namespace
+                    ON snapshots(name, namespace)
+                """
+            )
+
+    @staticmethod
+    def _to_db_params(record: SnapshotRecord) -> dict[str, Any]:
+        return {
+            "id": record.id,
+            "source_sandbox_id": record.source_sandbox_id,
+            "namespace": record.namespace,
+            "name": record.name,
+            "description": record.description,
+            "restore_config": Jsonb({"image": record.restore_config.image}),
+            "state": record.status.state.value,
+            "reason": record.status.reason,
+            "message": record.status.message,
+            "last_transition_at": PostgreSQLSnapshotRepository._normalize_datetime(
+                record.status.last_transition_at
+            ),
+            "created_at": PostgreSQLSnapshotRepository._normalize_datetime(record.created_at),
+            "updated_at": PostgreSQLSnapshotRepository._normalize_datetime(record.updated_at),
+        }
+
+    @staticmethod
+    def _normalize_datetime(value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    @staticmethod
+    def _row_to_record(row: Mapping[str, Any]) -> SnapshotRecord:
+        restore_config = row["restore_config"]
+        return SnapshotRecord(
+            id=row["id"],
+            source_sandbox_id=row["source_sandbox_id"],
+            namespace=row["namespace"],
+            name=row["name"],
+            description=row["description"],
+            restore_config=SnapshotRestoreConfig(image=restore_config.get("image")),
+            status=SnapshotStatusRecord(
+                state=SnapshotState(row["state"]),
+                reason=row["reason"],
+                message=row["message"],
+                last_transition_at=row["last_transition_at"],
+            ),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+
+__all__ = [
+    "POSTGRESQL_SCHEMA_LOCK_NAME",
+    "PostgreSQLSnapshotRepository",
+]

--- a/server/opensandbox_server/repositories/snapshots/postgresql.py
+++ b/server/opensandbox_server/repositories/snapshots/postgresql.py
@@ -36,7 +36,7 @@ from opensandbox_server.services.snapshot_repository import (
     SnapshotListResult,
 )
 
-POSTGRESQL_SCHEMA_LOCK_NAME = "opensandbox-server-snapshot-schema"
+_SCHEMA_LOCK_NAME = "opensandbox-server-snapshot-schema"
 
 _SELECT_COLUMNS = """
     id,
@@ -230,7 +230,7 @@ class PostgreSQLSnapshotRepository:
         with self._pool.connection() as conn:
             conn.execute(
                 "SELECT pg_advisory_xact_lock(hashtext(%s))",
-                (POSTGRESQL_SCHEMA_LOCK_NAME,),
+                (_SCHEMA_LOCK_NAME,),
             )
             conn.execute(
                 """
@@ -283,7 +283,7 @@ class PostgreSQLSnapshotRepository:
             "namespace": record.namespace,
             "name": record.name,
             "description": record.description,
-            "restore_config": Jsonb({"image": record.restore_config.image}),
+            "restore_config": Jsonb(record.restore_config.to_dict()),
             "state": record.status.state.value,
             "reason": record.status.reason,
             "message": record.status.message,
@@ -311,7 +311,7 @@ class PostgreSQLSnapshotRepository:
             namespace=row["namespace"],
             name=row["name"],
             description=row["description"],
-            restore_config=SnapshotRestoreConfig(image=restore_config.get("image")),
+            restore_config=SnapshotRestoreConfig.from_dict(restore_config),
             status=SnapshotStatusRecord(
                 state=SnapshotState(row["state"]),
                 reason=row["reason"],
@@ -324,6 +324,5 @@ class PostgreSQLSnapshotRepository:
 
 
 __all__ = [
-    "POSTGRESQL_SCHEMA_LOCK_NAME",
     "PostgreSQLSnapshotRepository",
 ]

--- a/server/opensandbox_server/repositories/snapshots/sqlite.py
+++ b/server/opensandbox_server/repositories/snapshots/sqlite.py
@@ -114,9 +114,7 @@ class SQLiteSnapshotRepository:
             params.append(query.name)
 
         if query.states:
-            clauses.append(
-                f"state IN ({', '.join('?' for _ in query.states)})"
-            )
+            clauses.append(f"state IN ({', '.join('?' for _ in query.states)})")
             params.extend(query.states)
 
         where_clause = f"WHERE {' AND '.join(clauses)}" if clauses else ""
@@ -181,7 +179,7 @@ class SQLiteSnapshotRepository:
                     record.namespace,
                     record.name,
                     record.description,
-                    json.dumps(self._restore_config_to_dict(record.restore_config), sort_keys=True),
+                    json.dumps(record.restore_config.to_dict(), sort_keys=True),
                     record.status.state.value,
                     record.status.reason,
                     record.status.message,
@@ -221,7 +219,7 @@ class SQLiteSnapshotRepository:
                     record.namespace,
                     record.name,
                     record.description,
-                    json.dumps(self._restore_config_to_dict(record.restore_config), sort_keys=True),
+                    json.dumps(record.restore_config.to_dict(), sort_keys=True),
                     record.status.state.value,
                     record.status.reason,
                     record.status.message,
@@ -285,9 +283,7 @@ class SQLiteSnapshotRepository:
         rows = conn.execute("PRAGMA table_info(snapshots)").fetchall()
         columns = {row["name"] for row in rows}
         if "namespace" not in columns:
-            conn.execute(
-                "ALTER TABLE snapshots ADD COLUMN namespace TEXT DEFAULT NULL"
-            )
+            conn.execute("ALTER TABLE snapshots ADD COLUMN namespace TEXT DEFAULT NULL")
 
     @staticmethod
     def _migrate_namespace_nullable(conn: sqlite3.Connection) -> None:
@@ -346,7 +342,7 @@ class SQLiteSnapshotRepository:
             record.namespace,
             record.name,
             record.description,
-            json.dumps(self._restore_config_to_dict(record.restore_config), sort_keys=True),
+            json.dumps(record.restore_config.to_dict(), sort_keys=True),
             record.status.state.value,
             record.status.reason,
             record.status.message,
@@ -354,12 +350,6 @@ class SQLiteSnapshotRepository:
             self._datetime_to_str(record.created_at),
             self._datetime_to_str(record.updated_at),
         )
-
-    @staticmethod
-    def _restore_config_to_dict(config: SnapshotRestoreConfig) -> dict[str, str | None]:
-        return {
-            "image": config.image,
-        }
 
     @staticmethod
     def _datetime_to_str(value) -> str | None:
@@ -374,14 +364,14 @@ class SQLiteSnapshotRepository:
             namespace=row["namespace"],
             name=row["name"],
             description=row["description"],
-            restore_config=SnapshotRestoreConfig(
-                image=restore_config.get("image"),
-            ),
+            restore_config=SnapshotRestoreConfig.from_dict(restore_config),
             status=SnapshotStatusRecord(
                 state=SnapshotState(row["state"]),
                 reason=row["reason"],
                 message=row["message"],
-                last_transition_at=SQLiteSnapshotRepository._str_to_datetime(row["last_transition_at"]),
+                last_transition_at=SQLiteSnapshotRepository._str_to_datetime(
+                    row["last_transition_at"]
+                ),
             ),
             created_at=SQLiteSnapshotRepository._str_to_datetime(row["created_at"]),
             updated_at=SQLiteSnapshotRepository._str_to_datetime(row["updated_at"]),

--- a/server/opensandbox_server/repositories/snapshots/sqlite.py
+++ b/server/opensandbox_server/repositories/snapshots/sqlite.py
@@ -238,6 +238,9 @@ class SQLiteSnapshotRepository:
         with self._connect() as conn:
             conn.execute("DELETE FROM snapshots WHERE id = ?", (snapshot_id,))
 
+    def close(self) -> None:
+        """SQLite connections are scoped to individual operations."""
+
     def _initialize_schema(self) -> None:
         with self._connect() as conn:
             conn.executescript(

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -653,7 +653,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                     "message": "poolRef is not supported by the Docker provider. Use Kubernetes BatchSandbox provider instead.",
                 },
             )
-        request = resolve_sandbox_image_from_request(request)
+        request = await resolve_sandbox_image_from_request(request)
         ensure_entrypoint(request.entrypoint or [])
         ensure_metadata_labels(request.metadata)
         ensure_platform_valid(request.platform)

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -828,7 +828,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         self._ensure_pool_mode_compatible(request, has_pool_ref)
 
         if not has_pool_ref:
-            request = resolve_sandbox_image_from_request(request)
+            request = await resolve_sandbox_image_from_request(request)
             ensure_entrypoint(request.entrypoint or [])
         ensure_metadata_labels(request.metadata)
         ensure_platform_valid(request.platform)

--- a/server/opensandbox_server/services/snapshot_models.py
+++ b/server/opensandbox_server/services/snapshot_models.py
@@ -20,9 +20,11 @@ restore configuration, and lifecycle status. They are intentionally decoupled
 from both API schemas and runtime-specific objects.
 """
 
-from dataclasses import dataclass, field
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 
 class SnapshotState(str, Enum):
@@ -47,6 +49,13 @@ class SnapshotRestoreConfig:
     """
 
     image: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, values: Mapping[str, Any]) -> "SnapshotRestoreConfig":
+        return cls(**{item.name: values[item.name] for item in fields(cls) if item.name in values})
 
 
 @dataclass(slots=True)

--- a/server/opensandbox_server/services/snapshot_repository.py
+++ b/server/opensandbox_server/services/snapshot_repository.py
@@ -85,6 +85,11 @@ class SnapshotRepository(Protocol):
         Delete a snapshot record by id.
         """
 
+    def close(self) -> None:
+        """
+        Release resources owned by the repository.
+        """
+
 
 __all__ = [
     "SnapshotRepository",

--- a/server/opensandbox_server/services/snapshot_restore.py
+++ b/server/opensandbox_server/services/snapshot_restore.py
@@ -19,16 +19,19 @@ Helpers for resolving sandbox create requests from snapshots.
 from __future__ import annotations
 
 from fastapi import HTTPException, status
+from starlette.concurrency import run_in_threadpool
 
 from opensandbox_server.api.schema import CreateSandboxRequest, ImageSpec
-from opensandbox_server.repositories.snapshots.factory import create_snapshot_repository
+from opensandbox_server.repositories.snapshots.factory import get_snapshot_repository
 from opensandbox_server.services.snapshot_models import SnapshotState
 from opensandbox_server.tenants.context import get_current_tenant
 
 DEFAULT_SNAPSHOT_RESTORE_ENTRYPOINT = ["tail", "-f", "/dev/null"]
 
 
-def resolve_sandbox_image_from_request(request: CreateSandboxRequest) -> CreateSandboxRequest:
+async def resolve_sandbox_image_from_request(
+    request: CreateSandboxRequest,
+) -> CreateSandboxRequest:
     """
     Normalize a sandbox create request to an effective image-backed request.
 
@@ -50,8 +53,8 @@ def resolve_sandbox_image_from_request(request: CreateSandboxRequest) -> CreateS
             },
         )
 
-    snapshot_repository = create_snapshot_repository()
-    snapshot = snapshot_repository.get(snapshot_id)
+    snapshot_repository = get_snapshot_repository()
+    snapshot = await run_in_threadpool(snapshot_repository.get, snapshot_id)
     if snapshot is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -39,7 +39,7 @@ from opensandbox_server.api.schema import (
     Snapshot,
     SnapshotStatus,
 )
-from opensandbox_server.repositories.snapshots.factory import create_snapshot_repository
+from opensandbox_server.repositories.snapshots.factory import get_snapshot_repository
 from opensandbox_server.services.constants import SnapshotErrorCodes
 from opensandbox_server.services.snapshot_runtime import (
     NoopSnapshotRuntime,
@@ -562,7 +562,7 @@ def create_snapshot_service(sandbox_service) -> SnapshotService:
     )
 
     return PersistedSnapshotService(
-        snapshot_repository=create_snapshot_repository(),
+        snapshot_repository=get_snapshot_repository(),
         sandbox_service=sandbox_service,
         snapshot_runtime=snapshot_runtime,
     )

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "opentelemetry-sdk",
     "opentelemetry-exporter-otlp-proto-http",
     "pydantic",
+    "psycopg[binary,pool]>=3.2,<4",
     "redis>=5",
     "pydantic-settings>=2.14.2",
     "pyyaml",

--- a/server/tests/snapshot_repository_contract.py
+++ b/server/tests/snapshot_repository_contract.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared behavioral contract for snapshot repository implementations."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from opensandbox_server.services.snapshot_models import (
+    SnapshotRecord,
+    SnapshotRestoreConfig,
+    SnapshotState,
+    SnapshotStatusRecord,
+)
+from opensandbox_server.services.snapshot_repository import (
+    SnapshotListQuery,
+    SnapshotRepository,
+)
+
+
+def snapshot_record(
+    snapshot_id: str,
+    sandbox_id: str,
+    created_at: datetime,
+    state: SnapshotState = SnapshotState.CREATING,
+    *,
+    namespace: str | None = None,
+) -> SnapshotRecord:
+    return SnapshotRecord(
+        id=snapshot_id,
+        source_sandbox_id=sandbox_id,
+        namespace=namespace,
+        name=f"name-{snapshot_id}",
+        description=f"description-{snapshot_id}",
+        restore_config=SnapshotRestoreConfig(
+            image=f"registry.example.com/snapshots/{snapshot_id}:latest"
+        ),
+        status=SnapshotStatusRecord(
+            state=state,
+            reason=f"reason-{snapshot_id}",
+            message=f"message-{snapshot_id}",
+            last_transition_at=created_at,
+        ),
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+class SnapshotRepositoryContract:
+    """Tests inherited by every concrete snapshot repository backend."""
+
+    @pytest.fixture
+    def repository(self) -> SnapshotRepository:
+        raise NotImplementedError
+
+    def test_persists_and_fetches_records(self, repository: SnapshotRepository) -> None:
+        record = snapshot_record(
+            "snap-001",
+            "sbx-001",
+            datetime.now(timezone.utc),
+            namespace="tenant-a",
+        )
+
+        repository.create(record)
+        loaded = repository.get(record.id)
+
+        assert loaded is not None
+        assert loaded.id == record.id
+        assert loaded.source_sandbox_id == record.source_sandbox_id
+        assert loaded.namespace == "tenant-a"
+        assert loaded.name == record.name
+        assert loaded.description == record.description
+        assert loaded.restore_config.image == record.restore_config.image
+        assert loaded.status == record.status
+        assert loaded.created_at == record.created_at
+        assert loaded.updated_at == record.updated_at
+        assert repository.get("missing") is None
+
+    def test_lists_and_updates_records(self, repository: SnapshotRepository) -> None:
+        now = datetime.now(timezone.utc)
+        first = snapshot_record("snap-001", "sbx-001", now, namespace="tenant-a")
+        second = snapshot_record(
+            "snap-002",
+            "sbx-001",
+            now + timedelta(seconds=1),
+            SnapshotState.READY,
+            namespace="tenant-a",
+        )
+        third = snapshot_record(
+            "snap-003",
+            "sbx-002",
+            now + timedelta(seconds=2),
+            SnapshotState.FAILED,
+            namespace="tenant-b",
+        )
+        for record in (first, second, third):
+            repository.create(record)
+
+        page = repository.list(
+            SnapshotListQuery(
+                page=1,
+                page_size=10,
+                source_sandbox_id="sbx-001",
+                name="name-snap-002",
+                states=[SnapshotState.READY.value],
+                namespace="tenant-a",
+            )
+        )
+        assert page.total_items == 1
+        assert [item.id for item in page.items] == ["snap-002"]
+
+        tenant_b = repository.list(
+            SnapshotListQuery(page=1, page_size=10, namespace="tenant-b")
+        )
+        assert tenant_b.total_items == 1
+        assert [item.id for item in tenant_b.items] == ["snap-003"]
+
+        partial_name = repository.list(
+            SnapshotListQuery(page=1, page_size=10, name="name-snap")
+        )
+        assert partial_name.total_items == 0
+        assert partial_name.items == []
+
+        ordered = repository.list(SnapshotListQuery(page=1, page_size=2))
+        assert ordered.total_items == 3
+        assert [item.id for item in ordered.items] == ["snap-003", "snap-002"]
+
+        second_page = repository.list(SnapshotListQuery(page=2, page_size=2))
+        assert second_page.total_items == 3
+        assert [item.id for item in second_page.items] == ["snap-001"]
+
+        updated = snapshot_record(
+            first.id,
+            first.source_sandbox_id,
+            first.created_at,
+            SnapshotState.READY,
+            namespace=first.namespace,
+        )
+        updated.restore_config.image = "registry.example.com/snapshots/snap-001:v2"
+        updated.updated_at = now + timedelta(seconds=3)
+        repository.update(updated)
+
+        loaded = repository.get(first.id)
+        assert loaded is not None
+        assert loaded.status.state == SnapshotState.READY
+        assert loaded.restore_config.image == "registry.example.com/snapshots/snap-001:v2"
+
+    def test_compare_and_swap_and_delete(self, repository: SnapshotRepository) -> None:
+        now = datetime.now(timezone.utc)
+        original = snapshot_record("snap-001", "sbx-001", now)
+        repository.create(original)
+
+        ready = snapshot_record(
+            original.id,
+            original.source_sandbox_id,
+            original.created_at,
+            SnapshotState.READY,
+        )
+        failed = snapshot_record(
+            original.id,
+            original.source_sandbox_id,
+            original.created_at,
+            SnapshotState.FAILED,
+        )
+        ready.restore_config.image = "registry.example.com/snapshots/snap-001:cas"
+
+        assert repository.update_if_state(ready, SnapshotState.CREATING) is True
+        assert repository.update_if_state(failed, SnapshotState.CREATING) is False
+        loaded = repository.get(original.id)
+        assert loaded is not None
+        assert loaded.status.state == SnapshotState.READY
+        assert loaded.restore_config.image == "registry.example.com/snapshots/snap-001:cas"
+
+        repository.delete(original.id)
+        repository.delete(original.id)
+        assert repository.get(original.id) is None
+
+
+__all__ = ["SnapshotRepositoryContract", "snapshot_record"]

--- a/server/tests/snapshot_repository_contract.py
+++ b/server/tests/snapshot_repository_contract.py
@@ -121,15 +121,11 @@ class SnapshotRepositoryContract:
         assert page.total_items == 1
         assert [item.id for item in page.items] == ["snap-002"]
 
-        tenant_b = repository.list(
-            SnapshotListQuery(page=1, page_size=10, namespace="tenant-b")
-        )
+        tenant_b = repository.list(SnapshotListQuery(page=1, page_size=10, namespace="tenant-b"))
         assert tenant_b.total_items == 1
         assert [item.id for item in tenant_b.items] == ["snap-003"]
 
-        partial_name = repository.list(
-            SnapshotListQuery(page=1, page_size=10, name="name-snap")
-        )
+        partial_name = repository.list(SnapshotListQuery(page=1, page_size=10, name="name-snap"))
         assert partial_name.total_items == 0
         assert partial_name.items == []
 
@@ -186,6 +182,3 @@ class SnapshotRepositoryContract:
         repository.delete(original.id)
         repository.delete(original.id)
         assert repository.get(original.id) is None
-
-
-__all__ = ["SnapshotRepositoryContract", "snapshot_record"]

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -15,9 +15,10 @@
 import textwrap
 
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from opensandbox_server import config as config_module
+from opensandbox_server.cli import render_full_config
 from opensandbox_server.config import (
     AppConfig,
     LogConfig,
@@ -33,6 +34,8 @@ from opensandbox_server.config import (
     SecureAccessConfig,
     SecureAccessKey,
     ServerConfig,
+    POSTGRESQL_DSN_ENV_VAR,
+    PostgreSQLStoreConfig,
     StoreConfig,
     StorageConfig,
 )
@@ -268,6 +271,20 @@ def test_store_defaults_to_sqlite():
     assert cfg.path.endswith("opensandbox.db")
 
 
+def test_postgresql_store_requires_dsn():
+    with pytest.raises(ValidationError, match="must be set"):
+        StoreConfig(type="postgresql")
+
+
+def test_postgresql_store_validates_pool_size():
+    with pytest.raises(ValidationError, match="min_pool_size"):
+        PostgreSQLStoreConfig(
+            dsn=SecretStr("postgresql://localhost/opensandbox"),
+            min_pool_size=3,
+            max_pool_size=2,
+        )
+
+
 def test_renew_intent_defaults():
     cfg = AppConfig(runtime=RuntimeConfig(type="docker", execd_image="opensandbox/execd:latest"))
     ar = cfg.renew_intent
@@ -343,6 +360,105 @@ def test_load_config_store_block(tmp_path, monkeypatch):
     loaded = config_module.load_config(config_path)
     assert loaded.store.type == "sqlite"
     assert loaded.store.path == str(db_path)
+
+
+def test_load_config_postgresql_dsn_from_environment(tmp_path, monkeypatch):
+    _reset_config(monkeypatch)
+    monkeypatch.setenv(
+        POSTGRESQL_DSN_ENV_VAR,
+        "postgresql://opensandbox:secret@postgres.example/opensandbox",
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            [store]
+            type = "postgresql"
+
+            [store.postgresql]
+            min_pool_size = 2
+            max_pool_size = 4
+
+            [runtime]
+            type = "docker"
+            execd_image = "opensandbox/execd:test"
+            """
+        )
+    )
+
+    loaded = config_module.load_config(config_path)
+
+    assert loaded.store.type == "postgresql"
+    assert loaded.store.postgresql.dsn is not None
+    assert (
+        loaded.store.postgresql.dsn.get_secret_value()
+        == "postgresql://opensandbox:secret@postgres.example/opensandbox"
+    )
+    assert loaded.store.postgresql.min_pool_size == 2
+    assert loaded.store.postgresql.max_pool_size == 4
+
+
+def test_postgresql_dsn_environment_overrides_toml(tmp_path, monkeypatch):
+    _reset_config(monkeypatch)
+    monkeypatch.setenv(POSTGRESQL_DSN_ENV_VAR, "postgresql://environment/opensandbox")
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            [store]
+            type = "postgresql"
+
+            [store.postgresql]
+            dsn = "postgresql://toml/opensandbox"
+
+            [runtime]
+            type = "docker"
+            execd_image = "opensandbox/execd:test"
+            """
+        )
+    )
+
+    loaded = config_module.load_config(config_path)
+
+    assert loaded.store.postgresql.dsn is not None
+    assert loaded.store.postgresql.dsn.get_secret_value() == "postgresql://environment/opensandbox"
+
+
+def test_postgresql_dsn_is_redacted_from_validation_errors(tmp_path, monkeypatch):
+    _reset_config(monkeypatch)
+    secret_dsn = "postgresql://opensandbox:sensitive-password@postgres/opensandbox"
+    monkeypatch.setenv(POSTGRESQL_DSN_ENV_VAR, secret_dsn)
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            [store]
+            type = "postgresql"
+
+            [store.postgresql]
+            min_pool_size = 3
+            max_pool_size = 2
+
+            [runtime]
+            type = "docker"
+            execd_image = "opensandbox/execd:test"
+            """
+        )
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        config_module.load_config(config_path)
+
+    assert secret_dsn not in str(exc_info.value)
+
+
+def test_full_config_includes_store_sections(tmp_path) -> None:
+    config_path = render_full_config(tmp_path / "generated.toml")
+
+    content = config_path.read_text()
+    assert "[store]" in content
+    assert "[store.postgresql]" in content
+    assert "min_pool_size" in content
 
 
 def test_load_config_renew_intent_legacy_redis_subtable(tmp_path, monkeypatch):

--- a/server/tests/test_snapshot_models.py
+++ b/server/tests/test_snapshot_models.py
@@ -60,3 +60,18 @@ def test_snapshot_record_supports_ready_restore_config() -> None:
     assert record.restore_config.image == "registry.example.com/snapshots/snap-002:latest"
     assert record.status.state == SnapshotState.READY
     assert record.status.last_transition_at == ready_at
+
+
+def test_snapshot_restore_config_serialization_ignores_unknown_fields() -> None:
+    config = SnapshotRestoreConfig(image="registry.example.com/snapshots/snap-003:latest")
+
+    assert config.to_dict() == {"image": "registry.example.com/snapshots/snap-003:latest"}
+    assert (
+        SnapshotRestoreConfig.from_dict(
+            {
+                "image": "registry.example.com/snapshots/snap-003:latest",
+                "future_field": "ignored",
+            }
+        )
+        == config
+    )

--- a/server/tests/test_snapshot_repository_postgresql.py
+++ b/server/tests/test_snapshot_repository_postgresql.py
@@ -14,7 +14,7 @@
 
 from concurrent.futures import ThreadPoolExecutor
 from collections.abc import Iterator
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import os
 from threading import Barrier
 
@@ -184,3 +184,35 @@ def test_postgresql_close_releases_pool(postgresql_dsn: str) -> None:
     repo.close()
 
     assert repo._pool.closed is True
+
+
+def test_postgresql_row_timestamps_are_normalized_to_utc() -> None:
+    local_timezone = timezone(timedelta(hours=8))
+    local_time = datetime(2026, 1, 2, 8, 0, tzinfo=local_timezone)
+
+    record = PostgreSQLSnapshotRepository._row_to_record(
+        {
+            "id": "snap-timezone",
+            "source_sandbox_id": "sbx-001",
+            "namespace": None,
+            "name": None,
+            "description": None,
+            "restore_config": {"image": None},
+            "state": SnapshotState.CREATING.value,
+            "reason": None,
+            "message": None,
+            "last_transition_at": local_time,
+            "created_at": local_time,
+            "updated_at": local_time,
+        }
+    )
+
+    expected = datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc)
+    last_transition_at = record.status.last_transition_at
+    assert last_transition_at is not None
+    assert last_transition_at == expected
+    assert last_transition_at.tzinfo is timezone.utc
+    assert record.created_at == expected
+    assert record.created_at.tzinfo is timezone.utc
+    assert record.updated_at == expected
+    assert record.updated_at.tzinfo is timezone.utc

--- a/server/tests/test_snapshot_repository_postgresql.py
+++ b/server/tests/test_snapshot_repository_postgresql.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Iterator
+from datetime import datetime, timezone
+import os
+from threading import Barrier
+
+import psycopg
+import pytest
+from pydantic import SecretStr
+
+from opensandbox_server.config import (
+    AppConfig,
+    PostgreSQLStoreConfig,
+    RuntimeConfig,
+    StoreConfig,
+)
+from opensandbox_server.repositories.snapshots.factory import create_snapshot_repository
+from opensandbox_server.repositories.snapshots.postgresql import PostgreSQLSnapshotRepository
+from opensandbox_server.services.snapshot_models import SnapshotState
+from tests.snapshot_repository_contract import (
+    SnapshotRepositoryContract,
+    snapshot_record,
+)
+
+TEST_POSTGRESQL_DSN_ENV_VAR = "OPENSANDBOX_TEST_POSTGRESQL_DSN"
+
+
+@pytest.fixture(scope="module")
+def postgresql_dsn() -> str:
+    dsn = os.environ.get(TEST_POSTGRESQL_DSN_ENV_VAR)
+    if not dsn:
+        pytest.skip(f"{TEST_POSTGRESQL_DSN_ENV_VAR} is not set")
+    return dsn
+
+
+def _repository(dsn: str) -> PostgreSQLSnapshotRepository:
+    return PostgreSQLSnapshotRepository(
+        dsn,
+        min_pool_size=0,
+        max_pool_size=4,
+        connect_timeout_seconds=5,
+        pool_timeout_seconds=5,
+    )
+
+
+class TestPostgreSQLSnapshotRepositoryContract(SnapshotRepositoryContract):
+    @pytest.fixture
+    def repository(self, postgresql_dsn: str) -> Iterator[PostgreSQLSnapshotRepository]:
+        repo = _repository(postgresql_dsn)
+        try:
+            with psycopg.connect(postgresql_dsn) as conn:
+                conn.execute("TRUNCATE TABLE snapshots")
+            yield repo
+        finally:
+            repo.close()
+
+
+def test_postgresql_factory_selects_backend(postgresql_dsn: str) -> None:
+    config = AppConfig(
+        runtime=RuntimeConfig(type="docker", execd_image="opensandbox/execd:test"),
+        store=StoreConfig(
+            type="postgresql",
+            postgresql=PostgreSQLStoreConfig(
+                dsn=SecretStr(postgresql_dsn),
+                min_pool_size=0,
+                max_pool_size=2,
+            ),
+        ),
+    )
+
+    repo = create_snapshot_repository(config)
+    try:
+        assert isinstance(repo, PostgreSQLSnapshotRepository)
+    finally:
+        repo.close()
+
+
+def test_postgresql_schema_initialization_is_concurrent_safe(
+    postgresql_dsn: str,
+    monkeypatch,
+) -> None:
+    with psycopg.connect(postgresql_dsn) as conn:
+        conn.execute("DROP TABLE IF EXISTS snapshots")
+
+    barrier = Barrier(2)
+    initialize_schema = PostgreSQLSnapshotRepository._initialize_schema
+
+    def initialize_schema_concurrently(repo: PostgreSQLSnapshotRepository) -> None:
+        barrier.wait(timeout=5)
+        initialize_schema(repo)
+
+    monkeypatch.setattr(
+        PostgreSQLSnapshotRepository,
+        "_initialize_schema",
+        initialize_schema_concurrently,
+    )
+
+    repositories: list[PostgreSQLSnapshotRepository] = []
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(_repository, postgresql_dsn) for _ in range(2)]
+            errors: list[BaseException] = []
+            for future in futures:
+                try:
+                    repositories.append(future.result())
+                except BaseException as exc:
+                    errors.append(exc)
+            if errors:
+                raise errors[0]
+
+        with psycopg.connect(postgresql_dsn) as conn:
+            row = conn.execute("SELECT to_regclass('snapshots')").fetchone()
+        assert row is not None
+        table_name = row[0]
+        assert table_name == "snapshots"
+    finally:
+        for repo in repositories:
+            repo.close()
+
+
+def test_postgresql_compare_and_swap_has_one_winner(postgresql_dsn: str) -> None:
+    repositories: list[PostgreSQLSnapshotRepository] = []
+    try:
+        first_repo = _repository(postgresql_dsn)
+        repositories.append(first_repo)
+        second_repo = _repository(postgresql_dsn)
+        repositories.append(second_repo)
+        with psycopg.connect(postgresql_dsn) as conn:
+            conn.execute("TRUNCATE TABLE snapshots")
+
+        now = datetime.now(timezone.utc)
+        original = snapshot_record("snap-race", "sbx-001", now)
+        ready = snapshot_record(
+            original.id,
+            original.source_sandbox_id,
+            original.created_at,
+            SnapshotState.READY,
+        )
+        failed = snapshot_record(
+            original.id,
+            original.source_sandbox_id,
+            original.created_at,
+            SnapshotState.FAILED,
+        )
+        first_repo.create(original)
+        barrier = Barrier(2)
+
+        def update(repo, record) -> bool:
+            barrier.wait(timeout=5)
+            return repo.update_if_state(record, SnapshotState.CREATING)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            ready_future = executor.submit(update, first_repo, ready)
+            failed_future = executor.submit(update, second_repo, failed)
+            results = [ready_future.result(), failed_future.result()]
+
+        assert sorted(results) == [False, True]
+        winning_state = SnapshotState.READY if results[0] else SnapshotState.FAILED
+        stored = first_repo.get(original.id)
+        assert stored is not None
+        assert stored.status.state == winning_state
+    finally:
+        for repo in repositories:
+            repo.close()
+
+
+def test_postgresql_close_releases_pool(postgresql_dsn: str) -> None:
+    repo = _repository(postgresql_dsn)
+
+    repo.close()
+
+    assert repo._pool.closed is True

--- a/server/tests/test_snapshot_repository_sqlite.py
+++ b/server/tests/test_snapshot_repository_sqlite.py
@@ -13,60 +13,23 @@
 # limitations under the License.
 
 import sqlite3
-from datetime import datetime, timedelta
 
+import pytest
+
+from opensandbox_server.repositories.snapshots import factory as factory_module
 from opensandbox_server.repositories.snapshots.factory import create_snapshot_repository
 from opensandbox_server.repositories.snapshots.sqlite import (
     SQLITE_BUSY_TIMEOUT_MS,
     SQLiteSnapshotRepository,
 )
 from opensandbox_server.config import AppConfig, RuntimeConfig, StoreConfig
-from opensandbox_server.services.snapshot_models import (
-    SnapshotRecord,
-    SnapshotRestoreConfig,
-    SnapshotState,
-    SnapshotStatusRecord,
-)
-from opensandbox_server.services.snapshot_repository import SnapshotListQuery
+from tests.snapshot_repository_contract import SnapshotRepositoryContract
 
 
-def _record(
-    snapshot_id: str,
-    sandbox_id: str,
-    created_at: datetime,
-    state: SnapshotState = SnapshotState.CREATING,
-) -> SnapshotRecord:
-    return SnapshotRecord(
-        id=snapshot_id,
-        source_sandbox_id=sandbox_id,
-        name=f"name-{snapshot_id}",
-        description=f"description-{snapshot_id}",
-        restore_config=SnapshotRestoreConfig(
-            image=f"registry.example.com/snapshots/{snapshot_id}:latest"
-        ),
-        status=SnapshotStatusRecord(
-            state=state,
-            reason=f"reason-{snapshot_id}",
-            message=f"message-{snapshot_id}",
-            last_transition_at=created_at,
-        ),
-        created_at=created_at,
-        updated_at=created_at,
-    )
-
-
-def test_sqlite_snapshot_repository_persists_and_fetches_records(tmp_path) -> None:
-    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
-    record = _record("snap-001", "sbx-001", datetime.utcnow())
-
-    repo.create(record)
-    loaded = repo.get("snap-001")
-
-    assert loaded is not None
-    assert loaded.id == "snap-001"
-    assert loaded.source_sandbox_id == "sbx-001"
-    assert loaded.restore_config.image == record.restore_config.image
-    assert loaded.status.state == SnapshotState.CREATING
+class TestSQLiteSnapshotRepositoryContract(SnapshotRepositoryContract):
+    @pytest.fixture
+    def repository(self, tmp_path) -> SQLiteSnapshotRepository:
+        return SQLiteSnapshotRepository(tmp_path / "snapshots.db")
 
 
 def test_sqlite_snapshot_repository_enables_wal_and_busy_timeout(tmp_path) -> None:
@@ -124,105 +87,6 @@ def test_sqlite_snapshot_repository_indexes_name_queries_after_migration(
     assert any("idx_snapshots_name_namespace" in row["detail"] for row in tenant_plan)
 
 
-def test_sqlite_snapshot_repository_lists_and_updates_records(tmp_path) -> None:
-    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
-    now = datetime.utcnow()
-    first = _record("snap-001", "sbx-001", now)
-    second = _record("snap-002", "sbx-001", now + timedelta(seconds=1), state=SnapshotState.READY)
-    third = _record("snap-003", "sbx-002", now + timedelta(seconds=2), state=SnapshotState.FAILED)
-
-    repo.create(first)
-    repo.create(second)
-    repo.create(third)
-
-    page = repo.list(
-        SnapshotListQuery(
-            page=1,
-            page_size=10,
-            source_sandbox_id="sbx-001",
-            name="name-snap-002",
-            states=["Ready"],
-        )
-    )
-
-    assert page.total_items == 1
-    assert [item.id for item in page.items] == ["snap-002"]
-
-    partial_name = repo.list(
-        SnapshotListQuery(page=1, page_size=10, name="name-snap")
-    )
-    assert partial_name.total_items == 0
-    assert partial_name.items == []
-
-    updated = SnapshotRecord(
-        id=first.id,
-        source_sandbox_id=first.source_sandbox_id,
-        name=first.name,
-        description=first.description,
-        restore_config=SnapshotRestoreConfig(image="registry.example.com/snapshots/snap-001:v2"),
-        status=SnapshotStatusRecord(
-            state=SnapshotState.READY,
-            reason="snapshot_ready",
-            message="Snapshot is ready.",
-            last_transition_at=now + timedelta(seconds=3),
-        ),
-        created_at=first.created_at,
-        updated_at=now + timedelta(seconds=3),
-    )
-    repo.update(updated)
-
-    loaded = repo.get("snap-001")
-    assert loaded is not None
-    assert loaded.status.state == SnapshotState.READY
-    assert loaded.restore_config.image == "registry.example.com/snapshots/snap-001:v2"
-
-
-def test_sqlite_snapshot_repository_update_if_state_is_atomic(tmp_path) -> None:
-    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
-    now = datetime.utcnow()
-    original = _record("snap-001", "sbx-001", now, state=SnapshotState.CREATING)
-    repo.create(original)
-
-    ready = SnapshotRecord(
-        id=original.id,
-        source_sandbox_id=original.source_sandbox_id,
-        name=original.name,
-        description=original.description,
-        restore_config=SnapshotRestoreConfig(image="opensandbox-snapshots:snap-001"),
-        status=SnapshotStatusRecord(
-            state=SnapshotState.READY,
-            reason="snapshot_ready",
-            message="Snapshot is ready.",
-            last_transition_at=now + timedelta(seconds=1),
-        ),
-        created_at=original.created_at,
-        updated_at=now + timedelta(seconds=1),
-    )
-    failed = SnapshotRecord(
-        id=original.id,
-        source_sandbox_id=original.source_sandbox_id,
-        name=original.name,
-        description=original.description,
-        restore_config=original.restore_config,
-        status=SnapshotStatusRecord(
-            state=SnapshotState.FAILED,
-            reason="snapshot_failed",
-            message="Snapshot failed.",
-            last_transition_at=now + timedelta(seconds=2),
-        ),
-        created_at=original.created_at,
-        updated_at=now + timedelta(seconds=2),
-    )
-
-    assert repo.update_if_state(ready, SnapshotState.CREATING) is True
-    assert repo.update_if_state(failed, SnapshotState.CREATING) is False
-
-    loaded = repo.get(original.id)
-    assert loaded is not None
-    assert loaded.status.state == SnapshotState.READY
-    assert loaded.restore_config.image == "opensandbox-snapshots:snap-001"
-
-
 def test_snapshot_repository_factory_defaults_to_sqlite(tmp_path) -> None:
     db_path = tmp_path / "factory-snapshots.db"
     config = AppConfig(
@@ -234,3 +98,54 @@ def test_snapshot_repository_factory_defaults_to_sqlite(tmp_path) -> None:
 
     assert isinstance(repo, SQLiteSnapshotRepository)
     assert repo.db_path == db_path
+
+
+def test_snapshot_repository_factory_reuses_process_repository(monkeypatch, tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "shared-snapshots.db")
+    factory_calls = 0
+
+    def create_repository() -> SQLiteSnapshotRepository:
+        nonlocal factory_calls
+        factory_calls += 1
+        return repo
+
+    factory_module.get_snapshot_repository.cache_clear()
+    monkeypatch.setattr(factory_module, "create_snapshot_repository", create_repository)
+
+    try:
+        assert factory_module.get_snapshot_repository() is repo
+        assert factory_module.get_snapshot_repository() is repo
+        assert factory_calls == 1
+    finally:
+        factory_module.get_snapshot_repository.cache_clear()
+
+
+def test_snapshot_repository_factory_closes_and_discards_process_repository(
+    monkeypatch, tmp_path
+) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "shared-snapshots.db")
+    close_calls = 0
+    factory_calls = 0
+
+    def close_repository() -> None:
+        nonlocal close_calls
+        close_calls += 1
+
+    def create_repository() -> SQLiteSnapshotRepository:
+        nonlocal factory_calls
+        factory_calls += 1
+        return repo
+
+    monkeypatch.setattr(repo, "close", close_repository)
+    monkeypatch.setattr(factory_module, "create_snapshot_repository", create_repository)
+    factory_module.get_snapshot_repository.cache_clear()
+
+    try:
+        factory_module.get_snapshot_repository()
+        factory_module.close_snapshot_repository()
+        factory_module.get_snapshot_repository()
+
+        assert close_calls == 1
+        assert factory_calls == 2
+    finally:
+        factory_module.get_snapshot_repository.cache_clear()

--- a/server/tests/test_snapshot_restore.py
+++ b/server/tests/test_snapshot_restore.py
@@ -31,7 +31,8 @@ from opensandbox_server.services.snapshot_restore import (
 )
 
 
-def test_snapshot_restore_resolves_effective_image(monkeypatch, tmp_path) -> None:
+@pytest.mark.asyncio
+async def test_snapshot_restore_resolves_effective_image(monkeypatch, tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     repo.create(
         SnapshotRecord(
@@ -45,7 +46,7 @@ def test_snapshot_restore_resolves_effective_image(monkeypatch, tmp_path) -> Non
         )
     )
     monkeypatch.setattr(
-        "opensandbox_server.services.snapshot_restore.create_snapshot_repository",
+        "opensandbox_server.services.snapshot_restore.get_snapshot_repository",
         lambda: repo,
     )
 
@@ -54,14 +55,15 @@ def test_snapshot_restore_resolves_effective_image(monkeypatch, tmp_path) -> Non
         resourceLimits=ResourceLimits(root={"cpu": "500m"}),
     )
 
-    resolved = resolve_sandbox_image_from_request(request)
+    resolved = await resolve_sandbox_image_from_request(request)
     assert resolved.image is not None
     assert resolved.image.uri == "registry.example.com/snapshots/snap-001:latest"
     assert resolved.snapshot_id == "snap-001"
     assert resolved.entrypoint == DEFAULT_SNAPSHOT_RESTORE_ENTRYPOINT
 
 
-def test_snapshot_restore_preserves_explicit_entrypoint(monkeypatch, tmp_path) -> None:
+@pytest.mark.asyncio
+async def test_snapshot_restore_preserves_explicit_entrypoint(monkeypatch, tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     repo.create(
         SnapshotRecord(
@@ -75,7 +77,7 @@ def test_snapshot_restore_preserves_explicit_entrypoint(monkeypatch, tmp_path) -
         )
     )
     monkeypatch.setattr(
-        "opensandbox_server.services.snapshot_restore.create_snapshot_repository",
+        "opensandbox_server.services.snapshot_restore.get_snapshot_repository",
         lambda: repo,
     )
 
@@ -85,14 +87,15 @@ def test_snapshot_restore_preserves_explicit_entrypoint(monkeypatch, tmp_path) -
         entrypoint=["python", "app.py"],
     )
 
-    resolved = resolve_sandbox_image_from_request(request)
+    resolved = await resolve_sandbox_image_from_request(request)
     assert resolved.image is not None
     assert resolved.image.uri == "registry.example.com/snapshots/snap-003:latest"
     assert resolved.snapshot_id == "snap-003"
     assert resolved.entrypoint == ["python", "app.py"]
 
 
-def test_snapshot_restore_rejects_unready_snapshot(monkeypatch, tmp_path) -> None:
+@pytest.mark.asyncio
+async def test_snapshot_restore_rejects_unready_snapshot(monkeypatch, tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     repo.create(
         SnapshotRecord(
@@ -106,7 +109,7 @@ def test_snapshot_restore_rejects_unready_snapshot(monkeypatch, tmp_path) -> Non
         )
     )
     monkeypatch.setattr(
-        "opensandbox_server.services.snapshot_restore.create_snapshot_repository",
+        "opensandbox_server.services.snapshot_restore.get_snapshot_repository",
         lambda: repo,
     )
 
@@ -116,5 +119,5 @@ def test_snapshot_restore_rejects_unready_snapshot(monkeypatch, tmp_path) -> Non
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        resolve_sandbox_image_from_request(request)
+        await resolve_sandbox_image_from_request(request)
     assert exc_info.value.status_code == 409

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -303,7 +303,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -616,6 +616,7 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "protobuf" },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
@@ -648,6 +649,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "protobuf", specifier = ">=7.35.1" },
+    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2,<4" },
     { name = "pydantic" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "python-multipart", specifier = ">=0.0.31" },
@@ -781,6 +783,101 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
     { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
     { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/bf/70d8a60488f9955cbbcd538beae44d56bb2f1d19e673b72788f2d343ff55/psycopg_binary-3.3.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b7bfff1ca23732b488cbca3076fc11bc98d520ee122514fdb17a8e20d3338f5a", size = 4609750, upload-time = "2026-05-01T23:24:20.06Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b0/29e98ba210c9dbc75a6dc91e3f99b9e06ea901a62ca95804e02a1ae13e6b/psycopg_binary-3.3.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:32a6fbf8481e3a370d0d72b860d35948a693cb01281da217f7b2f307636e591a", size = 4676700, upload-time = "2026-05-01T23:25:21.727Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ab/3df087b3c12bf74e47c08204172b2fabb5a144679110d5c7ad12d9201323/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bdef84570ebbce1d42b4e7ea952d21c414c5f118ad02fee00c5625f35e134429", size = 5496319, upload-time = "2026-05-01T23:25:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9a/f088207b4cd6772f9e0d8a91807e79fa2458d4eb9eb1ae406c68415f2bec/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbc10768a796c96d3243656016bf4e337c81c71097270bb7b0ad6210d9765", size = 5171906, upload-time = "2026-05-01T23:25:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/4523a857f253871d75c22e1c2e79fd47e599e736bcba1bad58d83e24be02/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf7f73a4a792bc5db58a4b385d8a1467e8d468f7548702fb0ed1e9b7501b1c13", size = 6762621, upload-time = "2026-05-01T23:25:41.392Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d1/925bf776503345bef428e6c45fb017d0139ddbe0e211814b585c4253dca8/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7b4d40c153fa352ab3cca530f3a0baedf7621b2ebcbd7f084009522c21788fc", size = 5006319, upload-time = "2026-05-01T23:25:51.419Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/aa/99727337206fbba357ca084bf4ea8b29dc986f61842a2685859af61416db/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f9b1c2533af01cd7648378599f82b0b8ae32f293296e6eec5753a625bc97ef28", size = 4535388, upload-time = "2026-05-01T23:25:57.957Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a4/567ba2c37d19d8c2f63d836385dfd2495aa5897bbee6cfab104d9ee58624/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad3bc94054876155549fdaedf4a46d1ec69d39a5bcee377148afe498e84c4b8e", size = 4224544, upload-time = "2026-05-01T23:26:03.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/23/86457f5a82731685d7701de7bfaa5eb783dd1fecbf875321897d9d9ce33a/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:eb4eed2079c01a4850bf467deacfab56d356d4225040170af03dc9958321242d", size = 3956282, upload-time = "2026-05-01T23:26:09.983Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d8/249456df16d47de082abd9b73bce8ccdeb0293eb12e590f9150c7cbdb788/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f80e3f2b5331dbbf0901bcb658056c03eeb2c1ef31d774afb0d61598b242e744", size = 4261736, upload-time = "2026-05-01T23:26:16.798Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/c4abe228acafd8a385c1fb615d4f1e3c9b8ad7a4e4f0e84118ba3ffeed9c/psycopg_binary-3.3.4-cp310-cp310-win_amd64.whl", hash = "sha256:574ea21a9651958f1535c5a1c649c7409e9168bcbffa29a3f2f961f58b322949", size = 3570620, upload-time = "2026-05-01T23:26:22.655Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]
@@ -1288,6 +1385,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -303,7 +303,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
# Summary
- Add an opt-in PostgreSQL backend for server-managed snapshot metadata while keeping SQLite as the default.
- Add SecretStr-backed DSN configuration, environment injection, connection pooling, concurrent-safe schema initialization, and PostgreSQL CRUD/CAS behavior.
- Reuse one process-level repository across snapshot creation and restore, close pooled resources during shutdown, and keep blocking repository reads off the async request loop.
- Share the repository behavior contract between SQLite and PostgreSQL, add PostgreSQL-specific concurrency/lifecycle coverage, and run it against PostgreSQL 16 in CI.
- Document the configuration and update the packaged Docker/Kubernetes examples. This PR does not add SQLite data migration, Helm wiring, health checks, leases, or reconcile logic.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests — `uv run pytest -q`: 1540 passed, 7 skipped
- [x] Integration tests — PostgreSQL 16 repository suite: 7 passed
- [x] e2e / manual verification — Server HTTP create sandbox -> Docker snapshot -> PostgreSQL JSONB row reaches `Ready` -> create sandbox with `snapshotId` reaches `Running`

# Breaking Changes
- [x] None — SQLite remains the default and existing `[store]` configuration continues to work.
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered — production DSNs can be injected through `OPENSANDBOX_STORE_POSTGRESQL_DSN` and are held as `SecretStr` during validation
- [x] Backward compatibility considered — PostgreSQL is opt-in, no silent fallback occurs, and persisted restore configuration ignores unknown future fields
