### PR TITLE
fix(server): align create provisioning contract

### DIFF
--- a/server/DEVELOPMENT.md
+++ b/server/DEVELOPMENT.md
@@ -57,12 +57,12 @@ Layered architecture:
 Client → POST /sandboxes
   → Auth Middleware validates API key
   → lifecycle.create_sandbox() receives CreateSandboxRequest
-  → sandbox_service.create_sandbox_async(request)
-  → Returns 202 Accepted with Pending status immediately
-  → Background thread provisions the sandbox
+  → await sandbox_service.create_sandbox(request)
+  → Runtime provisions the sandbox and waits for readiness
+  → Returns 202 Accepted with Running status
 ```
 
-Async provisioning avoids blocking API requests during slow operations (image pull, container start). Sandbox stored in pending state first, transitions to running when ready.
+Creation is synchronous from the client's perspective: the request remains open while the runtime provisions the sandbox. Docker moves blocking provisioning work to a worker thread but awaits its result; Kubernetes waits for the workload to be Running with an IP address. Provisioning failures are returned by the create request rather than a background Pending-to-Running flow.
 
 ### Expiration System
 

--- a/server/opensandbox_server/api/lifecycle.py
+++ b/server/opensandbox_server/api/lifecycle.py
@@ -70,7 +70,7 @@ snapshot_service = create_snapshot_service(sandbox_service)
     response_model_exclude_none=True,
     status_code=status.HTTP_202_ACCEPTED,
     responses={
-        202: {"description": "Sandbox creation accepted for asynchronous provisioning"},
+        202: {"description": "Sandbox created and provisioned successfully"},
         400: {"model": ErrorResponse, "description": "The request was invalid or malformed"},
         401: {"model": ErrorResponse, "description": "Authentication credentials are missing or invalid"},
         409: {"model": ErrorResponse, "description": "The operation conflicts with the current state"},

--- a/server/tests/test_routes_create_delete.py
+++ b/server/tests/test_routes_create_delete.py
@@ -20,6 +20,16 @@ from opensandbox_server.api import lifecycle
 from opensandbox_server.api.schema import CreateSandboxResponse, SandboxStatus
 
 
+def test_create_sandbox_openapi_describes_synchronous_provisioning(
+    client: TestClient,
+) -> None:
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    create_response = response.json()["paths"]["/v1/sandboxes"]["post"]["responses"]["202"]
+    assert create_response["description"] == "Sandbox created and provisioned successfully"
+
+
 def test_create_sandbox_returns_202_and_service_payload(
     client: TestClient,
     auth_headers: dict,


### PR DESCRIPTION
# Summary

- Align the server-generated OpenAPI description for `POST /v1/sandboxes` with the source lifecycle spec and current synchronous provisioning behavior.
- Replace the stale `create_sandbox_async` / background `Pending` flow in the server development guide with the current awaited Docker and Kubernetes flow.
- Add a regression test for the generated `202` response description.

This does not change the HTTP status code or runtime behavior. It only makes the generated contract and development documentation match the behavior established by #1178.

Fixes #1679.

# Testing

- [x] Unit tests: `cd server && uv run pytest -q` (`1593 passed, 7 skipped`)
- [x] Focused regression test was written failing first, then passed after the fix.
- [x] Lint: `uv run ruff check opensandbox_server/api/lifecycle.py tests/test_routes_create_delete.py`
- [x] Test-file format check: `uv run ruff format --check tests/test_routes_create_delete.py`
- [x] License headers: `./scripts/verify-license.sh`
- [x] Patch checks: `git diff --check` and a secret-pattern scan of the patch
- [ ] Full `uv run pyright`: currently blocked by 1407 pre-existing errors across the server tree; the new test lines have no diagnostics.
- [ ] Integration / e2e: not run because there is no runtime behavior change.

`ruff format --check` for the whole `lifecycle.py` file also reports pre-existing formatting drift. Formatting it would rewrite many unrelated lines, so this focused change leaves that baseline untouched.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered — no new inputs or behavior
- [x] Backward compatibility considered — status code and provisioning flow are unchanged
