### PR TITLE
feat(server): add opt-in KVM access for Linux Docker sandboxes

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -130,6 +130,16 @@ Manual cleanup mode:
 osb sandbox create --image python:3.12 --timeout none
 ```
 
+Linux KVM access on a local Docker runtime:
+
+```bash
+osb sandbox create --image python:3.12 --resource kvm=1
+```
+
+The server accepts only the exact value `kvm=1`, validates the host
+`/dev/kvm` device, and fails closed for missing or unsafe devices and remote
+Docker endpoints. This resource is not supported by the Kubernetes runtime.
+
 Explicit entrypoint argv:
 
 ```bash

--- a/docs/components/server.md
+++ b/docs/components/server.md
@@ -207,6 +207,30 @@ Response:
 }
 ```
 
+### Linux KVM access with Docker
+
+Linux sandboxes on a local Docker runtime can explicitly request the host KVM
+device:
+
+```bash
+osb sandbox create --image python:3.12 --resource kvm=1 -o json
+```
+
+The server accepts only the exact value `kvm=1`. It validates `/dev/kvm` as a
+non-symlink character device with identity `10:232`, maps it into the main
+sandbox container as read/write, and adds its non-root host GID as a
+supplementary group. Requests fail before provisioning when the device is
+missing or unsafe, or when Docker uses a remote endpoint.
+
+These checks run in the lifecycle server process namespace. If the server is
+containerized, `/dev/kvm` must be exposed to the lifecycle server container
+itself; visibility only on the Docker host is not sufficient.
+
+This option does not enable privileged mode, add capabilities, expose
+`/dev/net/tun`, or attach KVM to an egress sidecar. It is not supported by the
+Kubernetes runtime; Kubernetes deployments need an explicit device plugin and
+scheduling policy.
+
 **Other lifecycle calls** (same `OPEN-SANDBOX-API-KEY` header): `GET /v1/sandboxes/{id}`, `POST /v1/sandboxes/{id}/pause`, `POST /v1/sandboxes/{id}/resume`, `GET /v1/sandboxes/{id}/endpoints/{port}` (append `?use_server_proxy=true` when needed), `POST .../renew-expiration`, `DELETE /v1/sandboxes/{id}`. Full request/response shapes: **Swagger UI** above or OpenAPI under [specs/](/api/).
 
 For Kubernetes-backed sandboxes, pause/resume is implemented via `BatchSandbox.spec.pause` and internal `SandboxSnapshot` resources. The externally visible lifecycle transitions are `Running -> Pausing -> Paused -> Resuming -> Running`.

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -1195,6 +1195,11 @@ export interface components {
              *     Required when `extensions.poolRef` is not set.
              *     Optional when using pool mode (resource limits are defined by the Pool CRD template).
              *     SDK clients should provide sensible defaults (e.g., cpu: "500m", memory: "512Mi").
+             *
+             *     On a local Docker runtime, the exact value `kvm: "1"` opts a Linux
+             *     sandbox into `/dev/kvm` access. The server rejects remote Docker
+             *     endpoints and validates the host path as character device `10:232`.
+             *     Kubernetes does not support this portable resource key.
              */
             resourceLimits?: components["schemas"]["ResourceLimits"];
             /**

--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -485,7 +485,11 @@ class CreateSandboxRequest(BaseModel):
     resource_limits: Optional[ResourceLimits] = Field(
         None,
         alias="resourceLimits",
-        description="Runtime resource constraints (hard caps) for the sandbox instance. Optional when poolRef is provided.",
+        description=(
+            "Runtime resource constraints (hard caps) for the sandbox instance. "
+            "On a local Docker runtime, kvm='1' exposes a validated /dev/kvm device "
+            "to a Linux sandbox. Optional when poolRef is provided."
+        ),
     )
     resource_requests: Optional[ResourceLimits] = Field(
         None,

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -69,6 +69,10 @@ from opensandbox_server.services.docker.networking import (
     DockerNetworkingMixin,
 )
 from opensandbox_server.services.docker.container_ops import DockerContainerOpsMixin
+from opensandbox_server.services.docker.kvm import (
+    apply_kvm_host_config,
+    resolve_kvm_device_group,
+)
 from opensandbox_server.services.docker.metadata import DockerMetadataStore
 from opensandbox_server.services.docker.port_allocator import (
     allocate_port_bindings,
@@ -665,6 +669,16 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
         self._ensure_network_policy_support(request)
         self._validate_network_exists()
 
+        resource_limits = (
+            request.resource_limits.root if request.resource_limits else None
+        ) or {}
+        kvm_device_group = None
+        if not is_windows_platform(request.platform):
+            kvm_device_group = resolve_kvm_device_group(
+                resource_limits,
+                self.docker_client.api.base_url,
+            )
+
         try:
             sandbox_env, egress_env = split_egress_env(request.env)
         except ValueError as e:
@@ -687,6 +701,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                     sandbox_id, request, created_at, expires_at,
                     pvc_inspect_cache, auto_created_volumes,
                     sandbox_env=sandbox_env, egress_env=egress_env,
+                    kvm_device_group=kvm_device_group,
                 )
                 loop.call_soon_threadsafe(future.set_result, result)
             except BaseException as exc:
@@ -717,6 +732,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
         auto_created_volumes: Optional[list[str]] = None,
         sandbox_env: Optional[Dict[str, Optional[str]]] = None,
         egress_env: Optional[Dict[str, Optional[str]]] = None,
+        kvm_device_group: Optional[int] = None,
     ) -> CreateSandboxResponse:
         if sandbox_env is None and egress_env is None:
             sandbox_env, egress_env = split_egress_env(request.env)
@@ -864,6 +880,12 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                     labels[SANDBOX_HTTP_PORT_LABEL] = str(host_http_port)
                 else:
                     exposed_ports = None
+
+            if kvm_device_group is not None:
+                host_config_kwargs = apply_kvm_host_config(
+                    host_config_kwargs,
+                    kvm_device_group,
+                )
 
             # Inject volume bind mounts into Docker host config
             if runtime_volume_name:

--- a/server/opensandbox_server/services/docker/kvm.py
+++ b/server/opensandbox_server/services/docker/kvm.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import stat
+from typing import Any, Final, Mapping
+
+from fastapi import HTTPException, status
+
+from opensandbox_server.services.constants import SandboxErrorCodes
+
+KVM_DEVICE_PATH: Final = "/dev/kvm"
+KVM_DEVICE_MAPPING: Final = f"{KVM_DEVICE_PATH}:{KVM_DEVICE_PATH}:rw"
+KVM_DEVICE_MAJOR: Final = 10
+KVM_DEVICE_MINOR: Final = 232
+KVM_RESOURCE_KEY: Final = "kvm"
+_LOCAL_DOCKER_ADAPTER_URL: Final = "http+docker://localhost"
+_LOCAL_UNIX_URL_PREFIXES: Final = ("unix://", "http+unix://")
+
+
+def _invalid_kvm_request(message: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail={
+            "code": SandboxErrorCodes.INVALID_PARAMETER,
+            "message": message,
+        },
+    )
+
+
+def resolve_kvm_device_group(
+    resource_limits: Mapping[str, str],
+    docker_base_url: str,
+) -> int | None:
+    """Validate an explicit local-Docker KVM request and return the device GID."""
+    requested_value = resource_limits.get(KVM_RESOURCE_KEY)
+    if requested_value is None:
+        return None
+    if requested_value != "1":
+        raise _invalid_kvm_request("resourceLimits.kvm must be exactly '1'.")
+    local_docker_endpoint = (
+        docker_base_url.rstrip("/") == _LOCAL_DOCKER_ADAPTER_URL
+        or docker_base_url.startswith(_LOCAL_UNIX_URL_PREFIXES)
+    )
+    if not local_docker_endpoint:
+        raise _invalid_kvm_request(
+            "resourceLimits.kvm is supported only with a local Unix Docker endpoint."
+        )
+
+    try:
+        device = os.lstat(KVM_DEVICE_PATH)
+    except OSError as exc:
+        raise _invalid_kvm_request(
+            f"resourceLimits.kvm requires {KVM_DEVICE_PATH} on the Docker host."
+        ) from exc
+
+    if not stat.S_ISCHR(device.st_mode):
+        raise _invalid_kvm_request(
+            f"resourceLimits.kvm requires {KVM_DEVICE_PATH} to be a character device."
+        )
+    if (
+        os.major(device.st_rdev) != KVM_DEVICE_MAJOR
+        or os.minor(device.st_rdev) != KVM_DEVICE_MINOR
+    ):
+        raise _invalid_kvm_request(
+            f"resourceLimits.kvm requires {KVM_DEVICE_PATH} to be character device 10:232."
+        )
+    return device.st_gid
+
+
+def apply_kvm_host_config(
+    host_config_kwargs: dict[str, Any],
+    device_group: int,
+) -> dict[str, Any]:
+    """Add the validated KVM device and its non-root group to Docker HostConfig."""
+    updated = dict(host_config_kwargs)
+    devices = list(updated.get("devices") or [])
+    if KVM_DEVICE_MAPPING not in devices:
+        devices.append(KVM_DEVICE_MAPPING)
+    updated["devices"] = devices
+
+    if device_group != 0:
+        group_add = list(updated.get("group_add") or [])
+        if str(device_group) not in {str(group) for group in group_add}:
+            group_add.append(str(device_group))
+        updated["group_add"] = group_add
+    return updated

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -44,6 +44,7 @@ from opensandbox_server.services.k8s.provider_common import (
     _build_main_container,
     _container_to_dict,
     _extract_platform_unschedulable_message_from_pod,
+    _validate_kvm_resource_limits_for_k8s,
     _workload_platform_constraint_scope,
 )
 from opensandbox_server.services.k8s.status_helpers import (
@@ -150,6 +151,7 @@ class BatchSandboxProvider(WorkloadProvider):
     ) -> Dict[str, Any]:
         """Create a BatchSandbox in template mode or pool mode."""
         extensions = extensions or {}
+        _validate_kvm_resource_limits_for_k8s(resource_limits)
         windows_profile = is_windows_profile(platform)
 
         if self.runtime_class:

--- a/server/opensandbox_server/services/k8s/provider_common.py
+++ b/server/opensandbox_server/services/k8s/provider_common.py
@@ -53,6 +53,21 @@ _KVM_RESOURCE_LIMIT_KEY = "kvm"
 _K8S_NVIDIA_GPU_RESOURCE = "nvidia.com/gpu"
 
 
+def _validate_kvm_resource_limits_for_k8s(
+    resource_limits: Dict[str, str],
+) -> None:
+    if _KVM_RESOURCE_LIMIT_KEY in resource_limits:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": SandboxErrorCodes.INVALID_PARAMETER,
+                "message": (
+                    "resourceLimits.kvm is not supported by the Kubernetes runtime."
+                ),
+            },
+        )
+
+
 def _translate_resource_limits_for_k8s(
     resource_limits: Dict[str, str],
 ) -> Dict[str, str]:
@@ -81,16 +96,7 @@ def _translate_resource_limits_for_k8s(
     if not resource_limits:
         return {}
 
-    if _KVM_RESOURCE_LIMIT_KEY in resource_limits:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail={
-                "code": SandboxErrorCodes.INVALID_PARAMETER,
-                "message": (
-                    "resourceLimits.kvm is not supported by the Kubernetes runtime."
-                ),
-            },
-        )
+    _validate_kvm_resource_limits_for_k8s(resource_limits)
 
     translated: Dict[str, str] = {
         key: value

--- a/server/opensandbox_server/services/k8s/provider_common.py
+++ b/server/opensandbox_server/services/k8s/provider_common.py
@@ -45,6 +45,7 @@ from opensandbox_server.services.k8s.security_context import (
 DEFAULT_ENTRYPOINT = ["tail", "-f", "/dev/null"]
 
 _GPU_RESOURCE_LIMIT_KEY = "gpu"
+_KVM_RESOURCE_LIMIT_KEY = "kvm"
 # Canonical extended-resource name advertised by the NVIDIA device plugin.
 # Hardcoded for parity with the Docker runtime fix (#775), which targets
 # NVIDIA only via DeviceRequest capabilities=[["gpu"]]. Other vendor keys
@@ -57,7 +58,8 @@ def _translate_resource_limits_for_k8s(
 ) -> Dict[str, str]:
     """Translate request-level resource limits into Kubernetes resource keys.
 
-    The lifecycle API exposes a portable ``gpu`` key on ``resourceLimits``.
+    The Kubernetes runtime does not support the lifecycle API's ``kvm`` key.
+    The lifecycle API also exposes a portable ``gpu`` key on ``resourceLimits``;
     Kubernetes requires the canonical extended-resource name
     (``nvidia.com/gpu``) so the device plugin can schedule the request;
     otherwise the value is silently treated as an unknown extended resource.
@@ -66,18 +68,29 @@ def _translate_resource_limits_for_k8s(
         resource_limits: Raw resource limits from the create request.
 
     Returns:
-        A new dict with the ``gpu`` key translated to ``nvidia.com/gpu``
-        and any unparseable GPU value dropped. Other keys (cpu, memory, ...)
-        are passed through unchanged.
+        A new dict with the ``gpu`` key translated to ``nvidia.com/gpu`` and
+        any unparseable GPU value dropped. Other supported keys (cpu, memory,
+        ...) are passed through unchanged.
 
     Raises:
-        HTTPException: If ``gpu`` is the ``"all"`` sentinel. Docker accepts
-            ``"all"`` (mapped to an unbounded DeviceRequest), but Kubernetes
-            extended resources require an integer count, so we surface a
-            400 rather than silently scheduling without a GPU.
+        HTTPException: If ``kvm`` is present or ``gpu`` is the ``"all"``
+            sentinel. Docker accepts these values, but Kubernetes cannot
+            fulfill them, so we surface a 400 rather than silently scheduling
+            without the requested resource.
     """
     if not resource_limits:
         return {}
+
+    if _KVM_RESOURCE_LIMIT_KEY in resource_limits:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": SandboxErrorCodes.INVALID_PARAMETER,
+                "message": (
+                    "resourceLimits.kvm is not supported by the Kubernetes runtime."
+                ),
+            },
+        )
 
     translated: Dict[str, str] = {
         key: value

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -15,7 +15,7 @@
 import pytest
 from types import SimpleNamespace
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from fastapi import HTTPException
 from kubernetes.client import ApiException
 
@@ -40,6 +40,7 @@ from opensandbox_server.services.constants import (
     OPENSANDBOX_RUNTIME_MOUNT_PATH,
     OPENSANDBOX_RUNTIME_VOLUME_NAME,
     SANDBOX_EGRESS_AUTH_TOKEN_METADATA_KEY,
+    SandboxErrorCodes,
 )
 from opensandbox_server.services.k8s.batchsandbox_provider import BatchSandboxProvider
 from opensandbox_server.services.k8s.workload_provider import EgressWorkloadSettings
@@ -1634,6 +1635,34 @@ spec:
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
+
+    def test_create_workload_poolref_rejects_kvm_resource_limit(self, mock_k8s_client):
+        provider = BatchSandboxProvider(mock_k8s_client)
+
+        with (
+            patch.object(provider, "_create_workload_from_pool") as create_from_pool,
+            pytest.raises(HTTPException) as excinfo,
+        ):
+            provider.create_workload(
+                sandbox_id="test-id",
+                namespace="test-ns",
+                image_spec=ImageSpec(uri="", auth=None),
+                entrypoint=["python", "app.py"],
+                env={},
+                resource_limits={"cpu": "1", "memory": "1Gi", "kvm": "1"},
+                labels={},
+                expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+                execd_image="execd:latest",
+                extensions={"poolRef": "my-pool"},
+            )
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail == {
+            "code": SandboxErrorCodes.INVALID_PARAMETER,
+            "message": "resourceLimits.kvm is not supported by the Kubernetes runtime.",
+        }
+        create_from_pool.assert_not_called()
+        mock_k8s_client.create_custom_object.assert_not_called()
 
     def test_create_workload_poolref_rejects_network_policy(self, mock_k8s_client):
         provider = BatchSandboxProvider(mock_k8s_client)

--- a/server/tests/k8s/test_provider_common.py
+++ b/server/tests/k8s/test_provider_common.py
@@ -63,13 +63,29 @@ def test_translate_resource_limits_no_gpu_key_unchanged():
     assert result is not inputs
 
 
+@pytest.mark.parametrize("kvm_value", ["1", "0", ""])
+def test_translate_resource_limits_rejects_kvm(kvm_value):
+    with pytest.raises(HTTPException) as excinfo:
+        _translate_resource_limits_for_k8s({"kvm": kvm_value})
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail == {
+        "code": SandboxErrorCodes.INVALID_PARAMETER,
+        "message": "resourceLimits.kvm is not supported by the Kubernetes runtime.",
+    }
+
+
 def test_translate_resource_limits_rejects_all():
     with pytest.raises(HTTPException) as excinfo:
         _translate_resource_limits_for_k8s({"gpu": "all"})
     assert excinfo.value.status_code == 400
-    detail = excinfo.value.detail
-    assert detail["code"] == SandboxErrorCodes.INVALID_PARAMETER
-    assert "positive integer" in detail["message"]
+    assert excinfo.value.detail == {
+        "code": SandboxErrorCodes.INVALID_PARAMETER,
+        "message": (
+            "Kubernetes runtime requires resourceLimits.gpu to be a positive "
+            "integer; 'all' is not supported."
+        ),
+    }
 
 
 @pytest.mark.parametrize("bad_value", ["0", "-1", "bad", ""])

--- a/server/tests/test_docker_kvm.py
+++ b/server/tests/test_docker_kvm.py
@@ -1,0 +1,286 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import stat
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, status
+
+from opensandbox_server.api.schema import (
+    CreateSandboxRequest,
+    ImageSpec,
+    NetworkPolicy,
+    PlatformSpec,
+    ResourceLimits,
+)
+from opensandbox_server.config import AppConfig, EgressConfig, IngressConfig, RuntimeConfig
+from opensandbox_server.services.constants import SandboxErrorCodes
+from opensandbox_server.services.docker import DockerSandboxService
+
+
+def _app_config() -> AppConfig:
+    return AppConfig(
+        runtime=RuntimeConfig(
+            type="docker",
+            execd_image="ghcr.io/opensandbox/platform:latest",
+        ),
+        ingress=IngressConfig(mode="direct"),
+    )
+
+
+def _request(
+    kvm: str | None,
+    *,
+    network_policy: NetworkPolicy | None = None,
+) -> CreateSandboxRequest:
+    resources = {} if kvm is None else {"kvm": kvm}
+    return CreateSandboxRequest(
+        image=ImageSpec(uri="python:3.12", auth=None),
+        snapshotId=None,
+        platform=None,
+        timeout=120,
+        resourceLimits=ResourceLimits(root=resources),
+        resourceRequests=None,
+        env={},
+        metadata={},
+        entrypoint=["python"],
+        lifecycle=None,
+        networkPolicy=network_policy,
+        credentialProxy=None,
+        secureAccess=False,
+        volumes=None,
+        extensions=None,
+    )
+
+
+def _service(mock_docker, *, base_url: str = "http+docker://localhost"):
+    client = MagicMock()
+    client.api.base_url = base_url
+    client.containers.list.return_value = []
+    client.api.create_host_config.side_effect = lambda **kwargs: kwargs
+    client.api.create_container.return_value = {"Id": "main-id"}
+    client.containers.get.return_value = MagicMock(id="main-id")
+    mock_docker.from_env.return_value = client
+    return DockerSandboxService(config=_app_config()), client
+
+
+def _kvm_stat(*, mode: int = stat.S_IFCHR | 0o660, device: int | None = None, gid: int = 123):
+    return SimpleNamespace(
+        st_mode=mode,
+        st_rdev=os.makedev(10, 232) if device is None else device,
+        st_gid=gid,
+    )
+
+
+@pytest.mark.asyncio
+@patch("opensandbox_server.services.docker.docker_service.docker")
+async def test_linux_kvm_request_adds_minimal_device_and_group(mock_docker):
+    service, client = _service(mock_docker)
+
+    with (
+        patch("os.lstat", return_value=_kvm_stat()),
+        patch.object(service, "_ensure_image_available"),
+        patch.object(service, "_prepare_sandbox_runtime"),
+    ):
+        await service.create_sandbox(_request("1"))
+
+    host_config = client.api.create_host_config.call_args.kwargs
+    assert host_config["devices"] == ["/dev/kvm:/dev/kvm:rw"]
+    assert host_config["group_add"] == ["123"]
+    assert "privileged" not in host_config
+    assert "cap_add" not in host_config
+
+
+@pytest.mark.parametrize("value", ["", "0", "01", "2", "true", "all", " 1"])
+@pytest.mark.asyncio
+@patch("opensandbox_server.services.docker.docker_service.docker")
+async def test_kvm_request_is_exact_opt_in(mock_docker, value: str):
+    service, client = _service(mock_docker)
+
+    with (
+        patch.object(service, "_ensure_image_available") as ensure_image_available,
+        patch.object(service, "_prepare_sandbox_runtime") as prepare_sandbox_runtime,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await service.create_sandbox(_request(value))
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert SandboxErrorCodes.INVALID_PARAMETER in str(exc_info.value.detail)
+    ensure_image_available.assert_not_called()
+    prepare_sandbox_runtime.assert_not_called()
+    client.images.get.assert_not_called()
+    client.volumes.create.assert_not_called()
+    client.api.create_container.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "device_result",
+    [
+        FileNotFoundError(),
+        _kvm_stat(mode=stat.S_IFLNK | 0o777),
+        _kvm_stat(mode=stat.S_IFREG | 0o660),
+        _kvm_stat(device=os.makedev(10, 231)),
+    ],
+)
+@pytest.mark.asyncio
+@patch("opensandbox_server.services.docker.docker_service.docker")
+async def test_kvm_request_rejects_unsafe_device_before_provisioning(
+    mock_docker,
+    device_result,
+):
+    service, client = _service(mock_docker)
+    lstat = MagicMock(
+        side_effect=device_result if isinstance(device_result, OSError) else None,
+        return_value=None if isinstance(device_result, OSError) else device_result,
+    )
+
+    with (
+        patch("os.lstat", lstat),
+        patch.object(service, "_ensure_image_available") as ensure_image_available,
+        patch.object(service, "_prepare_sandbox_runtime") as prepare_sandbox_runtime,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await service.create_sandbox(_request("1"))
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert SandboxErrorCodes.INVALID_PARAMETER in str(exc_info.value.detail)
+    ensure_image_available.assert_not_called()
+    prepare_sandbox_runtime.assert_not_called()
+    client.images.get.assert_not_called()
+    client.volumes.create.assert_not_called()
+    client.api.create_container.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://docker.example:2375",
+        "http://localhost:2375",
+        "https://docker.example:2376",
+        "http+docker://ssh",
+        "http+docker://localnpipe",
+        "http+docker://localhost.example",
+    ],
+)
+@patch("opensandbox_server.services.docker.docker_service.docker")
+async def test_kvm_request_rejects_remote_docker(mock_docker, base_url: str):
+    service, client = _service(mock_docker, base_url=base_url)
+
+    with (
+        patch("os.lstat") as lstat,
+        patch.object(service, "_ensure_image_available") as ensure_image_available,
+        patch.object(service, "_prepare_sandbox_runtime") as prepare_sandbox_runtime,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await service.create_sandbox(_request("1"))
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert SandboxErrorCodes.INVALID_PARAMETER in str(exc_info.value.detail)
+    lstat.assert_not_called()
+    ensure_image_available.assert_not_called()
+    prepare_sandbox_runtime.assert_not_called()
+    client.api.create_container.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("opensandbox_server.services.docker.docker_service.docker")
+async def test_absent_kvm_resource_leaves_host_config_unchanged(mock_docker):
+    service, client = _service(mock_docker)
+
+    with (
+        patch("os.lstat") as lstat,
+        patch.object(service, "_ensure_image_available"),
+        patch.object(service, "_prepare_sandbox_runtime"),
+    ):
+        await service.create_sandbox(_request(None))
+
+    lstat.assert_not_called()
+    host_config = client.api.create_host_config.call_args.kwargs
+    assert "devices" not in host_config
+    assert "group_add" not in host_config
+
+
+@pytest.mark.asyncio
+@patch("opensandbox_server.services.docker.docker_service.docker")
+async def test_linux_kvm_root_group_omits_supplementary_group(mock_docker):
+    service, client = _service(mock_docker)
+
+    with (
+        patch("os.lstat", return_value=_kvm_stat(gid=0)),
+        patch.object(service, "_ensure_image_available"),
+        patch.object(service, "_prepare_sandbox_runtime"),
+    ):
+        await service.create_sandbox(_request("1"))
+
+    host_config = client.api.create_host_config.call_args.kwargs
+    assert host_config["devices"] == ["/dev/kvm:/dev/kvm:rw"]
+    assert "group_add" not in host_config
+
+
+@pytest.mark.asyncio
+@patch("opensandbox_server.services.docker.docker_service.docker")
+async def test_windows_profile_does_not_use_generic_kvm_path(mock_docker):
+    service, _ = _service(mock_docker)
+    request = _request("true").model_copy(
+        update={"platform": PlatformSpec(os="windows", arch="amd64")}
+    )
+
+    with (
+        patch(
+            "opensandbox_server.services.docker.docker_service.resolve_kvm_device_group"
+        ) as resolve_kvm,
+        patch.object(service, "_validate_volumes", return_value=({}, [])),
+        patch.object(service, "_provision_sandbox", return_value=MagicMock()),
+    ):
+        await service.create_sandbox(request)
+
+    resolve_kvm.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("opensandbox_server.services.docker.docker_service.docker")
+async def test_kvm_is_attached_only_to_main_container_with_egress(mock_docker):
+    service, client = _service(mock_docker)
+    service.app_config.docker.network_mode = "bridge"
+    service.network_mode = "bridge"
+    service.app_config.egress = EgressConfig(image="egress:latest")
+    client.api.create_container.side_effect = [{"Id": "sidecar-id"}, {"Id": "main-id"}]
+    client.containers.get.side_effect = [MagicMock(id="sidecar-id"), MagicMock(id="main-id")]
+
+    with (
+        patch("os.lstat", return_value=_kvm_stat()),
+        patch.object(service, "_ensure_image_available"),
+        patch.object(service, "_prepare_sandbox_runtime"),
+        patch.object(service, "_wait_for_egress_sidecar_ready"),
+        patch(
+            "opensandbox_server.services.docker.docker_service.allocate_port_bindings",
+            return_value={
+                "44772": ("0.0.0.0", 44772),
+                "8080": ("0.0.0.0", 8080),
+                "18080": ("0.0.0.0", 18080),
+            },
+        ),
+    ):
+        await service.create_sandbox(
+            _request("1", network_policy=NetworkPolicy(defaultAction="deny", egress=[]))
+        )
+
+    sidecar_host_config = client.api.create_host_config.call_args_list[0].kwargs
+    main_host_config = client.api.create_host_config.call_args_list[1].kwargs
+    assert "devices" not in sidecar_host_config
+    assert main_host_config["devices"] == ["/dev/kvm:/dev/kvm:rw"]

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -1423,6 +1423,11 @@ components:
             Optional when using pool mode (resource limits are defined by the Pool CRD template).
             SDK clients should provide sensible defaults (e.g., cpu: "500m", memory: "512Mi").
 
+            On a local Docker runtime, the exact value `kvm: "1"` opts a Linux
+            sandbox into `/dev/kvm` access. The server rejects remote Docker
+            endpoints and validates the host path as character device `10:232`.
+            Kubernetes does not support this portable resource key.
+
         resourceRequests:
           $ref: '#/components/schemas/ResourceLimits'
           description: |


### PR DESCRIPTION
# Summary
- Add exact `resourceLimits.kvm: "1"` opt-in for generic Linux sandboxes on a local Docker runtime.
- Validate server-visible `/dev/kvm` with `lstat` as character device `10:232`, map only `/dev/kvm:/dev/kvm:rw` into the main container, and add only its non-root GID.
- Reject invalid values, unsafe devices, remote Docker endpoints, and Kubernetes requests before provisioning; preserve existing Windows/QEMU behavior and egress-sidecar isolation.
- Document the runtime/security boundary and regenerate the JavaScript lifecycle API declaration.

Closes #1676

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [ ] e2e / manual verification

Validation performed:
- Server Ruff and focused Pyright: clean
- Focused Docker KVM and Kubernetes resource tests: 42 passed
- Full server suite: 1617 passed, 7 skipped
- Python SDK generator, Ruff, Pyright, and tests: passed
- JavaScript SDK lint, typecheck, build, and 104 tests: passed
- CLI help tests: 52 passed
- VitePress documentation build: passed
- `git diff --check`: clean

Real Docker/KVM E2E was not run because this environment has neither Docker nor `/dev/kvm`. Kotlin lifecycle generation was not run because no JDK is installed; its generated build output is ignored and untracked. Python package build was not run because the local environment lacks the build backend, while generator/lint/type/tests passed.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered