### PR TITLE
feat(sdk): allow aborting sandbox create and connect

### DIFF
--- a/sdks/sandbox/javascript/README.md
+++ b/sdks/sandbox/javascript/README.md
@@ -263,6 +263,7 @@ const config2 = new ConnectionConfig({
 | `healthCheck`                | Custom readiness check                           | -                            |
 | `readyTimeoutSeconds`        | Max time to wait for readiness                   | 30 seconds                   |
 | `healthCheckPollingInterval` | Poll interval while waiting (milliseconds)       | 200 ms                       |
+| `signal`                     | Abort creation and readiness requests             | -                            |
 
 Note: metadata keys under `opensandbox.io/` are reserved for system-managed
 labels and will be rejected by the server.

--- a/sdks/sandbox/javascript/src/adapters/healthAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/healthAdapter.ts
@@ -19,8 +19,11 @@ import type { ExecdHealth } from "../services/execdHealth.js";
 export class HealthAdapter implements ExecdHealth {
   constructor(private readonly client: ExecdClient) {}
 
-  async ping(): Promise<boolean> {
-    const { error, response } = await this.client.GET("/ping", { parseAs: "text" });
+  async ping(signal?: AbortSignal): Promise<boolean> {
+    const { error, response } = await this.client.GET("/ping", {
+      parseAs: "text",
+      signal,
+    });
     throwOnOpenApiFetchError({ error, response }, "Execd ping failed");
     return true;
   }

--- a/sdks/sandbox/javascript/src/adapters/sandboxesAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/sandboxesAdapter.ts
@@ -136,7 +136,10 @@ export class SandboxesAdapter implements Sandboxes {
     } as SandboxInfo;
   }
 
-  async createSandbox(req: CreateSandboxRequest): Promise<CreateSandboxResponse> {
+  async createSandbox(
+    req: CreateSandboxRequest,
+    signal?: AbortSignal,
+  ): Promise<CreateSandboxResponse> {
     // Make the OpenAPI contract explicit so backend schema changes surface quickly.
     const normalizedRequest = { ...req };
     const lifecycle = normalizedRequest.lifecycle;
@@ -160,6 +163,7 @@ export class SandboxesAdapter implements Sandboxes {
     const body: ApiCreateSandboxRequest = normalizedRequest as unknown as ApiCreateSandboxRequest;
     const { data, error, response } = await this.client.POST("/sandboxes", {
       body,
+      signal,
     });
     throwOnOpenApiFetchError({ error, response }, "Create sandbox failed");
     const raw = data as ApiCreateSandboxOk | undefined;
@@ -331,8 +335,22 @@ export class SandboxesAdapter implements Sandboxes {
   async getSandboxEndpoint(
     sandboxId: SandboxId,
     port: number,
-    useServerProxy = false
+    useServerProxy = false,
+    signal?: AbortSignal,
   ): Promise<Endpoint> {
+    signal?.throwIfAborted();
+    if (signal) {
+      const cached = this.endpointCache?.get(sandboxId, port, useServerProxy);
+      if (cached) return cached;
+      const endpoint = await this.fetchSandboxEndpoint(
+        sandboxId,
+        port,
+        useServerProxy,
+        signal,
+      );
+      this.endpointCache?.put(sandboxId, port, useServerProxy, endpoint);
+      return endpoint;
+    }
     if (this.endpointCache) {
       return this.endpointCache.getOrFetch(sandboxId, port, useServerProxy, () =>
         this.fetchSandboxEndpoint(sandboxId, port, useServerProxy)
@@ -344,10 +362,12 @@ export class SandboxesAdapter implements Sandboxes {
   private async fetchSandboxEndpoint(
     sandboxId: SandboxId,
     port: number,
-    useServerProxy: boolean
+    useServerProxy: boolean,
+    signal?: AbortSignal,
   ): Promise<Endpoint> {
     const { data, error, response } = await this.client.GET("/sandboxes/{sandboxId}/endpoints/{port}", {
       params: { path: { sandboxId, port }, query: { use_server_proxy: useServerProxy } },
+      signal,
     });
     throwOnOpenApiFetchError({ error, response }, "Get sandbox endpoint failed");
     const ok = data as ApiEndpointOk | undefined;

--- a/sdks/sandbox/javascript/src/config/connection.ts
+++ b/sdks/sandbox/javascript/src/config/connection.ts
@@ -214,6 +214,11 @@ function createTimedFetch(opts: {
         : (input as any)?.toString?.() ?? String(input);
 
     const ac = new AbortController();
+    const requestSignal =
+      init?.signal ??
+      (typeof Request !== "undefined" && input instanceof Request
+        ? input.signal
+        : undefined);
     const timeoutMs = Math.floor(timeoutSeconds * 1000);
     const t =
       Number.isFinite(timeoutMs) && timeoutMs > 0
@@ -229,11 +234,11 @@ function createTimedFetch(opts: {
         : undefined;
 
     const onAbort = () =>
-      ac.abort((init?.signal as any)?.reason ?? new Error("Aborted"));
-    if (init?.signal) {
-      if (init.signal.aborted) onAbort();
+      ac.abort((requestSignal as any)?.reason ?? new Error("Aborted"));
+    if (requestSignal) {
+      if (requestSignal.aborted) onAbort();
       else
-        init.signal.addEventListener("abort", onAbort, { once: true } as any);
+        requestSignal.addEventListener("abort", onAbort, { once: true } as any);
     }
 
     // Best-effort: attach the SDK host's own IP so the server can see the
@@ -281,8 +286,8 @@ function createTimedFetch(opts: {
       return res;
     } finally {
       if (t) clearTimeout(t);
-      if (init?.signal)
-        init.signal.removeEventListener("abort", onAbort as any);
+      if (requestSignal)
+        requestSignal.removeEventListener("abort", onAbort as any);
     }
   };
 }

--- a/sdks/sandbox/javascript/src/sandbox.ts
+++ b/sdks/sandbox/javascript/src/sandbox.ts
@@ -201,6 +201,10 @@ export interface SandboxCreateOptions {
    * Sandbox timeout in seconds. Set to `null` to require explicit cleanup.
    */
   timeoutSeconds?: number | null;
+  /**
+   * Optional signal used to cancel creation and readiness requests.
+   */
+  signal?: AbortSignal;
 
   /**
    * Skip readiness checks during create/connect.
@@ -250,10 +254,32 @@ export interface SandboxConnectOptions {
    * Polling interval for readiness checks (milliseconds).
    */
   healthCheckPollingInterval?: number;
+  /**
+   * Optional signal used to cancel connection and readiness requests.
+   */
+  signal?: AbortSignal;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
+function throwIfAborted(signal?: AbortSignal): void {
+  signal?.throwIfAborted();
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms));
+  throwIfAborted(signal);
+
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function toImageSpec(
@@ -368,6 +394,7 @@ export class Sandbox {
         }
       }
     }
+    throwIfAborted(opts.signal);
 
     const baseConnectionConfig =
       opts.connectionConfig instanceof ConnectionConfig
@@ -431,18 +458,20 @@ export class Sandbox {
         : opts.image?.uri ?? opts.snapshotId;
     const createStarted = Date.now();
     try {
-      const created = await sandboxes.createSandbox(req);
+      const created = await sandboxes.createSandbox(req, opts.signal);
       sandboxId = created.id as SandboxId;
 
       const endpoint = await sandboxes.getSandboxEndpoint(
         sandboxId,
         DEFAULT_EXECD_PORT,
-        connectionConfig.useServerProxy
+        connectionConfig.useServerProxy,
+        opts.signal,
       );
       const egressEndpoint = await sandboxes.getSandboxEndpoint(
         sandboxId,
         DEFAULT_EGRESS_PORT,
-        connectionConfig.useServerProxy
+        connectionConfig.useServerProxy,
+        opts.signal,
       );
       const execdBaseUrl = `${connectionConfig.protocol}://${endpoint.endpoint}`;
       const egressBaseUrl = `${connectionConfig.protocol}://${egressEndpoint.endpoint}`;
@@ -485,6 +514,7 @@ export class Sandbox {
             opts.healthCheckPollingInterval ??
             DEFAULT_HEALTH_CHECK_POLLING_INTERVAL_MILLIS,
           healthCheck: opts.healthCheck,
+          signal: opts.signal,
         });
       }
 
@@ -503,6 +533,20 @@ export class Sandbox {
         createDurationMs: Date.now() - createStarted,
         success: false,
       });
+      if (opts.signal?.aborted) {
+        void (async () => {
+          try {
+            if (sandboxId) {
+              await sandboxes.deleteSandbox(sandboxId);
+            }
+          } catch {
+            // Best-effort cleanup after cancellation.
+          } finally {
+            await connectionConfig.closeTransport().catch(() => undefined);
+          }
+        })();
+        throw err;
+      }
       if (sandboxId) {
         try {
           await sandboxes.deleteSandbox(sandboxId);
@@ -516,6 +560,7 @@ export class Sandbox {
   }
 
   static async connect(opts: SandboxConnectOptions): Promise<Sandbox> {
+    throwIfAborted(opts.signal);
     const baseConnectionConfig =
       opts.connectionConfig instanceof ConnectionConfig
         ? opts.connectionConfig
@@ -539,12 +584,14 @@ export class Sandbox {
       const endpoint = await sandboxes.getSandboxEndpoint(
         opts.sandboxId,
         DEFAULT_EXECD_PORT,
-        connectionConfig.useServerProxy
+        connectionConfig.useServerProxy,
+        opts.signal,
       );
       const egressEndpoint = await sandboxes.getSandboxEndpoint(
         opts.sandboxId,
         DEFAULT_EGRESS_PORT,
-        connectionConfig.useServerProxy
+        connectionConfig.useServerProxy,
+        opts.signal,
       );
       const execdBaseUrl = `${connectionConfig.protocol}://${endpoint.endpoint}`;
       const egressBaseUrl = `${connectionConfig.protocol}://${egressEndpoint.endpoint}`;
@@ -586,11 +633,16 @@ export class Sandbox {
             opts.healthCheckPollingInterval ??
             DEFAULT_HEALTH_CHECK_POLLING_INTERVAL_MILLIS,
           healthCheck: opts.healthCheck,
+          signal: opts.signal,
         });
       }
 
       return sbx;
     } catch (err) {
+      if (opts.signal?.aborted) {
+        void connectionConfig.closeTransport().catch(() => undefined);
+        throw err;
+      }
       await connectionConfig.closeTransport();
       throw err;
     }
@@ -737,6 +789,7 @@ export class Sandbox {
     readyTimeoutSeconds: number;
     pollingIntervalMillis: number;
     healthCheck?: (sbx: Sandbox) => boolean | Promise<boolean>;
+    signal?: AbortSignal;
   }): Promise<void> {
     const deadline = Date.now() + opts.readyTimeoutSeconds * 1000;
     let attempt = 0;
@@ -749,6 +802,7 @@ export class Sandbox {
 
     // Wait until execd becomes reachable and passes health check.
     while (true) {
+      throwIfAborted(opts.signal);
       if (Date.now() > deadline) {
         throw new SandboxReadyTimeoutException({
           message: buildTimeoutMessage(),
@@ -758,21 +812,24 @@ export class Sandbox {
       try {
         if (opts.healthCheck) {
           const ok = await opts.healthCheck(this);
+          throwIfAborted(opts.signal);
           if (ok) {
             return;
           }
         } else {
-          const ok = await this.health.ping();
+          const ok = await this.health.ping(opts.signal);
+          throwIfAborted(opts.signal);
           if (ok) {
             return;
           }
         }
         errorDetail = "Health check returned false continuously.";
       } catch (err) {
+        throwIfAborted(opts.signal);
         const message = err instanceof Error ? err.message : String(err);
         errorDetail = `Last health check error: ${message}`;
       }
-      await sleep(opts.pollingIntervalMillis);
+      await sleep(opts.pollingIntervalMillis, opts.signal);
     }
   }
 }

--- a/sdks/sandbox/javascript/src/services/execdHealth.ts
+++ b/sdks/sandbox/javascript/src/services/execdHealth.ts
@@ -13,5 +13,5 @@
 // limitations under the License.
 
 export interface ExecdHealth {
-  ping(): Promise<boolean>;
+  ping(signal?: AbortSignal): Promise<boolean>;
 }

--- a/sdks/sandbox/javascript/src/services/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/services/sandboxes.ts
@@ -30,7 +30,10 @@ import type {
 } from "../models/sandboxes.js";
 
 export interface Sandboxes {
-  createSandbox(req: CreateSandboxRequest): Promise<CreateSandboxResponse>;
+  createSandbox(
+    req: CreateSandboxRequest,
+    signal?: AbortSignal,
+  ): Promise<CreateSandboxResponse>;
   getSandbox(sandboxId: SandboxId): Promise<SandboxInfo>;
   listSandboxes(params?: ListSandboxesParams): Promise<ListSandboxesResponse>;
   patchSandboxMetadata(
@@ -59,7 +62,8 @@ export interface Sandboxes {
   getSandboxEndpoint(
     sandboxId: SandboxId,
     port: number,
-    useServerProxy?: boolean
+    useServerProxy?: boolean,
+    signal?: AbortSignal,
   ): Promise<Endpoint>;
 
   getSignedEndpoint(

--- a/sdks/sandbox/javascript/tests/sandbox.abort.test.mjs
+++ b/sdks/sandbox/javascript/tests/sandbox.abort.test.mjs
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ConnectionConfig, Sandbox } from "../dist/index.js";
+
+function createPendingConnectionConfig() {
+  const calls = [];
+  let notifyStarted;
+  const started = new Promise((resolve) => {
+    notifyStarted = resolve;
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const signal =
+      init?.signal ??
+      (typeof Request !== "undefined" && input instanceof Request
+        ? input.signal
+        : undefined);
+    calls.push({ input, init, signal });
+    notifyStarted();
+
+    return await new Promise((_, reject) => {
+      if (!signal) {
+        reject(new Error("Expected request signal"));
+        return;
+      }
+      const onAbort = () => reject(signal.reason);
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    });
+  };
+
+  let connectionConfig;
+  try {
+    connectionConfig = new ConnectionConfig({
+      domain: "http://127.0.0.1:8080",
+      disableMetrics: true,
+    }).withTransportIfMissing();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  return { calls, connectionConfig, started };
+}
+
+function assertAbortError(err) {
+  assert.equal(err?.name, "AbortError");
+  return true;
+}
+
+test("Sandbox.create aborts the in-flight Lifecycle API request", async () => {
+  const { calls, connectionConfig, started } = createPendingConnectionConfig();
+  const controller = new AbortController();
+
+  const creating = Sandbox.create({
+    connectionConfig,
+    image: "python:3.12",
+    skipHealthCheck: true,
+    signal: controller.signal,
+  });
+
+  await started;
+  controller.abort();
+
+  await assert.rejects(creating, assertAbortError);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].signal.aborted, true);
+});
+
+test("Sandbox.connect aborts the in-flight endpoint request", async () => {
+  const { calls, connectionConfig, started } = createPendingConnectionConfig();
+  const controller = new AbortController();
+
+  const connecting = Sandbox.connect({
+    connectionConfig,
+    sandboxId: "sandbox-test-id",
+    skipHealthCheck: true,
+    signal: controller.signal,
+  });
+
+  await started;
+  controller.abort();
+
+  await assert.rejects(connecting, assertAbortError);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].signal.aborted, true);
+});
+
+test("Sandbox.create rejects a pre-aborted signal before issuing a request", async () => {
+  const { calls, connectionConfig } = createPendingConnectionConfig();
+  const controller = new AbortController();
+  controller.abort();
+
+  await assert.rejects(
+    Sandbox.create({
+      connectionConfig,
+      image: "python:3.12",
+      skipHealthCheck: true,
+      signal: controller.signal,
+    }),
+    assertAbortError,
+  );
+  assert.equal(calls.length, 0);
+});
+
+test("Sandbox.create aborts a readiness check and cleans up the sandbox", async () => {
+  const controller = new AbortController();
+  let healthSignal;
+  let notifyHealthStarted;
+  const healthStarted = new Promise((resolve) => {
+    notifyHealthStarted = resolve;
+  });
+  const deleted = [];
+  let finishDelete;
+  const deleteFinished = new Promise((resolve) => {
+    finishDelete = resolve;
+  });
+
+  const sandboxes = {
+    async createSandbox() {
+      return { id: "sandbox-test-id" };
+    },
+    async getSandboxEndpoint(_sandboxId, port) {
+      return { endpoint: `127.0.0.1:${port}`, headers: {} };
+    },
+    async deleteSandbox(sandboxId) {
+      deleted.push(sandboxId);
+      await deleteFinished;
+    },
+  };
+  const adapterFactory = {
+    createLifecycleStack() {
+      return { sandboxes };
+    },
+    createExecdStack() {
+      return {
+        commands: {},
+        files: {},
+        health: {
+          async ping(signal) {
+            healthSignal = signal;
+            notifyHealthStarted();
+            return await new Promise((_, reject) => {
+              const onAbort = () => reject(signal.reason);
+              if (signal.aborted) onAbort();
+              else signal.addEventListener("abort", onAbort, { once: true });
+            });
+          },
+        },
+        metrics: {},
+      };
+    },
+    createEgressStack() {
+      return { egress: {} };
+    },
+  };
+
+  const creating = Sandbox.create({
+    adapterFactory,
+    connectionConfig: {
+      domain: "http://127.0.0.1:8080",
+      disableMetrics: true,
+    },
+    image: "python:3.12",
+    signal: controller.signal,
+  });
+
+  await healthStarted;
+  controller.abort();
+
+  let timeout;
+  const rejectionDeadline = new Promise((_, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error("Cancellation did not reject promptly")),
+      250,
+    );
+  });
+  try {
+    await assert.rejects(
+      Promise.race([creating, rejectionDeadline]),
+      assertAbortError,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+  assert.equal(healthSignal, controller.signal);
+  assert.deepEqual(deleted, ["sandbox-test-id"]);
+  finishDelete();
+});


### PR DESCRIPTION
# Summary
- Add optional `AbortSignal` support to `Sandbox.create()` and `Sandbox.connect()`.
- Propagate cancellation through lifecycle creation, endpoint discovery, and readiness health requests, including `Request.signal` handling in the timed fetch wrapper.
- Reject promptly with the signal's standard `AbortError` while performing post-create sandbox cleanup in the background.

Closes #1616.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
  - JavaScript Sandbox SDK: `108 passed`, including four new abort regression cases.
  - JavaScript Code Interpreter SDK: `4 passed`.
- [ ] Integration tests
- [x] e2e / manual verification
  - Local: Sandbox SDK lint, typecheck, tsup build, and full test suite passed; Code Interpreter lint, typecheck, build, and tests passed.
  - Tencent Cloud Linux (Node v24.11.1, pnpm 9.15.0): standard Sandbox SDK `lint`, `typecheck`, and `test` commands passed, including OpenAPI regeneration and package build; downstream Code Interpreter checks also passed.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
