### PR TITLE
feat(sdk/kotlin): typed exception for proxy backend-connection failures

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/exceptions/SandboxException.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/exceptions/SandboxException.kt
@@ -204,6 +204,36 @@ class SandboxCapacityExceededException
         )
 
 /**
+ * Thrown when the server proxy cannot connect to the selected sandbox backend for a proxied
+ * route (server responds with HTTP 502 and the [SandboxError.BACKEND_CONNECTION_FAILED] code).
+ *
+ * The code asserts only "the proxy could not reach *this* sandbox's backend", which data-plane
+ * health probes use to decide between replacing a broken instance and backing off during
+ * shared-infrastructure incidents. A 502 whose body carries no such code stays a plain
+ * [SandboxApiException] with [SandboxError.UNEXPECTED_RESPONSE] so proxy-wide failures are not
+ * silently downgraded and remain loud.
+ */
+class SandboxBackendUnreachableException
+    @JvmOverloads
+    constructor(
+        message: String? = null,
+        cause: Throwable? = null,
+        statusCode: Int? = 502,
+        error: SandboxError = SandboxError(SandboxError.BACKEND_CONNECTION_FAILED, message),
+        requestId: String? = null,
+        responseBody: String? = null,
+        isRetryable: Boolean = false,
+    ) : SandboxApiException(
+            message = message,
+            cause = cause,
+            statusCode = statusCode,
+            error = error,
+            requestId = requestId,
+            responseBody = responseBody,
+            isRetryable = isRetryable,
+        )
+
+/**
  * Thrown when an unexpected internal error occurs within the SDK
  */
 open class SandboxInternalException(
@@ -413,6 +443,12 @@ data class SandboxError(
 
         /** The sandbox workspace is over its storage capacity (server responds with HTTP 507). */
         const val STORAGE_CAPACITY_EXCEEDED = "STORAGE_CAPACITY_EXCEEDED"
+
+        /**
+         * The server proxy could not connect to the selected sandbox backend for a proxied route
+         * (server responds with HTTP 502).
+         */
+        const val BACKEND_CONNECTION_FAILED = "BACKEND_CONNECTION_FAILED"
 
         /** Pool-specific: no idle sandbox and policy is FAIL_FAST. */
         const val POOL_EMPTY = "POOL_EMPTY"

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
@@ -21,6 +21,7 @@ import com.alibaba.opensandbox.sandbox.api.infrastructure.ClientException
 import com.alibaba.opensandbox.sandbox.api.infrastructure.ServerError
 import com.alibaba.opensandbox.sandbox.api.infrastructure.ServerException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
+import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxBackendUnreachableException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxCapacityExceededException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxConnectionException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError
@@ -148,6 +149,18 @@ private fun buildSandboxApiException(
 
     if (isSandboxNotFoundCode(sandboxError.code)) {
         return SandboxNotFoundException(
+            message = message,
+            statusCode = statusCode,
+            cause = cause,
+            error = sandboxError,
+            requestId = requestId,
+            responseBody = responseBody,
+            isRetryable = isRetryable,
+        )
+    }
+
+    if (sandboxError.code == SandboxError.BACKEND_CONNECTION_FAILED) {
+        return SandboxBackendUnreachableException(
             message = message,
             statusCode = statusCode,
             cause = cause,

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxErrorClassificationTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxErrorClassificationTest.kt
@@ -18,6 +18,7 @@ package com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter
 
 import com.alibaba.opensandbox.sandbox.api.execd.infrastructure.ClientError
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
+import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxBackendUnreachableException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxCapacityExceededException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxNotFoundException
@@ -140,13 +141,17 @@ class SandboxErrorClassificationTest {
     fun `new exceptions should remain catchable as the existing api exception types`() {
         val notFound = SandboxNotFoundException("gone")
         val capacity = SandboxCapacityExceededException("full")
+        val backend = SandboxBackendUnreachableException("unreachable")
 
         assertInstanceOf(SandboxApiException::class.java, notFound)
         assertInstanceOf(SandboxApiException::class.java, capacity)
+        assertInstanceOf(SandboxApiException::class.java, backend)
         assertEquals(SandboxError.SANDBOX_NOT_FOUND, notFound.error.code)
         assertEquals(SandboxError.STORAGE_CAPACITY_EXCEEDED, capacity.error.code)
+        assertEquals(SandboxError.BACKEND_CONNECTION_FAILED, backend.error.code)
         assertEquals(404, notFound.statusCode)
         assertEquals(507, capacity.statusCode)
+        assertEquals(502, backend.statusCode)
     }
 
     @Test
@@ -175,5 +180,28 @@ class SandboxErrorClassificationTest {
         assertInstanceOf(SandboxCapacityExceededException::class.java, capacity)
         assertEquals("QUOTA::WORKSPACE_FULL", capacity.error.code)
         assertEquals(507, capacity.statusCode)
+    }
+
+    @Test
+    fun `backend connection failed code should surface a backend unreachable exception`() {
+        val ex =
+            errorResponse(
+                502,
+                """{"code":"BACKEND_CONNECTION_FAILED","message":"Could not connect to the backend sandbox sb-1: connection refused"}""",
+            ).toSandboxApiException { status, body -> "status=$status body=$body" }
+
+        assertInstanceOf(SandboxBackendUnreachableException::class.java, ex)
+        assertEquals(SandboxError.BACKEND_CONNECTION_FAILED, ex.error.code)
+        assertEquals(502, ex.statusCode)
+    }
+
+    @Test
+    fun `bare 502 without the backend connection code must not be classified as backend unreachable`() {
+        val ex =
+            errorResponse(502, "not a structured error body")
+                .toSandboxApiException { status, body -> "status=$status body=$body" }
+
+        assertInstanceOf(SandboxApiException::class.java, ex)
+        assertEquals(SandboxError.UNEXPECTED_RESPONSE, ex.error.code)
     }
 }


### PR DESCRIPTION
As proposed in #1665 (and unblocked by the wire contract that landed in #1675), expose the server proxy's `BACKEND_CONNECTION_FAILED` error code as a typed signal in the Kotlin SDK.

# Summary

#1675 made the server proxy answer backend-connection failures on proxied routes with HTTP 502 and a structured body:

```json
{"code": "BACKEND_CONNECTION_FAILED", "message": "Could not connect to the backend sandbox ..."}
```

This PR lets Kotlin SDK consumers branch on that failure class without matching message text, exactly as #1665 outlined for agent-platform health probes (replacing a broken instance vs. backing off during shared-infrastructure incidents):

- New `SandboxError.BACKEND_CONNECTION_FAILED` constant and `SandboxBackendUnreachableException` (`statusCode` defaults to 502, consistent with the other typed subtypes).
- Classification is code-based in the single `buildSandboxApiException` choke point, following the merged `SandboxNotFoundException` pattern — handwritten-OkHttp and generated-client paths behave identically.
- A 502 whose body carries no structured code stays a plain `SandboxApiException` / `UNEXPECTED_RESPONSE`, so proxy-wide 502s are not silently downgraded — mirroring the deliberate bare-404 stance.
- Existing `catch (SandboxApiException)` / `catch (SandboxException)` blocks are unaffected; purely additive.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Two new cases in `SandboxErrorClassificationTest`: 502 + `BACKEND_CONNECTION_FAILED` classifies to the typed exception with the server code preserved; bare 502 stays unclassified. The catch-compatibility test now also locks the new subtype and its 502 default. Full `:sandbox:test` passes (classification suite 11/11).

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [ ] Security impact considered
- [x] Backward compatibility considered
