### PR TITLE
fix(server): identify backend proxy connection failures

### DIFF
--- a/docs/components/server.md
+++ b/docs/components/server.md
@@ -209,6 +209,10 @@ Response:
 
 **Other lifecycle calls** (same `OPEN-SANDBOX-API-KEY` header): `GET /v1/sandboxes/{id}`, `POST /v1/sandboxes/{id}/pause`, `POST /v1/sandboxes/{id}/resume`, `GET /v1/sandboxes/{id}/endpoints/{port}` (append `?use_server_proxy=true` when needed), `POST .../renew-expiration`, `DELETE /v1/sandboxes/{id}`. Full request/response shapes: **Swagger UI** above or OpenAPI under [specs/](/api/).
 
+When a server-proxied HTTP route cannot connect to the selected sandbox backend,
+the server returns HTTP `502` with error code `BACKEND_CONNECTION_FAILED`. Use the
+code, rather than the human-readable message, to classify this failure.
+
 For Kubernetes-backed sandboxes, pause/resume is implemented via `BatchSandbox.spec.pause` and internal `SandboxSnapshot` resources. The externally visible lifecycle transitions are `Running -> Pausing -> Paused -> Resuming -> Running`.
 
 `secureAccess` currently applies only to **Kubernetes** sandboxes exposed through **ingress gateway mode**. Direct endpoint exposure, including non-gateway ingress configurations, is not supported for secured access.

--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -389,7 +389,7 @@ async def _proxy_http_request(
             # after client.send() must release the acquired pool connection.
             await _close_backend_response(resp)
             raise
-    except httpx.ConnectError as e:
+    except (httpx.ConnectError, httpx.ConnectTimeout) as e:
         raise HTTPException(
             status_code=502,
             detail={

--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -392,7 +392,10 @@ async def _proxy_http_request(
     except httpx.ConnectError as e:
         raise HTTPException(
             status_code=502,
-            detail=f"Could not connect to the backend sandbox {endpoint}: {e}",
+            detail={
+                "code": "BACKEND_CONNECTION_FAILED",
+                "message": f"Could not connect to the backend sandbox {endpoint}: {e}",
+            },
         ) from e
     except HTTPException:
         raise

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -81,7 +81,7 @@ class _FakeAsyncClient:
     def __init__(self):
         self.built = None
         self.response = _FakeStreamingResponse()
-        self.raise_connect_error = False
+        self.connection_error: httpx.RequestError | None = None
         self.raise_generic_error = False
 
     def build_request(
@@ -102,8 +102,8 @@ class _FakeAsyncClient:
         return self.built
 
     async def send(self, req, stream: bool = True):
-        if self.raise_connect_error:
-            raise httpx.ConnectError("connection refused")
+        if self.connection_error:
+            raise self.connection_error
         if self.raise_generic_error:
             raise RuntimeError("unexpected proxy error")
         return self.response
@@ -1069,10 +1069,15 @@ def test_proxy_websocket_relays_messages_and_forwards_safe_headers(
     assert lowered_headers["x-trace"] == "trace-ws"
 
 
-def test_proxy_maps_connect_error_to_502(
+@pytest.mark.parametrize(
+    "connection_error",
+    [httpx.ConnectError("connection refused"), httpx.ConnectTimeout("connection timed out")],
+)
+def test_proxy_maps_connect_failure_to_502(
     client: TestClient,
     auth_headers: dict,
     monkeypatch,
+    connection_error: httpx.RequestError,
 ) -> None:
     class StubService:
         @staticmethod
@@ -1081,7 +1086,7 @@ def test_proxy_maps_connect_error_to_502(
 
     monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
     fake_client = _FakeAsyncClient()
-    fake_client.raise_connect_error = True
+    fake_client.connection_error = connection_error
     _set_http_client(client, fake_client)
 
     response = client.get(

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -1090,7 +1090,9 @@ def test_proxy_maps_connect_error_to_502(
     )
 
     assert response.status_code == 502
-    assert "Could not connect to the backend sandbox" in response.json()["message"]
+    payload = response.json()
+    assert payload["code"] == "BACKEND_CONNECTION_FAILED"
+    assert "Could not connect to the backend sandbox" in payload["message"]
 
 
 def test_proxy_maps_unexpected_error_to_500(


### PR DESCRIPTION
## Summary

- return `BACKEND_CONNECTION_FAILED` when the server proxy cannot connect to a sandbox backend
- cover both immediate connection errors and connection timeouts while preserving HTTP 502
- document the stable error code for clients

Fixes #1665

## Validation

- `cd server && uv run pytest tests/test_routes_proxy.py -q` — 52 passed
- `cd server && uv run ruff check opensandbox_server/api/proxy.py tests/test_routes_proxy.py` — passed
- `cd server && uv run pyright opensandbox_server/api/proxy.py tests/test_routes_proxy.py` — 0 errors
- `cd docs && pnpm docs:build` — passed

## Risk

The change is limited to `httpx.ConnectError` and `httpx.ConnectTimeout` responses from server-proxied HTTP routes. The 502 status and message remain unchanged; only the machine-readable error code changes from the generic fallback to `BACKEND_CONNECTION_FAILED`. The route tests inject both connection failures directly; no live Docker or Kubernetes backend was required.