### PR TITLE
fix(execd): return the command SSE handler after execution completes

### DIFF
--- a/components/execd/pkg/web/controller/command.go
+++ b/components/execd/pkg/web/controller/command.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alibaba/opensandbox/execd/pkg/flag"
 	"github.com/alibaba/opensandbox/execd/pkg/jupyter/execute"
 	"github.com/alibaba/opensandbox/execd/pkg/runtime"
 	"github.com/alibaba/opensandbox/execd/pkg/telemetry"
@@ -113,12 +112,6 @@ func (c *CodeInterpretingController) RunCommand() {
 	}
 
 	waitForExecutionComplete(ctx, completeCh)
-
-	// Keep the SSE connection alive briefly so clients can read all
-	// buffered events and downstream components (e.g. egress sidecar)
-	// have time to synchronise state changes that were triggered
-	// during command execution.
-	time.Sleep(flag.ApiGracefulShutdownTimeout)
 }
 
 // InterruptCommand stops a running shell command session.

--- a/components/execd/pkg/web/controller/command_test.go
+++ b/components/execd/pkg/web/controller/command_test.go
@@ -20,7 +20,9 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/alibaba/opensandbox/execd/pkg/flag"
 	"github.com/alibaba/opensandbox/execd/pkg/runtime"
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
 	"github.com/stretchr/testify/require"
@@ -87,4 +89,31 @@ func TestGetBackgroundCommandOutput_MissingID(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Equal(t, model.ErrorCodeMissingQuery, resp.Code)
 	require.Equal(t, "missing command execution id", resp.Message)
+}
+
+func TestRunCommandReturnsBeforeGracefulShutdownTimeoutAfterImmediateComplete(t *testing.T) {
+	previousRunner := codeRunner
+	previousTimeout := flag.ApiGracefulShutdownTimeout
+	codeRunner = &fakeCodeRunner{
+		execute: func(request *runtime.ExecuteCodeRequest) error {
+			request.Hooks.OnExecuteComplete(5 * time.Millisecond)
+			return nil
+		},
+	}
+	flag.ApiGracefulShutdownTimeout = 200 * time.Millisecond
+	t.Cleanup(func() {
+		codeRunner = previousRunner
+		flag.ApiGracefulShutdownTimeout = previousTimeout
+	})
+
+	body := []byte(`{"command":"echo hi"}`)
+	ctx, w := newTestContext(http.MethodPost, "/command", body)
+	ctrl := NewCodeInterpretingController(ctx)
+
+	start := time.Now()
+	ctrl.RunCommand()
+	elapsed := time.Since(start)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Less(t, elapsed, flag.ApiGracefulShutdownTimeout/2)
 }


### PR DESCRIPTION
Closes #1661.

# Summary

Foreground commands (the `/command` SSE endpoint) pay a fixed ~1s tail latency: `RunCommand` waits for the execution-complete event and then unconditionally sleeps for `--graceful-shutdown-timeout` (default `1s`), so short commands such as `true`, `echo`, or `mkdir` measure ~1.01s end to end (measurements in #1661).

`waitForExecutionComplete` already bounds the drain window: it returns as soon as the final SSE event is written and flushed, on client disconnect, or at the `--graceful-shutdown-timeout` deadline. This drops the extra sleep so the command endpoint behaves like `RunCode` and `RunInSession`, which adopted exactly this early-return pattern in 7f95adbf ("return immediately to avoid fixed tail latency"). `--graceful-shutdown-timeout` keeps its meaning as the completion-wait deadline, so deployments that want a longer safety window can still tune it.

On the egress-sidecar concern from the old comment: `RunCode` / `RunInSession` have returned immediately after the completion callback since 7f95adbf over the same runner / SSE / egress topology, so this aligns the command endpoint with behavior that has already shipped.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

New `TestRunCommandReturnsBeforeGracefulShutdownTimeoutAfterImmediateComplete` mirrors the existing `RunCode` regression test: the handler must return well before the timeout when execution completes immediately. It fails on the old code and passes with this change. The rest of the `pkg/web/controller` suite shows no new failures (`TestBackgroundRun_HTTPFlow` and `TestGetRunLogs_RejectsMalformedCursor` fail identically on unmodified `main` in a Windows environment; Linux CI is unaffected).

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

The intended behavior change is the latency fix itself: the SSE response now closes right after the final event instead of holding the connection open for the grace window. The flag still bounds the completion wait, so no configuration migration is needed.

# Checklist

- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [ ] Security impact considered
- [x] Backward compatibility considered
