### PR TITLE
chore(python): bump user agent for 0.1.17.dev0

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -67,7 +67,7 @@ class ConnectionConfig(BaseModel):
         default=False, description="Enable debug logging for HTTP requests"
     )
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.16", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.17.dev0", description="User agent string"
     )
     headers: dict[str, str] = Field(
         default_factory=dict, description="User defined headers"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -55,7 +55,7 @@ class ConnectionConfigSync(BaseModel):
     )
     debug: bool = Field(default=False, description="Enable debug logging for HTTP requests")
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.16", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.17.dev0", description="User agent string"
     )
     headers: dict[str, str] = Field(default_factory=dict, description="User defined headers")
 

--- a/sdks/sandbox/python/tests/test_connection_config.py
+++ b/sdks/sandbox/python/tests/test_connection_config.py
@@ -22,8 +22,8 @@ from opensandbox.config import ConnectionConfig, ConnectionConfigSync
 # Regression: the default User-Agent version is hand-maintained and must be
 # bumped together with the package version. Update this expectation when releasing.
 def test_default_user_agent_matches_package_version() -> None:
-    assert ConnectionConfig().user_agent == "OpenSandbox-Python-SDK/0.1.16"
-    assert ConnectionConfigSync().user_agent == "OpenSandbox-Python-SDK/0.1.16"
+    assert ConnectionConfig().user_agent == "OpenSandbox-Python-SDK/0.1.17.dev0"
+    assert ConnectionConfigSync().user_agent == "OpenSandbox-Python-SDK/0.1.17.dev0"
 
 
 def test_protocol_validation() -> None:


### PR DESCRIPTION
# Summary
- update the default async Python SDK User-Agent to `OpenSandbox-Python-SDK/0.1.17.dev0`
- keep the synchronous default aligned
- update the regression test before publishing the `0.1.17.dev0` prerelease package

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Validation performed:
- `uv run ruff check src/opensandbox/config/connection.py src/opensandbox/config/connection_sync.py tests/test_connection_config.py`
- `uv run pyright`
- `uv run pytest tests/test_connection_config.py -v` (`6 passed`)
- `uv build`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered