### PR TITLE
fix(execd): bound command output retention

### DIFF
--- a/components/execd/main.go
+++ b/components/execd/main.go
@@ -124,7 +124,10 @@ func run() int {
 	ctrl := controller.InitCodeRunner()
 	commandJanitorCtx, stopCommandJanitor := context.WithCancel(context.Background())
 	defer stopCommandJanitor()
-	ctrl.StartCommandOutputJanitor(commandJanitorCtx)
+	if err := ctrl.StartCommandOutputJanitor(commandJanitorCtx); err != nil {
+		log.Error("command output: %v", err)
+		return 1
+	}
 
 	// Always store probe result for capabilities endpoint.
 	controller.InitIsolatedProbe(&isolationProbe)

--- a/components/execd/main.go
+++ b/components/execd/main.go
@@ -122,6 +122,9 @@ func run() int {
 	}
 
 	ctrl := controller.InitCodeRunner()
+	commandJanitorCtx, stopCommandJanitor := context.WithCancel(context.Background())
+	defer stopCommandJanitor()
+	ctrl.StartCommandOutputJanitor(commandJanitorCtx)
 
 	// Always store probe result for capabilities endpoint.
 	controller.InitIsolatedProbe(&isolationProbe)

--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -153,10 +153,13 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	if err != nil {
 		return fmt.Errorf("failed to get stdlog descriptor: %w", err)
 	}
-	defer stdout.Close()
-	defer stderr.Close()
 	stdoutPath := c.stdoutFileName(session)
 	stderrPath := c.stderrFileName(session)
+	defer func() {
+		_ = stdout.Close()
+		_ = stderr.Close()
+		removeCommandOutputFiles(stdoutPath, stderrPath)
+	}()
 
 	startAt := time.Now()
 	log.Info("received command: %v", log.SanitizeCommand(request.Code))

--- a/components/execd/pkg/runtime/command_cleanup_test.go
+++ b/components/execd/pkg/runtime/command_cleanup_test.go
@@ -50,6 +50,60 @@ func TestRunCommandRemovesForegroundOutputFiles(t *testing.T) {
 	require.False(t, status.Running)
 }
 
+func TestCommandOutputDirRejectsSymlink(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("symlink creation requires additional privileges on Windows")
+	}
+
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	target := t.TempDir()
+	c := NewController("", "")
+	require.NoError(t, os.Symlink(target, c.commandOutputDir()))
+
+	_, err := c.combinedOutputDescriptor("test-session")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "without following symlinks")
+	require.NoFileExists(t, filepath.Join(target, "test-session.output"))
+}
+
+func TestCommandOutputDirRejectsUnsafePermissions(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Unix permission validation does not apply on Windows")
+	}
+
+	t.Setenv("TMPDIR", t.TempDir())
+	c := NewController("", "")
+	require.NoError(t, os.Mkdir(c.commandOutputDir(), 0o777))
+	require.NoError(t, os.Chmod(c.commandOutputDir(), 0o777))
+
+	_, err := c.combinedOutputDescriptor("test-session")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsafe permissions")
+}
+
+func TestSeekBackgroundCommandOutputRejectsSymlink(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("symlink creation requires additional privileges on Windows")
+	}
+
+	tempDir := t.TempDir()
+	target := filepath.Join(tempDir, "secret")
+	link := filepath.Join(tempDir, "command.output")
+	require.NoError(t, os.WriteFile(target, []byte("must-not-leak"), 0o600))
+	require.NoError(t, os.Symlink(target, link))
+	c := NewController("", "")
+	c.storeCommandKernel("session", &commandKernel{
+		stdoutPath:   link,
+		stderrPath:   link,
+		isBackground: true,
+	})
+
+	output, _, err := c.SeekBackgroundCommandOutput("session", 0)
+	require.Error(t, err)
+	require.Empty(t, output)
+}
+
 func TestCleanupOrphanedCommandOutputsIsScopedAndAgeBounded(t *testing.T) {
 	if goruntime.GOOS == "windows" {
 		t.Skip("TMPDIR behavior differs on Windows")

--- a/components/execd/pkg/runtime/command_cleanup_test.go
+++ b/components/execd/pkg/runtime/command_cleanup_test.go
@@ -1,0 +1,139 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunCommandRemovesForegroundOutputFiles(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("shell command and TMPDIR behavior differ on Windows")
+	}
+
+	t.Setenv("TMPDIR", t.TempDir())
+	c := NewController("", "")
+	var session string
+	req := &ExecuteCodeRequest{
+		Code: "printf cleanup-proof",
+		Hooks: ExecuteResultHook{
+			OnExecuteInit:     func(id string) { session = id },
+			OnExecuteComplete: func(time.Duration) {},
+		},
+	}
+
+	require.NoError(t, c.runCommand(context.Background(), req))
+	require.NotEmpty(t, session)
+	require.NoFileExists(t, c.stdoutFileName(session))
+	require.NoFileExists(t, c.stderrFileName(session))
+	status, err := c.GetCommandStatus(session)
+	require.NoError(t, err)
+	require.False(t, status.Running)
+}
+
+func TestCleanupOrphanedCommandOutputsIsScopedAndAgeBounded(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("TMPDIR behavior differs on Windows")
+	}
+
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	c := NewController("", "")
+	now := time.Now()
+	old := now.Add(-commandOutputRetention - time.Minute)
+	recent := now.Add(-time.Minute)
+
+	legacyOld := filepath.Join(tempDir, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.stdout")
+	legacyRecent := filepath.Join(tempDir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.stderr")
+	unrelated := filepath.Join(tempDir, "notes.stdout")
+	symlink := filepath.Join(tempDir, "cccccccccccccccccccccccccccccccc.stdout")
+	require.NoError(t, os.WriteFile(legacyOld, []byte("old"), 0o600))
+	require.NoError(t, os.WriteFile(legacyRecent, []byte("recent"), 0o600))
+	require.NoError(t, os.WriteFile(unrelated, []byte("keep"), 0o600))
+	require.NoError(t, os.Symlink(unrelated, symlink))
+	require.NoError(t, os.Chtimes(legacyOld, old, old))
+	require.NoError(t, os.Chtimes(legacyRecent, recent, recent))
+
+	require.NoError(t, os.MkdirAll(c.commandOutputDir(), 0o700))
+	orphan := filepath.Join(c.commandOutputDir(), "dddddddddddddddddddddddddddddddd.output")
+	running := filepath.Join(c.commandOutputDir(), "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.output")
+	require.NoError(t, os.WriteFile(orphan, []byte("orphan"), 0o600))
+	require.NoError(t, os.WriteFile(running, []byte("running"), 0o600))
+	require.NoError(t, os.Chtimes(orphan, old, old))
+	require.NoError(t, os.Chtimes(running, old, old))
+	c.storeCommandKernel("running", &commandKernel{
+		stdoutPath:   running,
+		stderrPath:   running,
+		running:      true,
+		isBackground: true,
+	})
+
+	c.cleanupOrphanedCommandOutputs(now)
+
+	require.NoFileExists(t, legacyOld)
+	require.FileExists(t, legacyRecent)
+	require.FileExists(t, unrelated)
+	_, err := os.Lstat(symlink)
+	require.NoError(t, err)
+	require.NoFileExists(t, orphan)
+	require.FileExists(t, running)
+}
+
+func TestCleanupFinishedCommandsRetainsRunningAndRecentCommands(t *testing.T) {
+	tempDir := t.TempDir()
+	c := NewController("", "")
+	now := time.Now()
+	oldFinished := now.Add(-commandOutputRetention - time.Minute)
+	recentFinished := now.Add(-time.Minute)
+
+	oldPath := filepath.Join(tempDir, "old.output")
+	recentPath := filepath.Join(tempDir, "recent.output")
+	runningPath := filepath.Join(tempDir, "running.output")
+	for _, path := range []string{oldPath, recentPath, runningPath} {
+		require.NoError(t, os.WriteFile(path, []byte("output"), 0o600))
+	}
+
+	c.storeCommandKernel("old", &commandKernel{
+		stdoutPath: oldPath,
+		stderrPath: oldPath,
+		finishedAt: &oldFinished,
+	})
+	c.storeCommandKernel("recent", &commandKernel{
+		stdoutPath: recentPath,
+		stderrPath: recentPath,
+		finishedAt: &recentFinished,
+	})
+	c.storeCommandKernel("running", &commandKernel{
+		stdoutPath: runningPath,
+		stderrPath: runningPath,
+		running:    true,
+	})
+
+	c.cleanupFinishedCommands(now.Add(-commandOutputRetention))
+
+	require.NoFileExists(t, oldPath)
+	require.FileExists(t, recentPath)
+	require.FileExists(t, runningPath)
+	require.Nil(t, c.getCommandKernel("old"))
+	require.NotNil(t, c.getCommandKernel("recent"))
+	require.NotNil(t, c.getCommandKernel("running"))
+}

--- a/components/execd/pkg/runtime/command_common.go
+++ b/components/execd/pkg/runtime/command_common.go
@@ -25,8 +25,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alibaba/opensandbox/execd/pkg/log"
 	"github.com/alibaba/opensandbox/internal/safego"
+
+	"github.com/alibaba/opensandbox/execd/pkg/log"
 )
 
 const (

--- a/components/execd/pkg/runtime/command_common.go
+++ b/components/execd/pkg/runtime/command_common.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -78,17 +77,18 @@ func (c *Controller) storeCommandKernel(sessionID string, kernel *commandKernel)
 // continue to work even after the /tmp directory has been removed and recreated.
 func (c *Controller) stdLogDescriptor(session string) (io.WriteCloser, io.WriteCloser, error) {
 	logDir := c.commandOutputDir()
-	if err := os.MkdirAll(logDir, 0o700); err != nil {
-		return nil, nil, fmt.Errorf("failed to create temp dir %s: %w", logDir, err)
+	if err := ensurePrivateCommandOutputDir(logDir); err != nil {
+		return nil, nil, err
 	}
 
-	stdout, err := os.OpenFile(c.stdoutFileName(session), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	stdout, err := openNewCommandOutput(c.stdoutFileName(session))
 	if err != nil {
 		return nil, nil, err
 	}
-	stderr, err := os.OpenFile(c.stderrFileName(session), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	stderr, err := openNewCommandOutput(c.stderrFileName(session))
 	if err != nil {
-		stdout.Close()
+		_ = stdout.Close()
+		removeCommandOutputFiles(c.stdoutFileName(session))
 		return nil, nil, err
 	}
 
@@ -97,10 +97,10 @@ func (c *Controller) stdLogDescriptor(session string) (io.WriteCloser, io.WriteC
 
 func (c *Controller) combinedOutputDescriptor(session string) (io.WriteCloser, error) {
 	logDir := c.commandOutputDir()
-	if err := os.MkdirAll(logDir, 0o700); err != nil {
-		return nil, fmt.Errorf("failed to create temp dir %s: %w", logDir, err)
+	if err := ensurePrivateCommandOutputDir(logDir); err != nil {
+		return nil, err
 	}
-	return os.OpenFile(c.combinedOutputFileName(session), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	return openNewCommandOutput(c.combinedOutputFileName(session))
 }
 
 func (c *Controller) commandOutputDir() string {
@@ -207,13 +207,23 @@ func (c *Controller) cleanupFinishedCommands(cutoff time.Time) {
 func (c *Controller) cleanupOrphanedCommandOutputs(now time.Time) {
 	cutoff := now.Add(-commandOutputRetention)
 	protected := c.protectedCommandOutputPaths()
-	cleanupStaleCommandOutputFiles(c.commandOutputDir(), cutoff, legacyCommandOutputPattern.MatchString, protected)
+	if err := ensurePrivateCommandOutputDir(c.commandOutputDir()); err != nil {
+		log.Warn("skip private command output cleanup: %v", err)
+	} else {
+		cleanupStaleCommandOutputFiles(c.commandOutputDir(), cutoff, legacyCommandOutputPattern.MatchString, protected)
+	}
 	cleanupStaleCommandOutputFiles(os.TempDir(), cutoff, legacyCommandOutputPattern.MatchString, nil)
 }
 
 // StartCommandOutputJanitor bounds command metadata and output retention and
 // removes legacy files that older execd versions placed directly in /tmp.
-func (c *Controller) StartCommandOutputJanitor(ctx context.Context) {
+func (c *Controller) StartCommandOutputJanitor(ctx context.Context) error {
+	// Create and validate the private directory synchronously, before init mode
+	// launches the sandbox workload. A workload may otherwise pre-create the
+	// fixed temp path and make execd follow an unsafe directory or symlink.
+	if err := ensurePrivateCommandOutputDir(c.commandOutputDir()); err != nil {
+		return err
+	}
 	safego.Go(func() {
 		c.cleanupOrphanedCommandOutputs(time.Now())
 		c.cleanupFinishedCommands(time.Now().Add(-commandOutputRetention))
@@ -229,6 +239,7 @@ func (c *Controller) StartCommandOutputJanitor(ctx context.Context) {
 			}
 		}
 	})
+	return nil
 }
 
 // readFromPos streams new content from a file starting at startPos.

--- a/components/execd/pkg/runtime/command_common.go
+++ b/components/execd/pkg/runtime/command_common.go
@@ -17,13 +17,26 @@ package runtime
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"time"
+
+	"github.com/alibaba/opensandbox/execd/pkg/log"
+	"github.com/alibaba/opensandbox/internal/safego"
 )
+
+const (
+	commandOutputDirName       = "opensandbox-execd"
+	commandOutputRetention     = 24 * time.Hour
+	commandOutputSweepInterval = time.Hour
+)
+
+var legacyCommandOutputPattern = regexp.MustCompile(`^[0-9a-f]{32}\.(stdout|stderr|output)$`)
 
 // tailStdPipe streams appended log data until the process finishes.
 func (c *Controller) tailStdPipe(file string, onExecute func(text string), done <-chan struct{}) {
@@ -64,16 +77,16 @@ func (c *Controller) storeCommandKernel(sessionID string, kernel *commandKernel)
 // It ensures the temp directory exists before opening files, so that commands
 // continue to work even after the /tmp directory has been removed and recreated.
 func (c *Controller) stdLogDescriptor(session string) (io.WriteCloser, io.WriteCloser, error) {
-	logDir := os.TempDir()
-	if err := os.MkdirAll(logDir, 0o755); err != nil {
+	logDir := c.commandOutputDir()
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
 		return nil, nil, fmt.Errorf("failed to create temp dir %s: %w", logDir, err)
 	}
 
-	stdout, err := os.OpenFile(c.stdoutFileName(session), os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	stdout, err := os.OpenFile(c.stdoutFileName(session), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return nil, nil, err
 	}
-	stderr, err := os.OpenFile(c.stderrFileName(session), os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	stderr, err := os.OpenFile(c.stderrFileName(session), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		stdout.Close()
 		return nil, nil, err
@@ -83,25 +96,139 @@ func (c *Controller) stdLogDescriptor(session string) (io.WriteCloser, io.WriteC
 }
 
 func (c *Controller) combinedOutputDescriptor(session string) (io.WriteCloser, error) {
-	logDir := os.TempDir()
-	if err := os.MkdirAll(logDir, 0o755); err != nil {
+	logDir := c.commandOutputDir()
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
 		return nil, fmt.Errorf("failed to create temp dir %s: %w", logDir, err)
 	}
-	return os.OpenFile(c.combinedOutputFileName(session), os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	return os.OpenFile(c.combinedOutputFileName(session), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+}
+
+func (c *Controller) commandOutputDir() string {
+	return filepath.Join(os.TempDir(), commandOutputDirName)
 }
 
 // stdoutFileName constructs the stdout log path.
 func (c *Controller) stdoutFileName(session string) string {
-	return filepath.Join(os.TempDir(), session+".stdout")
+	return filepath.Join(c.commandOutputDir(), session+".stdout")
 }
 
 // stderrFileName constructs the stderr log path.
 func (c *Controller) stderrFileName(session string) string {
-	return filepath.Join(os.TempDir(), session+".stderr")
+	return filepath.Join(c.commandOutputDir(), session+".stderr")
 }
 
 func (c *Controller) combinedOutputFileName(session string) string {
-	return filepath.Join(os.TempDir(), session+".output")
+	return filepath.Join(c.commandOutputDir(), session+".output")
+}
+
+func removeCommandOutputFiles(paths ...string) {
+	seen := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			log.Warn("remove command output %s: %v", path, err)
+		}
+	}
+}
+
+func cleanupStaleCommandOutputFiles(dir string, cutoff time.Time, match func(string) bool, protected map[string]struct{}) {
+	directory, err := os.Open(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn("read command output directory %s: %v", dir, err)
+		}
+		return
+	}
+	defer directory.Close()
+
+	for {
+		entries, readErr := directory.Readdir(256)
+		for _, info := range entries {
+			if !info.Mode().IsRegular() || !match(info.Name()) || !info.ModTime().Before(cutoff) {
+				continue
+			}
+			path := filepath.Join(dir, info.Name())
+			if _, ok := protected[path]; ok {
+				continue
+			}
+			removeCommandOutputFiles(path)
+		}
+		if readErr != nil {
+			if readErr != io.EOF {
+				log.Warn("read command output directory %s: %v", dir, readErr)
+			}
+			return
+		}
+	}
+}
+
+func (c *Controller) protectedCommandOutputPaths() map[string]struct{} {
+	protected := make(map[string]struct{})
+	c.mu.RLock()
+	c.commandClientMap.Range(func(_, value any) bool {
+		kernel, ok := value.(*commandKernel)
+		if !ok {
+			return true
+		}
+		for _, path := range []string{kernel.stdoutPath, kernel.stderrPath} {
+			if path != "" {
+				protected[path] = struct{}{}
+			}
+		}
+		return true
+	})
+	c.mu.RUnlock()
+	return protected
+}
+
+func (c *Controller) cleanupFinishedCommands(cutoff time.Time) {
+	var paths []string
+	c.mu.Lock()
+	c.commandClientMap.Range(func(key, value any) bool {
+		kernel, ok := value.(*commandKernel)
+		if !ok || kernel.running || kernel.finishedAt == nil || !kernel.finishedAt.Before(cutoff) {
+			return true
+		}
+
+		paths = append(paths, kernel.stdoutPath, kernel.stderrPath)
+		c.commandClientMap.Delete(key)
+		return true
+	})
+	c.mu.Unlock()
+	removeCommandOutputFiles(paths...)
+}
+
+func (c *Controller) cleanupOrphanedCommandOutputs(now time.Time) {
+	cutoff := now.Add(-commandOutputRetention)
+	protected := c.protectedCommandOutputPaths()
+	cleanupStaleCommandOutputFiles(c.commandOutputDir(), cutoff, legacyCommandOutputPattern.MatchString, protected)
+	cleanupStaleCommandOutputFiles(os.TempDir(), cutoff, legacyCommandOutputPattern.MatchString, nil)
+}
+
+// StartCommandOutputJanitor bounds command metadata and output retention and
+// removes legacy files that older execd versions placed directly in /tmp.
+func (c *Controller) StartCommandOutputJanitor(ctx context.Context) {
+	safego.Go(func() {
+		c.cleanupOrphanedCommandOutputs(time.Now())
+		c.cleanupFinishedCommands(time.Now().Add(-commandOutputRetention))
+		ticker := time.NewTicker(commandOutputSweepInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case now := <-ticker.C:
+				c.cleanupFinishedCommands(now.Add(-commandOutputRetention))
+				c.cleanupOrphanedCommandOutputs(now)
+			}
+		}
+	})
 }
 
 // readFromPos streams new content from a file starting at startPos.

--- a/components/execd/pkg/runtime/command_output_unix.go
+++ b/components/execd/pkg/runtime/command_output_unix.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func ensurePrivateCommandOutputDir(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create command output parent directory: %w", err)
+	}
+	if err := os.Mkdir(path, 0o700); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("create command output directory %s: %w", path, err)
+	}
+
+	// Open the directory without following the final path component. This makes
+	// the type, owner, and mode checks refer to the object that execd will use,
+	// rather than to a symlink target selected by the sandbox workload.
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open command output directory %s without following symlinks: %w", path, err)
+	}
+	defer unix.Close(fd) //nolint:errcheck
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return fmt.Errorf("stat command output directory %s: %w", path, err)
+	}
+	if stat.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("command output directory %s is owned by uid %d, want %d", path, stat.Uid, os.Geteuid())
+	}
+	if stat.Mode&0o077 != 0 {
+		return fmt.Errorf("command output directory %s has unsafe permissions %#o", path, stat.Mode&0o777)
+	}
+	return nil
+}
+
+func openNewCommandOutput(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create command output file %s: %w", path, err)
+	}
+	return file, nil
+}
+
+func openCommandOutputForRead(path string) (*os.File, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("open command output file %s", path)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("command output file %s is not a regular file", path)
+	}
+	return file, nil
+}

--- a/components/execd/pkg/runtime/command_output_windows.go
+++ b/components/execd/pkg/runtime/command_output_windows.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+)
+
+func ensurePrivateCommandOutputDir(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return fmt.Errorf("create command output directory %s: %w", path, err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat command output directory %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("command output path %s is not a directory", path)
+	}
+	return nil
+}
+
+func openNewCommandOutput(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create command output file %s: %w", path, err)
+	}
+	return file, nil
+}
+
+func openCommandOutputForRead(path string) (*os.File, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("command output file %s is not a regular file", path)
+	}
+	return file, nil
+}

--- a/components/execd/pkg/runtime/command_status.go
+++ b/components/execd/pkg/runtime/command_status.go
@@ -17,7 +17,6 @@ package runtime
 import (
 	"fmt"
 	"io"
-	"os"
 	"time"
 )
 
@@ -94,7 +93,7 @@ func (c *Controller) SeekBackgroundCommandOutput(session string, cursor int64) (
 		return nil, -1, fmt.Errorf("cursor cannot be negative")
 	}
 
-	file, err := os.Open(kernel.stdoutPath)
+	file, err := openCommandOutputForRead(kernel.stdoutPath)
 	if err != nil {
 		return nil, -1, fmt.Errorf("error open combined output file for command %s: %w", session, err)
 	}

--- a/components/execd/pkg/runtime/command_windows.go
+++ b/components/execd/pkg/runtime/command_windows.go
@@ -42,6 +42,13 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	if err != nil {
 		return fmt.Errorf("failed to get stdlog descriptor: %w", err)
 	}
+	stdoutPath := c.stdoutFileName(session)
+	stderrPath := c.stderrFileName(session)
+	defer func() {
+		_ = stdout.Close()
+		_ = stderr.Close()
+		removeCommandOutputFiles(stdoutPath, stderrPath)
+	}()
 
 	startAt := time.Now()
 	log.Info("received command: %v", log.SanitizeCommand(request.Code))
@@ -62,11 +69,11 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	wg.Add(2)
 	safego.Go(func() {
 		defer wg.Done()
-		c.tailStdPipe(c.stdoutFileName(session), request.Hooks.OnExecuteStdout, done)
+		c.tailStdPipe(stdoutPath, request.Hooks.OnExecuteStdout, done)
 	})
 	safego.Go(func() {
 		defer wg.Done()
-		c.tailStdPipe(c.stderrFileName(session), request.Hooks.OnExecuteStderr, done)
+		c.tailStdPipe(stderrPath, request.Hooks.OnExecuteStderr, done)
 	})
 
 	err = cmd.Start()
@@ -80,7 +87,11 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 
 	kernel := &commandKernel{
 		pid:          cmd.Process.Pid,
+		stdoutPath:   stdoutPath,
+		stderrPath:   stderrPath,
+		startedAt:    startAt,
 		content:      request.Code,
+		running:      true,
 		isBackground: false,
 	}
 	c.storeCommandKernel(session, kernel)
@@ -90,6 +101,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	wg.Wait()
 	if err != nil {
 		var eName, eValue string
+		eCode := 1
 		var traceback []string
 
 		var exitError *exec.ExitError
@@ -97,6 +109,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 			exitCode := exitError.ExitCode()
 			eName = "CommandExecError"
 			eValue = strconv.Itoa(exitCode)
+			eCode = exitCode
 		} else {
 			eName = "CommandExecError"
 			eValue = err.Error()
@@ -110,8 +123,10 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 		})
 
 		log.Error("CommandExecError: error running commands: %v", err)
+		c.markCommandFinished(session, eCode, err.Error())
 		return nil
 	}
+	c.markCommandFinished(session, 0, "")
 	request.Hooks.OnExecuteComplete(time.Since(startAt))
 	return nil
 }

--- a/docs/components/execd.md
+++ b/docs/components/execd.md
@@ -72,6 +72,19 @@ Bash session API (which keeps its existing name for compatibility), and
 isolated sessions. Commands submitted to a fallback session must use syntax
 supported by that image's `sh` implementation.
 
+### Command output retention
+
+Foreground command output is streamed over SSE and its temporary stdout and
+stderr files are removed as soon as streaming completes. Completed command
+metadata and detached background-command output remain available for 24 hours.
+Cleanup runs hourly after that retention window. Running commands are never
+removed by retention cleanup.
+
+The command-output janitor also removes matching files older than 24 hours that
+were left directly under the system temporary directory by earlier execd
+versions. New output is isolated under the `opensandbox-execd` temporary
+subdirectory so command files do not accumulate in the shared directory root.
+
 ## PTY WebSocket access
 
 The first WebSocket attached to `/pty/{session_id}/ws` is the exclusive

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -479,6 +479,8 @@ paths:
       description: |
         Returns the current status of a command (foreground or background) by command ID.
         Includes running flag, exit code, error (if any), and start/finish timestamps.
+        Completed command metadata is retained for at least 24 hours and then removed
+        by an hourly cleanup. Running commands are never removed by retention cleanup.
       operationId: getCommandStatus
       tags:
         - Command
@@ -515,6 +517,8 @@ paths:
         tail cursor for the next poll. When no starting line is provided, the full logs are returned.
         Response body is plain text so it can be rendered directly in browsers; the latest line index
         is provided via response header `EXECD-COMMANDS-TAIL-CURSOR` for subsequent incremental requests.
+        Completed background command output is retained for at least 24 hours and then
+        removed by an hourly cleanup. Running command output is never removed by retention cleanup.
       operationId: getBackgroundCommandLogs
       tags:
         - Command


### PR DESCRIPTION
## Summary

- remove foreground stdout/stderr temp files after SSE streaming completes
- isolate new command output under a private `opensandbox-execd` temp subdirectory
- retain completed command status and background output for at least 24 hours, then clean them hourly
- preserve output for running commands and clean exact legacy command-log filenames left in the temp root
- document the retention behavior in the execd API and component guide

Fixes #1709

## Validation

- `go test ./pkg/runtime ./pkg/web/controller`
- `go test -race ./pkg/runtime`
- `git diff --check`

`go test ./...` also passes all packages except the existing `pkg/isolation` merged-view tests on macOS, where `/tmp` resolves through `/private/var` and the test sandbox rejects that symlink target. The changed runtime and controller packages pass.