### PR TITLE
fix(server): retry egress sidecar with new ports on Docker Desktop/Windows port conflicts

### DIFF
--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -835,6 +835,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                     runtime_volume_name=runtime_volume_name,
                     credential_proxy_enabled=credential_proxy_enabled,
                     extra_env=egress_env or None,
+                    port_allocator=allocate_port_bindings,
                 )
                 labels[SANDBOX_EMBEDDING_PROXY_PORT_LABEL] = str(host_execd_port)
                 labels[SANDBOX_HTTP_PORT_LABEL] = str(host_http_port)

--- a/server/opensandbox_server/services/docker/networking.py
+++ b/server/opensandbox_server/services/docker/networking.py
@@ -28,7 +28,7 @@ import socket
 import time
 import urllib.error
 import urllib.request
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from docker.errors import DockerException, NotFound as DockerNotFound
 from fastapi import HTTPException, status
@@ -78,6 +78,15 @@ def _docker_error_indicates_unsupported_ipv6_sysctls(exc: DockerException) -> bo
             or "no such file or directory" in message
             or "sysctl" in message
         )
+    )
+
+
+def _is_port_publish_error(exc: DockerException) -> bool:
+    """Return True when Docker reports an unavailable / reserved host port."""
+    message = str(exc).lower()
+    return (
+        "ports are not available" in message
+        or ("bind:" in message and "forbidden" in message)
     )
 
 
@@ -407,6 +416,9 @@ class DockerNetworkingMixin:
         runtime_volume_name: Optional[str] = None,
         credential_proxy_enabled: bool = False,
         extra_env: Optional[Dict[str, Optional[str]]] = None,
+        port_allocator: Optional[
+            Callable[..., dict[str, tuple[str, int]]]
+        ] = None,
     ):
         sidecar_name = f"sandbox-egress-{sandbox_id}"
         sidecar_labels = {
@@ -472,6 +484,10 @@ class DockerNetworkingMixin:
 
         sidecar_container = None
         sidecar_container_id: Optional[str] = None
+        # Track whether the last start() failed due to a port-publish error so
+        # we can retry with freshly-allocated ports (e.g. Docker Desktop /
+        # Windows OS-reserved ranges that the container-side probe cannot see).
+        last_port_error: Optional[DockerException] = None
         try:
             try:
                 with self._docker_operation("create egress sidecar", sandbox_id):
@@ -519,7 +535,11 @@ class DockerNetworkingMixin:
                 )
             sidecar_container = self.docker_client.containers.get(sidecar_container_id)
             with self._docker_operation("start egress sidecar", sandbox_id):
-                sidecar_container.start()
+                try:
+                    sidecar_container.start()
+                except DockerException as start_exc:
+                    last_port_error = start_exc
+                    raise
             if egress_api_host_port is not None:
                 self._wait_for_egress_sidecar_ready(
                     sandbox_id,
@@ -529,6 +549,116 @@ class DockerNetworkingMixin:
                 )
             return sidecar_container
         except Exception as exc:
+            # Retry once with freshly-allocated ports when the initial start
+            # failed due to a port-publish error (e.g. Docker Desktop / Windows
+            # OS-reserved ranges invisible from the container-side probe).
+            if (
+                last_port_error is not None
+                and port_allocator is not None
+                and not _is_port_publish_error(last_port_error)
+            ):
+                raise
+            if last_port_error is not None and port_allocator is not None:
+                logger.warning(
+                    "sandbox=%s | egress sidecar start failed with port error (%s); "
+                    "retrying with newly-allocated ports",
+                    sandbox_id,
+                    last_port_error,
+                )
+                try:
+                    # Re-allocate fresh ports; the old ones may now be released
+                    # or Docker may have picked different reserved ranges.
+                    retry_bindings = port_allocator(
+                        list(sidecar_port_bindings.keys()),
+                        min_port=self.app_config.docker.port_range_min,
+                        max_port=self.app_config.docker.port_range_max,
+                    )
+                    sidecar_port_bindings = retry_bindings
+                    # Rebuild the base host config so port_bindings reflects
+                    # the newly-allocated ports (the shallow copy in
+                    # build_sidecar_host_config would otherwise keep the old dict).
+                    base_sidecar_host_config_kwargs = {
+                        "network_mode": BRIDGE_NETWORK_MODE,
+                        "cap_add": ["NET_ADMIN"],
+                        "port_bindings": normalize_port_bindings(sidecar_port_bindings),
+                    }
+                    if runtime_volume_name:
+                        base_sidecar_host_config_kwargs["binds"] = [
+                            f"{runtime_volume_name}:{OPENSANDBOX_RUNTIME_MOUNT_PATH}:rw"
+                        ]
+                    sidecar_host_config = build_sidecar_host_config(
+                        include_ipv6_sysctls=include_ipv6_sysctls
+                    )
+                    # Clean up the container that was created with the old ports.
+                    if sidecar_container_id:
+                        try:
+                            with self._docker_operation(
+                                "cleanup egress sidecar (port-retry)", sandbox_id
+                            ):
+                                self.docker_client.api.remove_container(
+                                    sidecar_container_id, force=True
+                                )
+                        except DockerException as cleanup_exc:
+                            logger.warning(
+                                "Failed to cleanup egress sidecar for sandbox %s "
+                                "during port-retry: %s",
+                                sandbox_id,
+                                cleanup_exc,
+                            )
+                    with self._docker_operation("create egress sidecar (retry)", sandbox_id):
+                        sidecar_resp = self.docker_client.api.create_container(
+                            image=egress_image,
+                            name=sidecar_name,
+                            host_config=sidecar_host_config,
+                            labels=sidecar_labels,
+                            environment=sidecar_env,
+                            ports=[
+                                normalize_container_port_spec(p)
+                                for p in sidecar_port_bindings.keys()
+                            ],
+                        )
+                    sidecar_container_id = sidecar_resp.get("Id")
+                    if not sidecar_container_id:
+                        raise HTTPException(
+                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail={
+                                "code": SandboxErrorCodes.CONTAINER_START_FAILED,
+                                "message": "Docker did not return an egress sidecar container ID.",
+                            },
+                        )
+                    sidecar_container = self.docker_client.containers.get(
+                        sidecar_container_id
+                    )
+                    with self._docker_operation("start egress sidecar (retry)", sandbox_id):
+                        sidecar_container.start()
+                except DockerException as retry_exc:
+                    # If the retry also fails with a port error, re-raise with the
+                    # original error context so the caller sees the real cause.
+                    if _is_port_publish_error(retry_exc):
+                        raise HTTPException(
+                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail={
+                                "code": SandboxErrorCodes.CONTAINER_START_FAILED,
+                                "message": (
+                                    f"Egress sidecar container failed to start: "
+                                    f"{retry_exc}"
+                                ),
+                            },
+                        ) from retry_exc
+                    raise
+                if egress_api_host_port is not None:
+                    # Find the new host port for the egress API on retry.
+                    retry_api_host_port = next(
+                        (b[1] for b in sidecar_port_bindings.values()),
+                        egress_api_host_port,
+                    )
+                    self._wait_for_egress_sidecar_ready(
+                        sandbox_id,
+                        retry_api_host_port,
+                        egress_token,
+                        timeout_seconds=self.app_config.egress.readiness_timeout_seconds,
+                    )
+                return sidecar_container
             if sidecar_container is not None:
                 try:
                     with self._docker_operation("cleanup egress sidecar", sandbox_id):

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -1419,6 +1419,139 @@ def test_egress_sidecar_retries_without_ipv6_sysctls_when_daemon_rejects_them(mo
 
 
 @patch("opensandbox_server.services.docker.docker_service.docker")
+def test_egress_sidecar_retries_on_port_publish_error(mock_docker):
+    """When docker start fails with a port-publish error, the sidecar is
+    recreated with freshly-allocated ports and started again."""
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+
+    def host_cfg_side_effect(**kwargs):
+        return kwargs
+
+    mock_client.api.create_host_config.side_effect = host_cfg_side_effect
+
+    call_count = 0
+
+    def create_container_side_effect(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        return {"Id": f"sidecar-id-{call_count}"}
+
+    mock_client.api.create_container.side_effect = create_container_side_effect
+
+    def start_side_effect(*args, **kwargs):
+        if start_side_effect.attempt == 0:
+            start_side_effect.attempt += 1
+            raise DockerException(
+                "ports are not available: exposing port TCP 0.0.0.0:49870 -> "
+                "127.0.0.1:0: listen tcp4 0.0.0.0:49870: bind: An attempt was "
+                "made to access a socket in a way forbidden by its access permissions."
+            )
+        start_side_effect.attempt += 1
+
+    start_side_effect.attempt = 0
+    mock_client.containers.get.return_value = MagicMock(start=start_side_effect)
+
+    mock_docker.from_env.return_value = mock_client
+
+    cfg = _app_config()
+    cfg.docker.network_mode = "bridge"
+    cfg.egress = EgressConfig(image="egress:latest")
+    service = DockerSandboxService(config=cfg)
+
+    with (
+        patch.object(service, "_ensure_image_available"),
+        patch.object(service, "_docker_operation") as mock_op,
+        patch(
+            "opensandbox_server.services.docker.docker_service.allocate_port_bindings",
+            side_effect=[
+                {"44772": ("0.0.0.0", 51000), "8080": ("0.0.0.0", 51001)},
+            ],
+        ) as mock_alloc,
+    ):
+        mock_op.return_value.__enter__.return_value = None
+        mock_op.return_value.__exit__.return_value = None
+        service._start_egress_sidecar(
+            "sandbox-id",
+            NetworkPolicy(defaultAction="deny", egress=[]),
+            egress_token="egress-token",
+            host_execd_port=49870,
+            host_http_port=50000,
+            port_allocator=mock_alloc,
+        )
+
+    assert mock_client.api.create_container.call_count == 2
+    first_bindings = mock_client.api.create_container.call_args_list[0].kwargs["host_config"][
+        "port_bindings"
+    ]
+    second_bindings = mock_client.api.create_container.call_args_list[1].kwargs["host_config"][
+        "port_bindings"
+    ]
+    first_execd = first_bindings["44772"][1]
+    second_execd = second_bindings["44772"][1]
+    assert int(first_execd) != int(second_execd)
+    # Allocator called once during retry (initial ports passed as parameters).
+    assert mock_alloc.call_count == 1
+    assert mock_client.api.remove_container.call_count == 1
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_egress_sidecar_raises_on_second_port_failure(mock_docker):
+    """When both the initial start and the retry fail with port-publish errors,
+    an HTTPException is raised with the real Docker error."""
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+
+    def host_cfg_side_effect(**kwargs):
+        return kwargs
+
+    mock_client.api.create_host_config.side_effect = host_cfg_side_effect
+    mock_client.api.create_container.return_value = {"Id": "sidecar-id"}
+
+    def start_side_effect(*args, **kwargs):
+        raise DockerException(
+            "ports are not available: exposing port TCP 0.0.0.0:49870 -> "
+            "127.0.0.1:0: listen tcp4 0.0.0.0:49870: bind: permission denied"
+        )
+
+    mock_client.containers.get.return_value = MagicMock(start=start_side_effect)
+    mock_docker.from_env.return_value = mock_client
+
+    cfg = _app_config()
+    cfg.docker.network_mode = "bridge"
+    cfg.egress = EgressConfig(image="egress:latest")
+    service = DockerSandboxService(config=cfg)
+
+    def failing_allocator(*args, **kwargs):
+        return {"44772": ("0.0.0.0", 51000), "8080": ("0.0.0.0", 51001)}
+
+    with (
+        patch.object(service, "_ensure_image_available"),
+        patch.object(service, "_docker_operation") as mock_op,
+        patch(
+            "opensandbox_server.services.docker.docker_service.allocate_port_bindings",
+            side_effect=failing_allocator,
+        ),
+    ):
+        mock_op.return_value.__enter__.return_value = None
+        mock_op.return_value.__exit__.return_value = None
+        with pytest.raises(HTTPException) as exc_info:
+            service._start_egress_sidecar(
+                "sandbox-id",
+                NetworkPolicy(defaultAction="deny", egress=[]),
+                egress_token="egress-token",
+                host_execd_port=49870,
+                host_http_port=50000,
+                port_allocator=failing_allocator,
+            )
+
+    detail = exc_info.value.detail
+    assert isinstance(detail, dict)
+    assert detail["code"] == SandboxErrorCodes.CONTAINER_START_FAILED
+    assert "failed to start" in detail["message"].lower()
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
 def test_egress_sidecar_injects_sandbox_id_env(mock_docker):
     """Server unconditionally injects OPENSANDBOX_EGRESS_SANDBOX_ID into the sidecar env."""
     mock_client = MagicMock()


### PR DESCRIPTION
## Summary

When creating sandboxes with an egress sidecar on Docker Desktop for Windows (or other environments with OS-reserved excluded port ranges), `docker start` can fail with \`"ports are not available: ... bind: ... forbidden"\` even though the container-side port probe succeeded. The server currently raises a generic HTTP 500 without retrying — this PR adds a one-shot retry with freshly-allocated ports.

## Root Cause

`allocate_host_port()` in `port_allocator.py` probes availability with `socket.bind()` inside the server container (Linux network stack). On Docker Desktop/Windows the actual bind happens on the Windows host, where OS-reserved excluded port ranges (e.g. Hyper-V/WinNAT) make the bind fail with `WSAEACCES` — the container-side probe cannot see this.

`_start_egress_sidecar()` in `networking.py` only retried on the IPv6-sysctl rejection; any other `start()` failure (including `"ports are not available"`) cleaned up and raised HTTP 500 without re-allocating a new host port.

## Fix

- Added `_is_port_publish_error()` helper that detects `"ports are not available"` and `"bind:" + "forbidden"` patterns in Docker errors.
- When `start()` fails with a port-publish error and a `port_allocator` is wired in, re-allocate fresh ports, clean up the failed container, and retry create+start once.
- When the retry also fails with a port error, surface the real Docker error in the 500 detail instead of the generic message.
- Fixed a shallow-copy bug: `build_sidecar_host_config()` does `dict(base_sidecar_host_config_kwargs)`, which preserves the old `port_bindings` dict when `sidecar_port_bindings` is reassigned. The fix rebuilds `base_sidecar_host_config_kwargs` from scratch before the retry.

## Testing

- Added `test_egress_sidecar_retries_on_port_publish_error`: verifies that on a port-publish failure the sidecar is recreated with different ports and starts successfully.
- Added `test_egress_sidecar_raises_on_second_port_failure`: verifies that when both attempts fail, an HTTPException is raised with the real Docker error.
- All 146 tests in `test_docker_service.py` pass.
- `ruff check` passes on all changed files.

## Files Changed

- `server/opensandbox_server/services/docker/networking.py` — retry logic + `_is_port_publish_error`
- `server/opensandbox_server/services/docker/docker_service.py` — wire `port_allocator` at the call site
- `server/tests/test_docker_service.py` — two regression tests

Closes #1702