### PR TITLE
fix(execd): surface NSS trust prerequisites

### DIFF
--- a/.github/workflows/execd-test.yml
+++ b/.github/workflows/execd-test.yml
@@ -149,6 +149,11 @@ jobs:
         working-directory: components/execd
         run: bash tests/lifecycle.sh
 
+      - name: MITM CA NSS bootstrap test
+        if: matrix.os == 'ubuntu-latest'
+        working-directory: components/execd
+        run: bash tests/mitm_ca_nss.sh
+
       - name: Smoke test bwrap (Docker image build + extraction)
         if: matrix.os == 'ubuntu-latest'
         shell: bash

--- a/components/execd/Dockerfile
+++ b/components/execd/Dockerfile
@@ -141,6 +141,8 @@ RUN CGO_ENABLED=0 go build -tags ebpf -trimpath -buildvcs=false \
 
 FROM alpine:latest
 
+RUN apk add --no-cache nss-tools
+
 COPY --from=bwrap-builder --chown=0:0 /build/bwrap/bwrap /usr/local/bin/bwrap
 COPY --from=bwrap-builder --chown=0:0 /build/opensandbox-session-gate /usr/local/libexec/opensandbox-session-gate
 COPY --from=bwrap-builder --chown=0:0 /build/opensandbox-session-gate /opt/opensandbox/opensandbox-session-gate

--- a/components/execd/bootstrap.sh
+++ b/components/execd/bootstrap.sh
@@ -292,11 +292,11 @@ trust_mitm_ca() {
 trust_mitm_ca_nss() {
 	cert="$1"
 	[ -f "$cert" ] || return 0
-	[ -n "${HOME:-}" ] && [ -d "$HOME" ] || return 0
 	if ! command -v certutil >/dev/null 2>&1; then
 		echo "warning: certutil not found; Chromium/Chrome may not trust the mitm CA in NSS (install nss-tools on Alpine or libnss3-tools on Debian/Ubuntu)" >&2
 		return 0
 	fi
+	[ -n "${HOME:-}" ] && [ -d "$HOME" ] || return 0
 	pki="${HOME}/.pki/nssdb"
 	if ! mkdir -p "$pki" 2>/dev/null; then
 		return 0

--- a/components/execd/bootstrap.sh
+++ b/components/execd/bootstrap.sh
@@ -294,6 +294,7 @@ trust_mitm_ca_nss() {
 	[ -f "$cert" ] || return 0
 	[ -n "${HOME:-}" ] && [ -d "$HOME" ] || return 0
 	if ! command -v certutil >/dev/null 2>&1; then
+		echo "warning: certutil not found; Chromium/Chrome may not trust the mitm CA in NSS (install nss-tools on Alpine or libnss3-tools on Debian/Ubuntu)" >&2
 		return 0
 	fi
 	pki="${HOME}/.pki/nssdb"

--- a/components/execd/tests/init_container.sh
+++ b/components/execd/tests/init_container.sh
@@ -114,7 +114,8 @@ else
 fi
 
 # -------------------------------------------------------------------
-# Test 0: packaged executables and scripts have stable permissions.
+# Test 0: packaged executables and scripts have stable permissions, and the
+# official image carries the NSS tooling bootstrap uses for browser CA trust.
 # -------------------------------------------------------------------
 echo ""
 echo ">> Test 0: packaged executable and script permissions"
@@ -147,10 +148,14 @@ if ! docker run --rm \
         exit 1
       }
     done
+    command -v certutil >/dev/null || {
+      echo "certutil is missing from the official execd image" >&2
+      exit 1
+    }
   '; then
-  fail "test 0: packaged executable or script permissions are invalid"
+  fail "test 0: packaged runtime contract is invalid"
 fi
-echo "PASS: packaged executables and scripts are mode 0755"
+echo "PASS: packaged files are mode 0755 and certutil is available"
 
 # -------------------------------------------------------------------
 # Test 1: execd is PID 1, workload is its child, orphans are reaped,

--- a/components/execd/tests/mitm_ca_nss.sh
+++ b/components/execd/tests/mitm_ca_nss.sh
@@ -35,27 +35,53 @@ awk '
 # shellcheck source=/dev/null
 . "$TESTDIR/trust_mitm_ca_nss.sh"
 
-set +e
-HOME="$TESTDIR/home" PATH="$TESTDIR/empty-bin" \
-  trust_mitm_ca_nss "$TESTDIR/mitm-ca.pem" 2> "$TESTDIR/stderr"
-status=$?
-set -e
+assert_missing_certutil_warns() {
+  label="$1"
+  home_mode="$2"
+  stderr="$TESTDIR/stderr-$label"
 
-if [ "$status" -ne 0 ]; then
-  echo "FAIL: missing certutil made NSS trust setup fail with status $status" >&2
-  exit 1
-fi
-if ! grep -q 'certutil not found' "$TESTDIR/stderr"; then
-  echo "FAIL: missing certutil did not emit an actionable warning" >&2
-  exit 1
-fi
-if ! grep -q 'nss-tools' "$TESTDIR/stderr"; then
-  echo "FAIL: warning did not name the Alpine nss-tools package" >&2
-  exit 1
-fi
-if ! grep -q 'libnss3-tools' "$TESTDIR/stderr"; then
-  echo "FAIL: warning did not name the Debian/Ubuntu libnss3-tools package" >&2
-  exit 1
-fi
+  set +e
+  case "$home_mode" in
+    valid)
+      HOME="$TESTDIR/home" PATH="$TESTDIR/empty-bin" \
+        trust_mitm_ca_nss "$TESTDIR/mitm-ca.pem" 2> "$stderr"
+      ;;
+    unset)
+      (unset HOME; PATH="$TESTDIR/empty-bin" \
+        trust_mitm_ca_nss "$TESTDIR/mitm-ca.pem") 2> "$stderr"
+      ;;
+    nonexistent)
+      HOME="$TESTDIR/missing-home" PATH="$TESTDIR/empty-bin" \
+        trust_mitm_ca_nss "$TESTDIR/mitm-ca.pem" 2> "$stderr"
+      ;;
+    *)
+      echo "FAIL: unknown HOME mode $home_mode" >&2
+      exit 1
+      ;;
+  esac
+  status=$?
+  set -e
+
+  if [ "$status" -ne 0 ]; then
+    echo "FAIL: $label made NSS trust setup fail with status $status" >&2
+    exit 1
+  fi
+  if ! grep -q 'certutil not found' "$stderr"; then
+    echo "FAIL: $label did not emit an actionable warning" >&2
+    exit 1
+  fi
+  if ! grep -q 'nss-tools' "$stderr"; then
+    echo "FAIL: $label did not name the Alpine nss-tools package" >&2
+    exit 1
+  fi
+  if ! grep -q 'libnss3-tools' "$stderr"; then
+    echo "FAIL: $label did not name the Debian/Ubuntu libnss3-tools package" >&2
+    exit 1
+  fi
+}
+
+assert_missing_certutil_warns 'valid HOME' valid
+assert_missing_certutil_warns 'unset HOME' unset
+assert_missing_certutil_warns 'nonexistent HOME' nonexistent
 
 echo "PASS: missing certutil warns with package guidance and remains best-effort"

--- a/components/execd/tests/mitm_ca_nss.sh
+++ b/components/execd/tests/mitm_ca_nss.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Regression test: a workload image without certutil must receive an
+# actionable Chromium/Chrome NSS warning without making bootstrap fail.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BOOTSTRAP="$ROOT_DIR/bootstrap.sh"
+TESTDIR="$(mktemp -d)"
+trap 'rm -rf "$TESTDIR"' EXIT
+
+mkdir -p "$TESTDIR/home" "$TESTDIR/empty-bin"
+printf '%s\n' 'test certificate' > "$TESTDIR/mitm-ca.pem"
+
+# Load the production helper without executing the rest of bootstrap.sh.
+awk '
+  /^trust_mitm_ca_nss\(\) \{/ { capture = 1 }
+  capture { print }
+  capture && /^}/ { exit }
+' "$BOOTSTRAP" > "$TESTDIR/trust_mitm_ca_nss.sh"
+# shellcheck source=/dev/null
+. "$TESTDIR/trust_mitm_ca_nss.sh"
+
+set +e
+HOME="$TESTDIR/home" PATH="$TESTDIR/empty-bin" \
+  trust_mitm_ca_nss "$TESTDIR/mitm-ca.pem" 2> "$TESTDIR/stderr"
+status=$?
+set -e
+
+if [ "$status" -ne 0 ]; then
+  echo "FAIL: missing certutil made NSS trust setup fail with status $status" >&2
+  exit 1
+fi
+if ! grep -q 'certutil not found' "$TESTDIR/stderr"; then
+  echo "FAIL: missing certutil did not emit an actionable warning" >&2
+  exit 1
+fi
+if ! grep -q 'nss-tools' "$TESTDIR/stderr"; then
+  echo "FAIL: warning did not name the Alpine nss-tools package" >&2
+  exit 1
+fi
+if ! grep -q 'libnss3-tools' "$TESTDIR/stderr"; then
+  echo "FAIL: warning did not name the Debian/Ubuntu libnss3-tools package" >&2
+  exit 1
+fi
+
+echo "PASS: missing certutil warns with package guidance and remains best-effort"

--- a/docs/components/execd.md
+++ b/docs/components/execd.md
@@ -216,6 +216,23 @@ override it.
 | `OPENSANDBOX_ID` | Authoritative sandbox id stamped into eBPF audit records (`sandbox_id`) and metrics; the server injects it on Docker/Kubernetes task-template paths. Kubernetes pool allocations that skip the task template (default entrypoint, no env, no init mode) cannot inject it, and the eBPF layer reports `unsupported` attribution on that path. |
 | `OPENSANDBOX_EXECD_METRICS_EXTRA_ATTRS` | Optional extra metric attrs (`k=v,k2=v2`). |
 
+### Transparent MITM CA trust
+
+When transparent MITM is enabled, `bootstrap.sh` installs the exported CA into
+the available system, NSS, and JDK trust stores on a best-effort basis. The
+official execd image includes `certutil` through Alpine's `nss-tools` package,
+so it can update the per-user NSS database used by Chromium and Chrome when
+that image is used directly.
+
+The Docker and Kubernetes runtime injection paths copy execd, `bootstrap.sh`,
+and static helpers into the workload image. They do not copy the execd image's
+dynamic NSS libraries or package database. A custom workload image that needs
+Chromium or Chrome trust must therefore install its native `certutil` package,
+such as `nss-tools` on Alpine or `libnss3-tools` on Debian/Ubuntu. If
+`certutil` is absent, bootstrap logs a warning and continues; other available
+trust-store integrations still run, but Chromium or Chrome may reject the
+intercepted certificate.
+
 ### Lifecycle hook trust boundary
 
 `execd` runs configured `preStart` and `periodic` commands directly as its own


### PR DESCRIPTION
# Summary

- install Alpine `nss-tools` in the official execd image so its advertised Chromium/Chrome NSS import has `certutil`
- warn with native package guidance when an injected workload image lacks `certutil`, while preserving best-effort startup
- document that Docker/Kubernetes artifact injection does not transfer distro-specific dynamic NSS tooling
- add focused regressions for the missing-tool diagnostic and the packaged image contract

Closes #1711.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
  - `go test -count=1 -skip '^TestMergedView_' ./...`
  - `go vet ./...`
  - `gofmt -l . ../internal` (no output)
- [x] Integration tests
  - `bash tests/mitm_ca_nss.sh`
  - `bash tests/init_mode.sh`
  - `bash tests/lifecycle.sh`
  - `bash tests/sigterm_forward.sh`
  - `bash -n bootstrap.sh tests/mitm_ca_nss.sh tests/init_container.sh`
- [ ] e2e / manual verification
  - the Docker image build and `tests/init_container.sh` image-contract assertion were not run locally because no Docker-compatible daemon is installed; the existing Ubuntu execd workflow runs this regression
- docs rendered successfully with the installed VitePress CLI; the local pnpm 11 preflight itself was blocked by its `ERR_PNPM_IGNORED_BUILDS` policy before invoking the repository script
- `./scripts/verify-license.sh`
- `git diff --cached --check`

The unfiltered Go suite also reaches 498 passing tests on this macOS host, then fails 14 pre-existing `TestMergedView_*` cases because `/var` is a symlink to `/private/var` and the safety check reports `symlink target denied: /var`. No Go source or those tests are changed here; the filtered command above runs every other package/test.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
