### PR TITLE
fix(python): publish pool warmups incrementally

### DIFF
--- a/docs/guides/client-pool.md
+++ b/docs/guides/client-pool.md
@@ -43,7 +43,9 @@ Two flows happen concurrently:
   `warmup_concurrency`. Kotlin reconciles once per second, admits at most
   `warmup_create_qps` new creates per tick, and independently limits post-create
   readiness and preparation work with `warmup_concurrency`. A successful warmup is
-  published to the idle buffer with a TTL of `idle_timeout`.
+  published to the idle buffer with a TTL of `idle_timeout`. Within a Python
+  reconcile tick, each successful warmup is published as soon as it completes;
+  slower peers in the same tick do not delay its availability.
 - **Acquire (any node).** `acquire()` pops an idle ID from the store, connects a
   `Sandbox` client to it, optionally runs a health check and a `renew()` to the
   caller-supplied timeout, and hands it to the caller. Non-leader nodes can acquire

--- a/sdks/sandbox/python/src/opensandbox/_async_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_async_pool_reconciler.py
@@ -92,49 +92,112 @@ async def _run_primary_replenish_once(
     if not await state_store.renew_primary_lock(pool_name, owner_id, ttl):
         return
 
-    results = await asyncio.gather(
-        *(create_one() for _ in range(to_create)),
-        return_exceptions=True,
-    )
-    created_ids: list[str] = []
+    tasks: set[asyncio.Future[str | None]] = {
+        asyncio.ensure_future(create_one()) for _ in range(to_create)
+    }
+    pending = set(tasks)
+    handled_tasks: set[asyncio.Future[str | None]] = set()
     failure_count = 0
     last_error: str | None = None
-    for result in results:
-        if isinstance(result, BaseException):
-            failure_count += 1
-            last_error = str(result)
-        elif result is not None:
-            created_ids.append(result)
-        else:
-            failure_count += 1
-            last_error = None
-    reconcile_state.record_failures(failure_count, last_error)
-
     created = 0
-    for index, sandbox_id in enumerate(created_ids):
-        if not await state_store.renew_primary_lock(pool_name, owner_id, ttl):
-            for orphaned_id in created_ids[index:]:
-                await _discard(on_discard_sandbox, orphaned_id)
-            logger.warning(
-                f"Async reconcile lost primary lock before put_idle; dropped {len(created_ids) - index} newly created sandbox(es): pool_name={pool_name}"
+    commit_failed = False
+    commit_error: str | None = None
+    accept_commits = True
+    dropped = 0
+    stop_reason: str | None = None
+    try:
+        while pending:
+            done, pending = await asyncio.wait(
+                pending, return_when=asyncio.FIRST_COMPLETED
             )
-            return
-        try:
-            await state_store.put_idle(pool_name, sandbox_id)
-            created += 1
-            reconcile_state.record_success()
-        except Exception as exc:
-            reconcile_state.record_failure(str(exc))
-            for orphaned_id in created_ids[index:]:
+            for task in done:
                 try:
-                    await state_store.remove_idle(pool_name, orphaned_id)
-                except Exception:
-                    pass
-                await _discard(on_discard_sandbox, orphaned_id)
-            logger.warning(
-                f"Async reconcile put_idle failed; dropped {len(created_ids) - index} newly created sandbox(es): pool_name={pool_name} error={exc}"
+                    sandbox_id = task.result()
+                except asyncio.CancelledError:
+                    failure_count += 1
+                    last_error = "warmup task cancelled"
+                    handled_tasks.add(task)
+                    continue
+                except Exception as exc:
+                    failure_count += 1
+                    last_error = str(exc)
+                    handled_tasks.add(task)
+                    continue
+                if sandbox_id is None:
+                    failure_count += 1
+                    last_error = None
+                    handled_tasks.add(task)
+                    continue
+
+                if not accept_commits:
+                    await _discard(on_discard_sandbox, sandbox_id)
+                    dropped += 1
+                    handled_tasks.add(task)
+                    continue
+                try:
+                    lock_renewed = await state_store.renew_primary_lock(
+                        pool_name, owner_id, ttl
+                    )
+                except Exception as exc:
+                    lock_renewed = False
+                    commit_failed = True
+                    commit_error = str(exc)
+                    stop_reason = "primary lock renewal failed"
+                if not lock_renewed:
+                    accept_commits = False
+                    stop_reason = stop_reason or "primary lock lost"
+                    await _discard(on_discard_sandbox, sandbox_id)
+                    dropped += 1
+                    handled_tasks.add(task)
+                    continue
+                try:
+                    await state_store.put_idle(pool_name, sandbox_id)
+                    created += 1
+                except Exception as exc:
+                    accept_commits = False
+                    stop_reason = "commit failed"
+                    commit_failed = True
+                    commit_error = str(exc)
+                    try:
+                        await state_store.remove_idle(pool_name, sandbox_id)
+                    except Exception:
+                        pass
+                    await _discard(on_discard_sandbox, sandbox_id)
+                    dropped += 1
+                handled_tasks.add(task)
+    finally:
+        unhandled_tasks = tasks - handled_tasks
+        if unhandled_tasks:
+            cleanup_task = asyncio.create_task(
+                _cleanup_unhandled_tasks(
+                    tasks=unhandled_tasks,
+                    state_store=state_store,
+                    pool_name=pool_name,
+                    on_discard_sandbox=on_discard_sandbox,
+                )
             )
-            return
+            cleanup_cancellation: asyncio.CancelledError | None = None
+            while not cleanup_task.done():
+                try:
+                    await asyncio.shield(cleanup_task)
+                except asyncio.CancelledError as exc:
+                    cleanup_cancellation = cleanup_cancellation or exc
+                    continue
+            cleanup_task.result()
+            if cleanup_cancellation is not None:
+                raise cleanup_cancellation
+
+    reconcile_state.record_failures(failure_count, last_error)
+    if created > 0:
+        reconcile_state.record_success()
+    if commit_failed:
+        reconcile_state.record_failure(commit_error)
+
+    if dropped > 0:
+        error_detail = f" error={commit_error}" if commit_error else ""
+        logger.warning(
+            f"Async reconcile {stop_reason}; dropped {dropped} newly created sandbox(es): pool_name={pool_name}{error_detail}"
+        )
     if created > 0:
         logger.debug(
             f"Async reconcile created {created} sandboxes: pool_name={pool_name}"
@@ -167,6 +230,33 @@ async def _shrink_excess_idle(
     logger.debug(
         f"Async reconcile shrunk {removed} idle sandbox(es): pool_name={pool_name}"
     )
+
+
+async def _cleanup_unhandled_tasks(
+    *,
+    tasks: set[asyncio.Future[str | None]],
+    state_store: AsyncPoolStateStore,
+    pool_name: str,
+    on_discard_sandbox: Callable[[str], Awaitable[None]],
+) -> None:
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    discarded = 0
+    for sandbox_id in results:
+        if isinstance(sandbox_id, BaseException) or sandbox_id is None:
+            continue
+        try:
+            await state_store.remove_idle(pool_name, sandbox_id)
+        except Exception:
+            pass
+        await _discard(on_discard_sandbox, sandbox_id)
+        discarded += 1
+    if discarded > 0:
+        logger.warning(
+            f"Async reconcile interrupted; discarded {discarded} uncommitted sandbox(es): pool_name={pool_name}"
+        )
 
 
 async def _discard(

--- a/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from concurrent.futures import Executor, wait
+from concurrent.futures import CancelledError, Executor, as_completed
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
@@ -146,48 +146,73 @@ def _run_primary_replenish_once(
         return
 
     futures = [warmup_executor.submit(create_one) for _ in range(to_create)]
-    wait(futures)
-    created_ids: list[str] = []
     failure_count = 0
     last_error: str | None = None
-    for future in futures:
+    created = 0
+    commit_failed = False
+    commit_error: str | None = None
+    accept_commits = True
+    dropped = 0
+    stop_reason: str | None = None
+    for future in as_completed(futures):
         try:
             sandbox_id = future.result()
-            if sandbox_id is not None:
-                created_ids.append(sandbox_id)
-            else:
+            if sandbox_id is None:
                 failure_count += 1
                 last_error = None
+                continue
+        except CancelledError:
+            failure_count += 1
+            last_error = "warmup future cancelled"
+            continue
         except Exception as exc:
             failure_count += 1
             last_error = str(exc)
-    reconcile_state.record_failures(failure_count, last_error)
+            continue
 
-    created = 0
-    for index, sandbox_id in enumerate(created_ids):
-        if not state_store.renew_primary_lock(pool_name, owner_id, ttl):
-            for orphaned_id in created_ids[index:]:
-                _discard(on_discard_sandbox, orphaned_id)
-            logger.warning(
-                f"Reconcile lost primary lock before put_idle; dropped {len(created_ids) - index} newly created sandbox(es): pool_name={pool_name}"
-            )
-            return
+        if not accept_commits:
+            _discard(on_discard_sandbox, sandbox_id)
+            dropped += 1
+            continue
+        try:
+            lock_renewed = state_store.renew_primary_lock(pool_name, owner_id, ttl)
+        except Exception as exc:
+            lock_renewed = False
+            commit_failed = True
+            commit_error = str(exc)
+            stop_reason = "primary lock renewal failed"
+        if not lock_renewed:
+            accept_commits = False
+            stop_reason = stop_reason or "primary lock lost"
+            _discard(on_discard_sandbox, sandbox_id)
+            dropped += 1
+            continue
         try:
             state_store.put_idle(pool_name, sandbox_id)
             created += 1
-            reconcile_state.record_success()
         except Exception as exc:
-            reconcile_state.record_failure(str(exc))
-            for orphaned_id in created_ids[index:]:
-                try:
-                    state_store.remove_idle(pool_name, orphaned_id)
-                except Exception:
-                    pass
-                _discard(on_discard_sandbox, orphaned_id)
-            logger.warning(
-                f"Reconcile put_idle failed; dropped {len(created_ids) - index} newly created sandbox(es): pool_name={pool_name} error={exc}"
-            )
-            return
+            accept_commits = False
+            stop_reason = "commit failed"
+            commit_failed = True
+            commit_error = str(exc)
+            try:
+                state_store.remove_idle(pool_name, sandbox_id)
+            except Exception:
+                pass
+            _discard(on_discard_sandbox, sandbox_id)
+            dropped += 1
+
+    reconcile_state.record_failures(failure_count, last_error)
+    if created > 0:
+        reconcile_state.record_success()
+    if commit_failed:
+        reconcile_state.record_failure(commit_error)
+
+    if dropped > 0:
+        error_detail = f" error={commit_error}" if commit_error else ""
+        logger.warning(
+            f"Reconcile {stop_reason}; dropped {dropped} newly created sandbox(es): pool_name={pool_name}{error_detail}"
+        )
     if created > 0:
         logger.debug(f"Reconcile created {created} sandboxes: pool_name={pool_name}")
 

--- a/sdks/sandbox/python/tests/test_pool_async.py
+++ b/sdks/sandbox/python/tests/test_pool_async.py
@@ -216,6 +216,128 @@ async def test_async_reconcile_batch_failures_only_advance_backoff_once() -> Non
 
 
 @pytest.mark.asyncio
+async def test_async_reconcile_commits_fast_warmup_before_slow_peer_finishes() -> (
+    None
+):
+    store = InMemoryAsyncPoolStateStore()
+    config = AsyncPoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=2,
+        warmup_concurrency=2,
+        state_store=store,
+        connection_config=ConnectionConfig(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    )
+    state = ReconcileState(degraded_threshold=3)
+    slow_started = asyncio.Event()
+    release_slow = asyncio.Event()
+    calls = 0
+
+    async def create_one() -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            slow_started.set()
+            await release_slow.wait()
+            return "slow"
+        await slow_started.wait()
+        return "fast"
+
+    reconcile_task = asyncio.create_task(
+        run_async_reconcile_tick(
+            config=config,
+            state_store=store,
+            create_one=create_one,
+            on_discard_sandbox=_noop_discard,
+            reconcile_state=state,
+        )
+    )
+
+    async def fast_is_idle() -> bool:
+        return (await store.snapshot_counters("pool")).idle_count == 1
+
+    try:
+        await asyncio.wait_for(slow_started.wait(), timeout=2)
+        await _eventually(fast_is_idle)
+        assert not reconcile_task.done()
+        assert await store.try_take_idle("pool") == "fast"
+    finally:
+        release_slow.set()
+        await asyncio.wait_for(reconcile_task, timeout=2)
+
+    assert await store.try_take_idle("pool") == "slow"
+
+
+@pytest.mark.asyncio
+async def test_async_reconcile_cancellation_discards_uncommitted_warmup() -> None:
+    store = InMemoryAsyncPoolStateStore()
+    config = AsyncPoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=2,
+        warmup_concurrency=2,
+        state_store=store,
+        connection_config=ConnectionConfig(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    )
+    state = ReconcileState(degraded_threshold=3)
+    slow_started = asyncio.Event()
+    discard_started = asyncio.Event()
+    release_discard = asyncio.Event()
+    discarded: list[str] = []
+    calls = 0
+
+    async def create_one() -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            slow_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                return "late"
+        await slow_started.wait()
+        return "fast"
+
+    async def discard(sandbox_id: str) -> None:
+        discard_started.set()
+        await release_discard.wait()
+        discarded.append(sandbox_id)
+
+    reconcile_task = asyncio.create_task(
+        run_async_reconcile_tick(
+            config=config,
+            state_store=store,
+            create_one=create_one,
+            on_discard_sandbox=discard,
+            reconcile_state=state,
+        )
+    )
+
+    async def fast_is_idle() -> bool:
+        return (await store.snapshot_counters("pool")).idle_count == 1
+
+    try:
+        await asyncio.wait_for(slow_started.wait(), timeout=2)
+        await _eventually(fast_is_idle)
+        reconcile_task.cancel()
+        await asyncio.wait_for(discard_started.wait(), timeout=2)
+        reconcile_task.cancel()
+        release_discard.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(reconcile_task, timeout=2)
+    finally:
+        release_discard.set()
+        reconcile_task.cancel()
+        await asyncio.gather(reconcile_task, return_exceptions=True)
+
+    assert await store.try_take_idle("pool") == "fast"
+    assert await store.try_take_idle("pool") is None
+    assert discarded == ["late"]
+
+
+@pytest.mark.asyncio
 async def test_async_acquire_fail_fast_stale_idle_raises_and_kills_candidate() -> None:
     store = InMemoryAsyncPoolStateStore()
     await store.put_idle("pool", "stale-1")

--- a/sdks/sandbox/python/tests/test_pool_sync.py
+++ b/sdks/sandbox/python/tests/test_pool_sync.py
@@ -98,6 +98,72 @@ def test_reconcile_batch_failures_only_advance_backoff_once() -> None:
     )
 
 
+def test_reconcile_commits_fast_warmup_before_slow_peer_finishes() -> None:
+    store = InMemoryPoolStateStore()
+    config = PoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=2,
+        warmup_concurrency=2,
+        state_store=store,
+        connection_config=ConnectionConfigSync(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    )
+    state = ReconcileState(degraded_threshold=3)
+    slow_started = threading.Event()
+    release_slow = threading.Event()
+    reconcile_finished = threading.Event()
+    reconcile_errors: list[BaseException] = []
+    call_lock = threading.Lock()
+    calls = 0
+
+    def create_one() -> str:
+        nonlocal calls
+        with call_lock:
+            calls += 1
+            call = calls
+        if call == 1:
+            slow_started.set()
+            if not release_slow.wait(timeout=2):
+                raise TimeoutError("slow warmup was never released")
+            return "slow"
+        if not slow_started.wait(timeout=2):
+            raise TimeoutError("slow warmup never started")
+        return "fast"
+
+    def reconcile(warmup_executor: ThreadPoolExecutor) -> None:
+        try:
+            run_reconcile_tick(
+                config=config,
+                state_store=store,
+                create_one=create_one,
+                on_discard_sandbox=lambda _sandbox_id: None,
+                reconcile_state=state,
+                warmup_executor=warmup_executor,
+            )
+        except BaseException as exc:
+            reconcile_errors.append(exc)
+        finally:
+            reconcile_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        reconcile_thread = threading.Thread(target=reconcile, args=(executor,))
+        reconcile_thread.start()
+        try:
+            assert slow_started.wait(timeout=2)
+            _eventually(lambda: store.snapshot_counters("pool").idle_count == 1)
+            assert not reconcile_finished.is_set()
+            assert store.try_take_idle("pool") == "fast"
+        finally:
+            release_slow.set()
+            reconcile_thread.join(timeout=2)
+            assert not reconcile_thread.is_alive()
+
+    assert reconcile_finished.is_set()
+    assert not reconcile_errors, reconcile_errors
+    assert store.try_take_idle("pool") == "slow"
+
+
 def test_acquire_fail_fast_empty_raises_pool_empty() -> None:
     pool = _create_pool(max_idle=0)
     pool.start()


### PR DESCRIPTION
# Summary
- publish each Python SDK pool warmup to the idle pool as soon as that sandbox is ready, instead of waiting for the whole batch
- preserve primary-lock validation and discard uncommitted warmups after lock loss, commit failure, or cancellation
- cover sync and async behavior with focused regression tests and document the incremental availability semantics

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [x] e2e / manual verification

Validation performed:
- `uv run ruff check`
- `uv run pyright`
- `uv run pytest tests/ -v`
- `uv build`
- docs build
- Docker/Redis Pool E2E: `41 passed in 152.27s` across sync and async suites

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered