### PR TITLE
feat(javascript): add client-side sandbox pool

### DIFF
--- a/docs/sdks/javascript.md
+++ b/docs/sdks/javascript.md
@@ -97,6 +97,42 @@ const sandbox = await Sandbox.create({
 
 The Server validates `timeoutSeconds`; `preStart` accepts 1–10800 seconds, while `periodic` accepts 1–300 seconds. Both default to 60 seconds when omitted. See [Lifecycle Hooks](/guides/lifecycle-hooks) for timing, failure behavior, and provider limitations.
 
+## Client-Side Sandbox Pool
+
+`SandboxPool` keeps a best-effort idle buffer of clean, ready sandboxes. Acquiring removes a sandbox from the pool permanently; the caller kills it after use instead of returning it to the pool.
+
+```ts
+import {
+  AcquirePolicy,
+  InMemoryPoolStateStore,
+  SandboxPool,
+} from "@alibaba-group/opensandbox";
+
+const pool = SandboxPool.create({
+  poolName: "workers",
+  maxIdle: 2,
+  stateStore: new InMemoryPoolStateStore(),
+  connectionConfig: config,
+  creationSpec: { image: "ubuntu:24.04" },
+});
+
+await pool.start();
+const sandbox = await pool.acquire({
+  sandboxTimeoutSeconds: 3600,
+  policy: AcquirePolicy.DIRECT_CREATE,
+});
+
+try {
+  await sandbox.commands.run("echo ready");
+} finally {
+  await sandbox.kill();
+  await sandbox.close();
+  await pool.shutdown();
+}
+```
+
+The built-in `InMemoryPoolStateStore` is limited to one JavaScript process. To share a pool across processes, provide a distributed `PoolStateStore` whose idle-take, membership, and primary-lock operations are atomic.
+
 ## Usage Examples
 
 ### 1. Lifecycle Management

--- a/sdks/sandbox/javascript/README.md
+++ b/sdks/sandbox/javascript/README.md
@@ -64,6 +64,47 @@ try {
 }
 ```
 
+## Client-side sandbox pool
+
+`SandboxPool` maintains a best-effort buffer of clean, ready sandboxes. An
+acquired sandbox becomes caller-owned and is never returned to the pool; kill
+it when the work is complete. The pool replenishes the idle buffer in the
+background.
+
+```ts
+import {
+  AcquirePolicy,
+  InMemoryPoolStateStore,
+  SandboxPool,
+} from "@alibaba-group/opensandbox";
+
+const pool = SandboxPool.create({
+  poolName: "workers",
+  maxIdle: 2,
+  stateStore: new InMemoryPoolStateStore(),
+  connectionConfig: { apiKey: process.env.OPEN_SANDBOX_API_KEY },
+  creationSpec: { image: "ubuntu:24.04" },
+});
+
+await pool.start();
+const sandbox = await pool.acquire({
+  sandboxTimeoutSeconds: 3600,
+  policy: AcquirePolicy.DIRECT_CREATE,
+});
+
+try {
+  await sandbox.commands.run("echo ready");
+} finally {
+  await sandbox.kill();
+  await sandbox.close();
+  await pool.shutdown();
+}
+```
+
+`InMemoryPoolStateStore` is process-local. Applications that share a logical
+pool across processes must provide a distributed `PoolStateStore` whose take,
+membership, and primary-lock operations are atomic.
+
 ## Usage Examples
 
 ### 1. Lifecycle Management

--- a/sdks/sandbox/javascript/src/core/exceptions.ts
+++ b/sdks/sandbox/javascript/src/core/exceptions.ts
@@ -18,6 +18,10 @@ export type SandboxErrorCode =
   | "UNHEALTHY"
   | "INVALID_ARGUMENT"
   | "UNEXPECTED_RESPONSE"
+  | "POOL_EMPTY"
+  | "POOL_ACQUIRE_FAILED"
+  | "POOL_NOT_RUNNING"
+  | "POOL_STATE_STORE_UNAVAILABLE"
   // Allow server-defined codes as well.
   | (string & {});
 
@@ -33,6 +37,10 @@ export class SandboxError {
   static readonly UNHEALTHY: SandboxErrorCode = "UNHEALTHY";
   static readonly INVALID_ARGUMENT: SandboxErrorCode = "INVALID_ARGUMENT";
   static readonly UNEXPECTED_RESPONSE: SandboxErrorCode = "UNEXPECTED_RESPONSE";
+  static readonly POOL_EMPTY: SandboxErrorCode = "POOL_EMPTY";
+  static readonly POOL_ACQUIRE_FAILED: SandboxErrorCode = "POOL_ACQUIRE_FAILED";
+  static readonly POOL_NOT_RUNNING: SandboxErrorCode = "POOL_NOT_RUNNING";
+  static readonly POOL_STATE_STORE_UNAVAILABLE: SandboxErrorCode = "POOL_STATE_STORE_UNAVAILABLE";
 
   constructor(
     readonly code: SandboxErrorCode,
@@ -130,6 +138,46 @@ export class InvalidArgumentException extends SandboxException {
       message: opts.message,
       cause: opts.cause,
       error: new SandboxError(SandboxError.INVALID_ARGUMENT, opts.message),
+    });
+  }
+}
+
+export class PoolEmptyException extends SandboxException {
+  readonly name: string = "PoolEmptyException";
+
+  constructor(poolName: string) {
+    const message = `Sandbox pool '${poolName}' has no idle sandbox available`;
+    super({ message, error: new SandboxError(SandboxError.POOL_EMPTY, message) });
+  }
+}
+
+export class PoolAcquireFailedException extends SandboxException {
+  readonly name: string = "PoolAcquireFailedException";
+
+  constructor(poolName: string, cause?: unknown) {
+    const message = `Sandbox pool '${poolName}' could not acquire a usable idle sandbox`;
+    super({ message, cause, error: new SandboxError(SandboxError.POOL_ACQUIRE_FAILED, message) });
+  }
+}
+
+export class PoolNotRunningException extends SandboxException {
+  readonly name: string = "PoolNotRunningException";
+
+  constructor(poolName: string, state: string) {
+    const message = `Sandbox pool '${poolName}' is not running (state=${state})`;
+    super({ message, error: new SandboxError(SandboxError.POOL_NOT_RUNNING, message) });
+  }
+}
+
+export class PoolStateStoreUnavailableException extends SandboxException {
+  readonly name: string = "PoolStateStoreUnavailableException";
+
+  constructor(operation: string, cause?: unknown) {
+    const message = `Sandbox pool state store operation '${operation}' failed`;
+    super({
+      message,
+      cause,
+      error: new SandboxError(SandboxError.POOL_STATE_STORE_UNAVAILABLE, message),
     });
   }
 }

--- a/sdks/sandbox/javascript/src/index.ts
+++ b/sdks/sandbox/javascript/src/index.ts
@@ -20,6 +20,10 @@ export {
   SandboxInternalException,
   SandboxReadyTimeoutException,
   SandboxUnhealthyException,
+  PoolAcquireFailedException,
+  PoolEmptyException,
+  PoolNotRunningException,
+  PoolStateStoreUnavailableException,
 } from "./core/exceptions.js";
 
 // Factory pattern (stable public interface; does NOT expose OpenAPI generated models).
@@ -140,6 +144,31 @@ export type {
   SandboxCreateOptions,
 } from "./sandbox.js";
 export { Sandbox } from "./sandbox.js";
+
+export { SandboxPool } from "./pool.js";
+export { InMemoryPoolStateStore } from "./poolStore.js";
+export {
+  AcquirePolicy,
+  PoolHealthState,
+  PoolLifecycleState,
+  PooledSandboxCreateReason,
+} from "./poolTypes.js";
+export type {
+  IdleEntry,
+  PoolCreationSpec,
+  PoolHealthCheck,
+  PoolLogger,
+  PoolSandboxPreparer,
+  PoolSnapshot,
+  PoolStateStore,
+  PooledSandboxCreateContext,
+  PooledSandboxCreator,
+  ReapResult,
+  SandboxAcquireOptions,
+  SandboxPoolOptions,
+  StoreCounters,
+  TakeIdleResult,
+} from "./poolTypes.js";
 
 export type {
   ContentReplaceEntry,

--- a/sdks/sandbox/javascript/src/pool.ts
+++ b/sdks/sandbox/javascript/src/pool.ts
@@ -1,0 +1,790 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ConnectionConfig } from "./config/connection.js";
+import {
+  PoolAcquireFailedException,
+  PoolEmptyException,
+  PoolNotRunningException,
+  PoolStateStoreUnavailableException,
+  SandboxReadyTimeoutException,
+} from "./core/exceptions.js";
+import { InMemoryPoolStateStore } from "./poolStore.js";
+import {
+  AcquirePolicy,
+  PoolHealthState,
+  PoolLifecycleState,
+  PooledSandboxCreateReason,
+  type IdleEntry,
+  type PoolCreationSpec,
+  type PoolHealthCheck,
+  type PoolSnapshot,
+  type PoolStateStore,
+  type SandboxAcquireOptions,
+  type SandboxPoolOptions,
+  type TakeIdleResult,
+} from "./poolTypes.js";
+import { Sandbox } from "./sandbox.js";
+import { SandboxManager } from "./manager.js";
+
+const DEFAULT_IDLE_TIMEOUT_SECONDS = 24 * 60 * 60;
+const DEFAULT_READY_TIMEOUT_SECONDS = 30;
+const DEFAULT_POLLING_INTERVAL_MILLIS = 200;
+
+interface ResolvedPoolOptions {
+  poolName: string;
+  maxIdle: number;
+  connectionConfig: ConnectionConfig;
+  creationSpec: PoolCreationSpec;
+  sandboxCreator?: SandboxPoolOptions["sandboxCreator"];
+  stateStore: PoolStateStore;
+  ownerId: string;
+  warmupConcurrency: number;
+  warmupConcurrencyConfigured: boolean;
+  primaryLockTtlSeconds: number;
+  reconcileIntervalSeconds: number;
+  degradedThreshold: number;
+  emptyBehavior: AcquirePolicy;
+  idleTimeoutSeconds: number;
+  drainTimeoutSeconds: number;
+  acquireMinRemainingTtlSeconds: number;
+  acquireReadyTimeoutSeconds: number;
+  acquireHealthCheckPollingIntervalMillis: number;
+  acquireHealthCheck?: PoolHealthCheck;
+  maxAcquireRetries: number;
+  warmupReadyTimeoutSeconds: number;
+  warmupHealthCheckPollingIntervalMillis: number;
+  warmupHealthCheck?: PoolHealthCheck;
+  warmupPreparer?: SandboxPoolOptions["warmupPreparer"];
+  logger?: SandboxPoolOptions["logger"];
+}
+
+function makeOwnerId(): string {
+  const random = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(16).slice(2);
+  return `pool-owner-${random}`;
+}
+
+function cloneConnectionConfig(config: ConnectionConfig): ConnectionConfig {
+  return new ConnectionConfig({
+    domain: config.domain,
+    protocol: config.protocol,
+    apiKey: config.apiKey,
+    headers: { ...config.headers },
+    requestTimeoutSeconds: config.requestTimeoutSeconds,
+    debug: config.debug,
+    useServerProxy: config.useServerProxy,
+    endpointCacheTtlMs: config.endpointCacheTtlMs,
+    endpointCacheSize: config.endpointCacheSize,
+    endpointCacheDisabled: config.endpointCacheDisabled,
+    disableMetrics: config.disableMetrics,
+  });
+}
+
+function requireNonNegative(value: number, name: string): void {
+  if (!Number.isFinite(value) || value < 0) throw new Error(`${name} must be a non-negative number`);
+}
+
+function requirePositive(value: number, name: string): void {
+  if (!Number.isFinite(value) || value <= 0) throw new Error(`${name} must be a positive number`);
+}
+
+function requireNonNegativeInteger(value: number, name: string): void {
+  requireNonNegative(value, name);
+  if (!Number.isInteger(value)) throw new Error(`${name} must be an integer`);
+}
+
+function policyRetries(policy: AcquirePolicy): boolean {
+  return policy === AcquirePolicy.RETRY_NEXT_IDLE || policy === AcquirePolicy.RETRY_NEXT_IDLE_THEN_CREATE;
+}
+
+function policyCreates(policy: AcquirePolicy): boolean {
+  return policy === AcquirePolicy.DIRECT_CREATE || policy === AcquirePolicy.RETRY_NEXT_IDLE_THEN_CREATE;
+}
+
+function sleep(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const onDone = () => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    const timer = setTimeout(onDone, milliseconds);
+    if (!signal) return;
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/** A client-side buffer of clean, ready sandboxes. */
+export class SandboxPool {
+  private readonly options: ResolvedPoolOptions;
+  private manager?: SandboxManager;
+  private lifecycleState = PoolLifecycleState.NOT_STARTED;
+  private healthState = PoolHealthState.HEALTHY;
+  private failureCount = 0;
+  private lastError?: string;
+  private backoffUntilMs = 0;
+  private inFlightOperations = 0;
+  private timer?: ReturnType<typeof setInterval>;
+  private startPromise?: Promise<void>;
+  private reconcilePromise?: Promise<void>;
+  private shutdownPromise?: Promise<void>;
+  private abortController?: AbortController;
+  private allowWarmupCommitWhileDraining = false;
+
+  private constructor(options: SandboxPoolOptions) {
+    const poolName = options.poolName?.trim();
+    if (!poolName) throw new Error("poolName is required");
+    requireNonNegativeInteger(options.maxIdle, "maxIdle");
+
+    const idleTimeoutSeconds = options.idleTimeoutSeconds ?? DEFAULT_IDLE_TIMEOUT_SECONDS;
+    const acquireMinRemainingTtlSeconds =
+      options.acquireMinRemainingTtlSeconds ?? Math.min(idleTimeoutSeconds / 2, 60);
+    const warmupConcurrency = options.warmupConcurrency ?? Math.max(1, Math.ceil(options.maxIdle * 0.2));
+    const creationSpec = options.creationSpec ?? ({} as PoolCreationSpec);
+    if (
+      !options.sandboxCreator &&
+      (creationSpec.image === undefined) === (creationSpec.snapshotId === undefined)
+    ) {
+      throw new Error("creationSpec must provide exactly one of image or snapshotId when sandboxCreator is absent");
+    }
+
+    requirePositive(idleTimeoutSeconds, "idleTimeoutSeconds");
+    requirePositive(warmupConcurrency, "warmupConcurrency");
+    if (!Number.isInteger(warmupConcurrency)) throw new Error("warmupConcurrency must be an integer");
+    requirePositive(options.primaryLockTtlSeconds ?? 60, "primaryLockTtlSeconds");
+    requirePositive(options.reconcileIntervalSeconds ?? 30, "reconcileIntervalSeconds");
+    requirePositive(options.degradedThreshold ?? 3, "degradedThreshold");
+    requireNonNegative(options.drainTimeoutSeconds ?? 30, "drainTimeoutSeconds");
+    requireNonNegative(acquireMinRemainingTtlSeconds, "acquireMinRemainingTtlSeconds");
+    if (acquireMinRemainingTtlSeconds >= idleTimeoutSeconds) {
+      throw new Error("acquireMinRemainingTtlSeconds must be less than idleTimeoutSeconds");
+    }
+    requirePositive(options.acquireReadyTimeoutSeconds ?? DEFAULT_READY_TIMEOUT_SECONDS, "acquireReadyTimeoutSeconds");
+    requirePositive(options.warmupReadyTimeoutSeconds ?? DEFAULT_READY_TIMEOUT_SECONDS, "warmupReadyTimeoutSeconds");
+    requirePositive(
+      options.acquireHealthCheckPollingIntervalMillis ?? DEFAULT_POLLING_INTERVAL_MILLIS,
+      "acquireHealthCheckPollingIntervalMillis",
+    );
+    requirePositive(
+      options.warmupHealthCheckPollingIntervalMillis ?? DEFAULT_POLLING_INTERVAL_MILLIS,
+      "warmupHealthCheckPollingIntervalMillis",
+    );
+    requirePositive(options.maxAcquireRetries ?? 3, "maxAcquireRetries");
+    if (!Number.isInteger(options.maxAcquireRetries ?? 3)) {
+      throw new Error("maxAcquireRetries must be an integer");
+    }
+
+    this.options = {
+      poolName,
+      maxIdle: options.maxIdle,
+      connectionConfig:
+        options.connectionConfig instanceof ConnectionConfig
+          ? cloneConnectionConfig(options.connectionConfig)
+          : new ConnectionConfig(options.connectionConfig),
+      creationSpec,
+      sandboxCreator: options.sandboxCreator,
+      stateStore: options.stateStore ?? new InMemoryPoolStateStore(),
+      ownerId: options.ownerId?.trim() ? options.ownerId.trim() : makeOwnerId(),
+      warmupConcurrency,
+      warmupConcurrencyConfigured: options.warmupConcurrency !== undefined,
+      primaryLockTtlSeconds: options.primaryLockTtlSeconds ?? 60,
+      reconcileIntervalSeconds: options.reconcileIntervalSeconds ?? 30,
+      degradedThreshold: options.degradedThreshold ?? 3,
+      emptyBehavior: options.emptyBehavior ?? AcquirePolicy.DIRECT_CREATE,
+      idleTimeoutSeconds,
+      drainTimeoutSeconds: options.drainTimeoutSeconds ?? 30,
+      acquireMinRemainingTtlSeconds,
+      acquireReadyTimeoutSeconds: options.acquireReadyTimeoutSeconds ?? DEFAULT_READY_TIMEOUT_SECONDS,
+      acquireHealthCheckPollingIntervalMillis:
+        options.acquireHealthCheckPollingIntervalMillis ?? DEFAULT_POLLING_INTERVAL_MILLIS,
+      acquireHealthCheck: options.acquireHealthCheck,
+      maxAcquireRetries: options.maxAcquireRetries ?? 3,
+      warmupReadyTimeoutSeconds: options.warmupReadyTimeoutSeconds ?? DEFAULT_READY_TIMEOUT_SECONDS,
+      warmupHealthCheckPollingIntervalMillis:
+        options.warmupHealthCheckPollingIntervalMillis ?? DEFAULT_POLLING_INTERVAL_MILLIS,
+      warmupHealthCheck: options.warmupHealthCheck,
+      warmupPreparer: options.warmupPreparer,
+      logger: options.logger,
+    };
+  }
+
+  static create(options: SandboxPoolOptions): SandboxPool {
+    return new SandboxPool(options);
+  }
+
+  static inMemoryStateStore(): InMemoryPoolStateStore {
+    return new InMemoryPoolStateStore();
+  }
+
+  async start(): Promise<void> {
+    if (this.lifecycleState === PoolLifecycleState.RUNNING) return;
+    if (this.lifecycleState === PoolLifecycleState.STARTING) {
+      await this.startPromise;
+      return;
+    }
+    if (this.lifecycleState === PoolLifecycleState.DRAINING) {
+      throw new PoolNotRunningException(this.options.poolName, this.lifecycleState);
+    }
+    this.lifecycleState = PoolLifecycleState.STARTING;
+    this.startPromise = (async () => {
+      await this.reconcilePromise?.catch(() => undefined);
+      await this.finishStart();
+    })();
+    try {
+      await this.startPromise;
+    } finally {
+      this.startPromise = undefined;
+    }
+  }
+
+  private async finishStart(): Promise<void> {
+    try {
+      await this.options.stateStore.setMaxIdle(this.options.poolName, this.options.maxIdle);
+      await this.options.stateStore.setIdleEntryTtl(this.options.poolName, this.options.idleTimeoutSeconds);
+    } catch (cause) {
+      if (this.lifecycleState === PoolLifecycleState.STARTING) {
+        this.lifecycleState = PoolLifecycleState.STOPPED;
+      }
+      throw new PoolStateStoreUnavailableException("start", cause);
+    }
+    if (this.lifecycleState !== PoolLifecycleState.STARTING) {
+      throw new PoolNotRunningException(this.options.poolName, this.lifecycleState);
+    }
+
+    this.abortController = new AbortController();
+    try {
+      this.manager ??= this.createManager();
+    } catch (cause) {
+      if (this.lifecycleState === PoolLifecycleState.STARTING) {
+        this.lifecycleState = PoolLifecycleState.STOPPED;
+      }
+      throw cause;
+    }
+    this.recordSuccess();
+    this.lifecycleState = PoolLifecycleState.RUNNING;
+    this.timer = setInterval(() => this.triggerReconcile(), this.options.reconcileIntervalSeconds * 1000);
+    (this.timer as unknown as { unref?: () => void }).unref?.();
+    if (this.options.primaryLockTtlSeconds <= this.options.warmupReadyTimeoutSeconds) {
+      this.options.logger?.warn?.("pool primary lock TTL may expire during warmup", {
+        poolName: this.options.poolName,
+        primaryLockTtlSeconds: this.options.primaryLockTtlSeconds,
+        warmupReadyTimeoutSeconds: this.options.warmupReadyTimeoutSeconds,
+      });
+    }
+    if (this.options.maxIdle > 0) this.triggerReconcile();
+  }
+
+  async acquire(options: SandboxAcquireOptions = {}): Promise<Sandbox> {
+    if (this.lifecycleState !== PoolLifecycleState.RUNNING) {
+      throw new PoolNotRunningException(this.options.poolName, this.lifecycleState);
+    }
+    options.signal?.throwIfAborted();
+    const policy = options.policy ?? this.options.emptyBehavior;
+    const maxAttempts = policyRetries(policy) ? this.options.maxAcquireRetries : 1;
+    const minTtl = options.minRemainingTtlSeconds ?? this.options.acquireMinRemainingTtlSeconds;
+    requireNonNegative(minTtl, "minRemainingTtlSeconds");
+    if (options.sandboxTimeoutSeconds !== undefined) {
+      requirePositive(options.sandboxTimeoutSeconds, "sandboxTimeoutSeconds");
+    }
+
+    this.inFlightOperations += 1;
+    try {
+      let attempted = false;
+      let lastError: unknown;
+      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        let result: TakeIdleResult;
+        try {
+          result = await this.options.stateStore.tryTakeIdleWithMinTtl(this.options.poolName, minTtl);
+        } catch (cause) {
+          if (!policyCreates(policy)) throw new PoolStateStoreUnavailableException("tryTakeIdle", cause);
+          this.options.logger?.warn?.("pool state store unavailable; falling back to direct create", {
+            poolName: this.options.poolName,
+            error: cause,
+          });
+          lastError = cause;
+          break;
+        }
+        void this.killSandboxIds(result.discardedAliveSandboxIds);
+        if (!result.sandboxId) break;
+        attempted = true;
+        let sandbox: Sandbox | undefined;
+        try {
+          sandbox = await Sandbox.connect({
+            sandboxId: result.sandboxId,
+            connectionConfig: this.options.connectionConfig,
+            adapterFactory: this.options.creationSpec.adapterFactory,
+            skipHealthCheck: true,
+            signal: options.signal,
+          });
+          if (!options.skipHealthCheck) {
+            await this.waitUntilHealthy(
+              sandbox,
+              this.options.acquireHealthCheck,
+              this.options.acquireReadyTimeoutSeconds,
+              this.options.acquireHealthCheckPollingIntervalMillis,
+              options.signal,
+            );
+          }
+        } catch (cause) {
+          lastError = cause;
+          await sandbox?.close().catch(() => undefined);
+          void this.killSandboxId(result.sandboxId).catch(() => undefined);
+          if (options.signal?.aborted) throw options.signal.reason;
+          this.options.logger?.warn?.("pool idle sandbox connect or health check failed", {
+            poolName: this.options.poolName,
+            sandboxId: result.sandboxId,
+            attempt: attempt + 1,
+            error: cause,
+          });
+          if (this.lifecycleState !== PoolLifecycleState.RUNNING) {
+            throw new PoolNotRunningException(this.options.poolName, this.lifecycleState);
+          }
+          if (!policyRetries(policy)) break;
+          continue;
+        }
+        try {
+          await this.renewAcquired(sandbox, options.sandboxTimeoutSeconds);
+          this.ensureAcquireStillRunning();
+        } catch (cause) {
+          await this.killAndClose(sandbox);
+          throw cause;
+        }
+        return sandbox;
+      }
+
+      if (!policyCreates(policy)) {
+        if (attempted) throw new PoolAcquireFailedException(this.options.poolName, lastError);
+        throw new PoolEmptyException(this.options.poolName);
+      }
+
+      const sandbox = await this.createSandbox(PooledSandboxCreateReason.DIRECT_CREATE, options.signal);
+      try {
+        if (!options.skipHealthCheck) {
+          await this.waitUntilHealthy(
+            sandbox,
+            this.options.acquireHealthCheck,
+            this.options.acquireReadyTimeoutSeconds,
+            this.options.acquireHealthCheckPollingIntervalMillis,
+            options.signal,
+          );
+        }
+        await this.renewAcquired(sandbox, options.sandboxTimeoutSeconds);
+        this.ensureAcquireStillRunning();
+        return sandbox;
+      } catch (cause) {
+        await this.killAndClose(sandbox);
+        throw cause;
+      }
+    } finally {
+      this.inFlightOperations -= 1;
+      this.triggerReconcile();
+    }
+  }
+
+  async resize(maxIdle: number): Promise<void> {
+    requireNonNegativeInteger(maxIdle, "maxIdle");
+    this.ensureRunning();
+    this.inFlightOperations += 1;
+    try {
+      await this.storeCall("setMaxIdle", () => this.options.stateStore.setMaxIdle(this.options.poolName, maxIdle));
+      this.options.maxIdle = maxIdle;
+      if (!this.options.warmupConcurrencyConfigured) {
+        this.options.warmupConcurrency = Math.max(1, Math.ceil(maxIdle * 0.2));
+      }
+      this.triggerReconcile();
+    } finally {
+      this.inFlightOperations -= 1;
+    }
+  }
+
+  async releaseAllIdle(): Promise<number> {
+    this.inFlightOperations += 1;
+    try {
+      const initialIdleCount = (
+        await this.storeCall("snapshotCounters", () =>
+          this.options.stateStore.snapshotCounters(this.options.poolName),
+        )
+      ).idleCount;
+      let released = 0;
+      while (released < initialIdleCount) {
+        const sandboxId = await this.storeCall("tryTakeIdle", () =>
+          this.options.stateStore.tryTakeIdle(this.options.poolName),
+        );
+        if (!sandboxId) return released;
+        await this.killSandboxId(sandboxId);
+        released += 1;
+      }
+      return released;
+    } finally {
+      this.inFlightOperations -= 1;
+    }
+  }
+
+  async snapshot(): Promise<PoolSnapshot> {
+    const counters = await this.storeCall("snapshotCounters", () =>
+      this.options.stateStore.snapshotCounters(this.options.poolName),
+    );
+    return {
+      lifecycleState: this.lifecycleState,
+      healthState: this.healthState,
+      idleCount: counters.idleCount,
+      maxIdle: await this.storeCall("getMaxIdle", () => this.options.stateStore.getMaxIdle(this.options.poolName)),
+      failureCount: this.failureCount,
+      backoffActive: Date.now() < this.backoffUntilMs,
+      lastError: this.lastError,
+      inFlightOperations: this.inFlightOperations,
+    };
+  }
+
+  snapshotIdleEntries(): Promise<IdleEntry[]> {
+    return this.storeCall("snapshotIdleEntries", () =>
+      this.options.stateStore.snapshotIdleEntries(this.options.poolName),
+    );
+  }
+
+  async shutdown(graceful = true): Promise<void> {
+    if (this.lifecycleState === PoolLifecycleState.NOT_STARTED || this.lifecycleState === PoolLifecycleState.STOPPED) {
+      this.lifecycleState = PoolLifecycleState.STOPPED;
+      return;
+    }
+    if (this.lifecycleState === PoolLifecycleState.DRAINING) {
+      await this.shutdownPromise;
+      return;
+    }
+    this.lifecycleState = PoolLifecycleState.DRAINING;
+    this.allowWarmupCommitWhileDraining = graceful;
+    this.shutdownPromise = this.finishShutdown(graceful);
+    await this.shutdownPromise;
+  }
+
+  private async finishShutdown(graceful: boolean): Promise<void> {
+    try {
+      await this.startPromise?.catch(() => undefined);
+      if (this.timer) clearInterval(this.timer);
+      this.timer = undefined;
+
+      if (graceful) {
+        const deadline = Date.now() + this.options.drainTimeoutSeconds * 1000;
+        while ((this.inFlightOperations > 0 || this.reconcilePromise) && Date.now() < deadline) {
+          await sleep(10);
+        }
+      }
+      this.allowWarmupCommitWhileDraining = false;
+      this.abortController?.abort(new Error("Sandbox pool is shutting down"));
+      try {
+        await this.options.stateStore.releasePrimaryLock(this.options.poolName, this.options.ownerId);
+      } catch {
+        // Best-effort release; a TTL-backed lock will expire naturally.
+      }
+      try {
+        await this.manager?.close();
+      } catch {
+        // Shutdown still transitions to STOPPED when transport cleanup fails.
+      }
+      this.manager = undefined;
+    } finally {
+      this.allowWarmupCommitWhileDraining = false;
+      this.lifecycleState = PoolLifecycleState.STOPPED;
+      this.shutdownPromise = undefined;
+    }
+  }
+
+  close(): Promise<void> {
+    return this.shutdown(true);
+  }
+
+  private ensureRunning(): void {
+    if (this.lifecycleState !== PoolLifecycleState.RUNNING) {
+      throw new PoolNotRunningException(this.options.poolName, this.lifecycleState);
+    }
+  }
+
+  private triggerReconcile(): void {
+    if (this.lifecycleState !== PoolLifecycleState.RUNNING || this.reconcilePromise) return;
+    if (Date.now() < this.backoffUntilMs) return;
+    let runAgain = false;
+    this.reconcilePromise = this.reconcile()
+      .then((shouldContinue) => {
+        runAgain = shouldContinue;
+        this.recordSuccess();
+      })
+      .catch((error: unknown) => this.recordFailure(error))
+      .finally(() => {
+        this.reconcilePromise = undefined;
+        if (runAgain) this.triggerReconcile();
+      });
+  }
+
+  private async reconcile(): Promise<boolean> {
+    const { poolName, ownerId, primaryLockTtlSeconds, stateStore } = this.options;
+    if (!(await stateStore.tryAcquirePrimaryLock(poolName, ownerId, primaryLockTtlSeconds))) return false;
+
+    let heartbeatError: unknown;
+    let leadershipLost = false;
+    let heartbeatInFlight = Promise.resolve();
+    const heartbeatIntervalMillis = Math.max(1, Math.floor((primaryLockTtlSeconds * 1000) / 3));
+    const heartbeat = setInterval(() => {
+      heartbeatInFlight = heartbeatInFlight.then(async () => {
+        try {
+          if (!(await stateStore.renewPrimaryLock(poolName, ownerId, primaryLockTtlSeconds))) {
+            leadershipLost = true;
+          }
+        } catch (error) {
+          heartbeatError = error;
+        }
+      });
+    }, heartbeatIntervalMillis);
+    (heartbeat as unknown as { unref?: () => void }).unref?.();
+
+    try {
+      const reaped = await stateStore.reapExpiredIdleWithMinTtl(
+        poolName,
+        new Date(),
+        this.options.acquireMinRemainingTtlSeconds,
+      );
+      await this.killSandboxIds(reaped.discardedAliveSandboxIds);
+
+      const maxIdle = await stateStore.getMaxIdle(poolName);
+      let idleCount = (await stateStore.snapshotCounters(poolName)).idleCount;
+      while (idleCount > maxIdle) {
+        const sandboxId = await stateStore.tryTakeIdle(poolName);
+        if (!sandboxId) break;
+        await this.killSandboxId(sandboxId);
+        idleCount -= 1;
+      }
+
+      const deficit = maxIdle - idleCount;
+      const createCount = Math.min(deficit, this.options.warmupConcurrency);
+      if (createCount <= 0) {
+        await stateStore.renewPrimaryLock(poolName, ownerId, primaryLockTtlSeconds);
+      } else {
+        const results = await Promise.allSettled(
+          Array.from({ length: createCount }, () => this.createIdleSandbox()),
+        );
+        const failures = results.filter((result): result is PromiseRejectedResult => result.status === "rejected");
+        for (const failure of failures) {
+          this.options.logger?.warn?.("pool warmup sandbox creation failed", {
+            poolName,
+            error: failure.reason,
+          });
+        }
+        if (failures.length > 0) throw failures[0].reason;
+      }
+    } finally {
+      clearInterval(heartbeat);
+      await heartbeatInFlight;
+    }
+    if (heartbeatError) throw heartbeatError;
+    if (leadershipLost) {
+      this.options.logger?.warn?.("pool lost primary ownership during reconcile", { poolName });
+      return false;
+    }
+    const latestMaxIdle = await stateStore.getMaxIdle(poolName);
+    return (await stateStore.snapshotCounters(poolName)).idleCount < latestMaxIdle;
+  }
+
+  private async createIdleSandbox(): Promise<void> {
+    this.inFlightOperations += 1;
+    let sandbox: Sandbox | undefined;
+    let committed = false;
+    try {
+      sandbox = await this.createSandbox(PooledSandboxCreateReason.WARMUP, this.abortController?.signal);
+      await this.waitUntilHealthy(
+        sandbox,
+        this.options.warmupHealthCheck,
+        this.options.warmupReadyTimeoutSeconds,
+        this.options.warmupHealthCheckPollingIntervalMillis,
+        this.abortController?.signal,
+      );
+      await this.options.warmupPreparer?.(sandbox);
+      await sandbox.renew(this.options.idleTimeoutSeconds);
+      const stillPrimary = await this.options.stateStore.renewPrimaryLock(
+        this.options.poolName,
+        this.options.ownerId,
+        this.options.primaryLockTtlSeconds,
+      );
+      const mayCommit =
+        this.lifecycleState === PoolLifecycleState.RUNNING ||
+        (this.lifecycleState === PoolLifecycleState.DRAINING && this.allowWarmupCommitWhileDraining);
+      if (!stillPrimary || !mayCommit) {
+        await this.killAndClose(sandbox);
+        return;
+      }
+      await this.options.stateStore.putIdle(this.options.poolName, String(sandbox.id));
+      committed = true;
+      await sandbox.close().catch((error: unknown) => {
+        this.options.logger?.warn?.("failed to close pooled sandbox client", {
+          sandboxId: String(sandbox!.id),
+          error,
+        });
+      });
+    } catch (cause) {
+      if (sandbox && !committed) await this.killAndClose(sandbox);
+      throw cause;
+    } finally {
+      this.inFlightOperations -= 1;
+    }
+  }
+
+  private async createSandbox(reason: PooledSandboxCreateReason, signal?: AbortSignal): Promise<Sandbox> {
+    if (this.options.sandboxCreator) {
+      return await this.options.sandboxCreator({
+        poolName: this.options.poolName,
+        ownerId: this.options.ownerId,
+        idleTimeoutSeconds: this.options.idleTimeoutSeconds,
+        reason,
+        readyTimeoutSeconds:
+          reason === PooledSandboxCreateReason.WARMUP
+            ? this.options.warmupReadyTimeoutSeconds
+            : this.options.acquireReadyTimeoutSeconds,
+        healthCheckPollingIntervalMillis:
+          reason === PooledSandboxCreateReason.WARMUP
+            ? this.options.warmupHealthCheckPollingIntervalMillis
+            : this.options.acquireHealthCheckPollingIntervalMillis,
+        skipHealthCheck: true,
+        connectionConfig: this.options.connectionConfig,
+        creationSpec: this.options.creationSpec,
+        signal,
+      });
+    }
+    return await Sandbox.create({
+      ...this.options.creationSpec,
+      connectionConfig: this.options.connectionConfig,
+      timeoutSeconds: this.options.idleTimeoutSeconds,
+      skipHealthCheck: true,
+      signal,
+    });
+  }
+
+  private async waitUntilHealthy(
+    sandbox: Sandbox,
+    healthCheck: PoolHealthCheck | undefined,
+    timeoutSeconds: number,
+    pollingIntervalMillis: number,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutSeconds * 1000;
+    let attempts = 0;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+      signal?.throwIfAborted();
+      attempts += 1;
+      let healthy = false;
+      try {
+        healthy = healthCheck ? await healthCheck(sandbox) : await sandbox.isHealthy();
+      } catch (error) {
+        lastError = error;
+        healthy = false;
+      }
+      if (healthy) return;
+      await sleep(pollingIntervalMillis, signal);
+    }
+    throw new SandboxReadyTimeoutException({
+      message: `Sandbox health check timed out after ${timeoutSeconds}s (${attempts} attempts).`,
+      cause: lastError,
+    });
+  }
+
+  private async renewAcquired(sandbox: Sandbox, timeoutSeconds?: number): Promise<void> {
+    if (timeoutSeconds === undefined) return;
+    await sandbox.renew(timeoutSeconds);
+  }
+
+  private async killSandboxIds(sandboxIds: string[]): Promise<void> {
+    if (sandboxIds.length === 0) return;
+    this.inFlightOperations += 1;
+    try {
+      let manager: SandboxManager;
+      try {
+        manager = this.manager ?? this.createManager();
+      } catch (error) {
+        this.options.logger?.warn?.("failed to create manager for pooled sandbox cleanup", { error });
+        return;
+      }
+      try {
+        for (const sandboxId of sandboxIds) {
+          try {
+            await manager.killSandbox(sandboxId);
+          } catch (error) {
+            this.options.logger?.warn?.("failed to kill pooled sandbox", { sandboxId, error });
+          }
+        }
+      } finally {
+        if (!this.manager) await manager.close().catch(() => undefined);
+      }
+    } finally {
+      this.inFlightOperations -= 1;
+    }
+  }
+
+  private async killSandboxId(sandboxId: string): Promise<void> {
+    await this.killSandboxIds([sandboxId]);
+  }
+
+  private async killAndClose(sandbox: Sandbox): Promise<void> {
+    await sandbox.kill().catch(() => undefined);
+    await sandbox.close().catch(() => undefined);
+  }
+
+  private ensureAcquireStillRunning(): void {
+    if (this.lifecycleState === PoolLifecycleState.RUNNING) return;
+    throw new PoolNotRunningException(this.options.poolName, this.lifecycleState);
+  }
+
+  private recordSuccess(): void {
+    this.failureCount = 0;
+    this.lastError = undefined;
+    this.backoffUntilMs = 0;
+    this.healthState = PoolHealthState.HEALTHY;
+  }
+
+  private recordFailure(error: unknown): void {
+    this.failureCount += 1;
+    this.lastError = error instanceof Error ? error.message : String(error);
+    if (this.failureCount >= this.options.degradedThreshold) {
+      this.healthState = PoolHealthState.DEGRADED;
+      const backoffSeconds = Math.min(
+        24 * 60 * 60,
+        30 * 2 ** (this.failureCount - this.options.degradedThreshold),
+      );
+      this.backoffUntilMs = Date.now() + backoffSeconds * 1000;
+    }
+    this.options.logger?.warn?.("pool reconcile failed", {
+      poolName: this.options.poolName,
+      error,
+      failureCount: this.failureCount,
+    });
+  }
+
+  private createManager(): SandboxManager {
+    return SandboxManager.create({
+      connectionConfig: this.options.connectionConfig,
+      adapterFactory: this.options.creationSpec.adapterFactory,
+    });
+  }
+
+  private async storeCall<T>(operation: string, call: () => Promise<T>): Promise<T> {
+    try {
+      return await call();
+    } catch (cause) {
+      if (cause instanceof PoolStateStoreUnavailableException) throw cause;
+      throw new PoolStateStoreUnavailableException(operation, cause);
+    }
+  }
+}

--- a/sdks/sandbox/javascript/src/pool.ts
+++ b/sdks/sandbox/javascript/src/pool.ts
@@ -320,7 +320,7 @@ export class SandboxPool {
           lastError = cause;
           break;
         }
-        void this.killSandboxIds(result.discardedAliveSandboxIds);
+        void this.killSandboxIds(result.discardedAliveSandboxIds).catch(() => undefined);
         if (!result.sandboxId) break;
         attempted = true;
         let sandbox: Sandbox | undefined;
@@ -572,7 +572,9 @@ export class SandboxPool {
       const deficit = maxIdle - idleCount;
       const createCount = Math.min(deficit, this.options.warmupConcurrency);
       if (createCount <= 0) {
-        await stateStore.renewPrimaryLock(poolName, ownerId, primaryLockTtlSeconds);
+        if (!(await stateStore.renewPrimaryLock(poolName, ownerId, primaryLockTtlSeconds))) {
+          leadershipLost = true;
+        }
       } else {
         const results = await Promise.allSettled(
           Array.from({ length: createCount }, () => this.createIdleSandbox()),
@@ -710,9 +712,10 @@ export class SandboxPool {
     if (sandboxIds.length === 0) return;
     this.inFlightOperations += 1;
     try {
+      const pooledManager = this.manager;
       let manager: SandboxManager;
       try {
-        manager = this.manager ?? this.createManager();
+        manager = pooledManager ?? this.createManager();
       } catch (error) {
         this.options.logger?.warn?.("failed to create manager for pooled sandbox cleanup", { error });
         return;
@@ -726,7 +729,7 @@ export class SandboxPool {
           }
         }
       } finally {
-        if (!this.manager) await manager.close().catch(() => undefined);
+        if (!pooledManager) await manager.close().catch(() => undefined);
       }
     } finally {
       this.inFlightOperations -= 1;

--- a/sdks/sandbox/javascript/src/poolStore.ts
+++ b/sdks/sandbox/javascript/src/poolStore.ts
@@ -1,0 +1,197 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {
+  IdleEntry,
+  PoolStateStore,
+  ReapResult,
+  StoreCounters,
+  TakeIdleResult,
+} from "./poolTypes.js";
+
+const DEFAULT_IDLE_TTL_SECONDS = 24 * 60 * 60;
+
+interface PrimaryLock {
+  ownerId: string;
+  expiresAtMs: number;
+}
+
+interface PoolState {
+  idleById: Map<string, IdleEntry>;
+  idleOrder: string[];
+  lock?: PrimaryLock;
+  maxIdle: number;
+  idleTtlSeconds: number;
+}
+
+/** Process-local state store. Calls are atomic within one JavaScript runtime. */
+export class InMemoryPoolStateStore implements PoolStateStore {
+  private readonly pools = new Map<string, PoolState>();
+
+  private state(poolName: string): PoolState {
+    let state = this.pools.get(poolName);
+    if (!state) {
+      state = {
+        idleById: new Map(),
+        idleOrder: [],
+        maxIdle: 0,
+        idleTtlSeconds: DEFAULT_IDLE_TTL_SECONDS,
+      };
+      this.pools.set(poolName, state);
+    }
+    return state;
+  }
+
+  async tryTakeIdle(poolName: string): Promise<string | undefined> {
+    return (await this.tryTakeIdleWithMinTtl(poolName, 0)).sandboxId;
+  }
+
+  async tryTakeIdleWithMinTtl(
+    poolName: string,
+    minRemainingTtlSeconds: number,
+  ): Promise<TakeIdleResult> {
+    const state = this.state(poolName);
+    const now = Date.now();
+    const result: TakeIdleResult = { discardedAliveSandboxIds: [] };
+
+    while (state.idleOrder.length > 0) {
+      const sandboxId = state.idleOrder.shift()!;
+      const entry = state.idleById.get(sandboxId);
+      if (!entry) continue;
+      state.idleById.delete(sandboxId);
+
+      const remainingMs = entry.expiresAt.getTime() - now;
+      if (remainingMs <= 0) continue;
+      if (remainingMs < minRemainingTtlSeconds * 1000) {
+        result.discardedAliveSandboxIds.push(sandboxId);
+        continue;
+      }
+      result.sandboxId = sandboxId;
+      return result;
+    }
+    return result;
+  }
+
+  async putIdle(poolName: string, sandboxId: string): Promise<void> {
+    if (!sandboxId.trim()) throw new Error("sandboxId must not be blank");
+    const state = this.state(poolName);
+    const existing = state.idleById.get(sandboxId);
+    if (existing && existing.expiresAt.getTime() > Date.now()) return;
+    if (existing) state.idleOrder = state.idleOrder.filter((id) => id !== sandboxId);
+
+    state.idleById.set(sandboxId, {
+      sandboxId,
+      expiresAt: new Date(Date.now() + state.idleTtlSeconds * 1000),
+    });
+    state.idleOrder.push(sandboxId);
+  }
+
+  async removeIdle(poolName: string, sandboxId: string): Promise<void> {
+    const state = this.state(poolName);
+    state.idleById.delete(sandboxId);
+    this.compact(state);
+  }
+
+  async tryAcquirePrimaryLock(
+    poolName: string,
+    ownerId: string,
+    ttlSeconds: number,
+  ): Promise<boolean> {
+    const state = this.state(poolName);
+    const now = Date.now();
+    if (state.lock && state.lock.ownerId !== ownerId && state.lock.expiresAtMs > now) return false;
+    state.lock = { ownerId, expiresAtMs: now + ttlSeconds * 1000 };
+    return true;
+  }
+
+  async renewPrimaryLock(
+    poolName: string,
+    ownerId: string,
+    ttlSeconds: number,
+  ): Promise<boolean> {
+    const state = this.state(poolName);
+    const now = Date.now();
+    if (state.lock?.ownerId !== ownerId) return false;
+    if (state.lock.expiresAtMs <= now) {
+      state.lock = undefined;
+      return false;
+    }
+    state.lock.expiresAtMs = now + ttlSeconds * 1000;
+    return true;
+  }
+
+  async releasePrimaryLock(poolName: string, ownerId: string): Promise<void> {
+    const state = this.state(poolName);
+    if (state.lock?.ownerId === ownerId) state.lock = undefined;
+  }
+
+  async reapExpiredIdle(poolName: string, now: Date): Promise<void> {
+    await this.reapExpiredIdleWithMinTtl(poolName, now, 0);
+  }
+
+  async reapExpiredIdleWithMinTtl(
+    poolName: string,
+    now: Date,
+    minRemainingTtlSeconds: number,
+  ): Promise<ReapResult> {
+    const state = this.state(poolName);
+    const discardedAliveSandboxIds: string[] = [];
+    const thresholdMs = minRemainingTtlSeconds * 1000;
+    for (const [sandboxId, entry] of state.idleById) {
+      const remainingMs = entry.expiresAt.getTime() - now.getTime();
+      if (remainingMs <= 0 || remainingMs < thresholdMs) {
+        state.idleById.delete(sandboxId);
+        if (remainingMs > 0) discardedAliveSandboxIds.push(sandboxId);
+      }
+    }
+    this.compact(state);
+    return { discardedAliveSandboxIds };
+  }
+
+  async snapshotCounters(poolName: string): Promise<StoreCounters> {
+    await this.reapExpiredIdle(poolName, new Date());
+    return { idleCount: this.state(poolName).idleById.size };
+  }
+
+  async snapshotIdleEntries(poolName: string): Promise<IdleEntry[]> {
+    await this.reapExpiredIdle(poolName, new Date());
+    const state = this.state(poolName);
+    return state.idleOrder.flatMap((sandboxId) => {
+      const entry = state.idleById.get(sandboxId);
+      return entry ? [{ ...entry, expiresAt: new Date(entry.expiresAt) }] : [];
+    });
+  }
+
+  async getMaxIdle(poolName: string): Promise<number> {
+    return this.state(poolName).maxIdle;
+  }
+
+  async setMaxIdle(poolName: string, maxIdle: number): Promise<void> {
+    if (!Number.isInteger(maxIdle) || maxIdle < 0) {
+      throw new Error("maxIdle must be a non-negative integer");
+    }
+    this.state(poolName).maxIdle = maxIdle;
+  }
+
+  async setIdleEntryTtl(poolName: string, ttlSeconds: number): Promise<void> {
+    if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+      throw new Error("ttlSeconds must be a positive number");
+    }
+    this.state(poolName).idleTtlSeconds = ttlSeconds;
+  }
+
+  private compact(state: PoolState): void {
+    state.idleOrder = state.idleOrder.filter((id) => state.idleById.has(id));
+  }
+}

--- a/sdks/sandbox/javascript/src/poolTypes.ts
+++ b/sdks/sandbox/javascript/src/poolTypes.ts
@@ -1,0 +1,168 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ConnectionConfig, ConnectionConfigOptions } from "./config/connection.js";
+import type { Sandbox, SandboxCreateOptions } from "./sandbox.js";
+
+export enum AcquirePolicy {
+  DIRECT_CREATE = "DIRECT_CREATE",
+  FAIL_FAST = "FAIL_FAST",
+  RETRY_NEXT_IDLE = "RETRY_NEXT_IDLE",
+  RETRY_NEXT_IDLE_THEN_CREATE = "RETRY_NEXT_IDLE_THEN_CREATE",
+}
+
+export enum PoolLifecycleState {
+  NOT_STARTED = "NOT_STARTED",
+  STARTING = "STARTING",
+  RUNNING = "RUNNING",
+  DRAINING = "DRAINING",
+  STOPPED = "STOPPED",
+}
+
+export enum PoolHealthState {
+  HEALTHY = "HEALTHY",
+  DEGRADED = "DEGRADED",
+}
+
+export interface IdleEntry {
+  sandboxId: string;
+  expiresAt: Date;
+}
+
+export interface TakeIdleResult {
+  sandboxId?: string;
+  discardedAliveSandboxIds: string[];
+}
+
+export interface ReapResult {
+  discardedAliveSandboxIds: string[];
+}
+
+export interface StoreCounters {
+  idleCount: number;
+}
+
+/**
+ * Persistence contract used by a client-side sandbox pool.
+ *
+ * Distributed implementations must make each method atomic. In particular,
+ * taking an idle entry must remove it in the same operation, `putIdle` must be
+ * idempotent for a `(poolName, sandboxId)` pair, and primary-lock renew/release
+ * must only succeed for the current owner.
+ */
+export interface PoolStateStore {
+  tryTakeIdle(poolName: string): Promise<string | undefined>;
+  tryTakeIdleWithMinTtl(poolName: string, minRemainingTtlSeconds: number): Promise<TakeIdleResult>;
+  putIdle(poolName: string, sandboxId: string): Promise<void>;
+  removeIdle(poolName: string, sandboxId: string): Promise<void>;
+  tryAcquirePrimaryLock(poolName: string, ownerId: string, ttlSeconds: number): Promise<boolean>;
+  renewPrimaryLock(poolName: string, ownerId: string, ttlSeconds: number): Promise<boolean>;
+  releasePrimaryLock(poolName: string, ownerId: string): Promise<void>;
+  reapExpiredIdle(poolName: string, now: Date): Promise<void>;
+  reapExpiredIdleWithMinTtl(
+    poolName: string,
+    now: Date,
+    minRemainingTtlSeconds: number,
+  ): Promise<ReapResult>;
+  snapshotCounters(poolName: string): Promise<StoreCounters>;
+  snapshotIdleEntries(poolName: string): Promise<IdleEntry[]>;
+  getMaxIdle(poolName: string): Promise<number>;
+  setMaxIdle(poolName: string, maxIdle: number): Promise<void>;
+  setIdleEntryTtl(poolName: string, ttlSeconds: number): Promise<void>;
+}
+
+export interface PoolSnapshot {
+  lifecycleState: PoolLifecycleState;
+  healthState: PoolHealthState;
+  idleCount: number;
+  maxIdle: number;
+  failureCount: number;
+  backoffActive: boolean;
+  lastError?: string;
+  inFlightOperations: number;
+}
+
+export type PoolCreationSpec = Omit<
+  SandboxCreateOptions,
+  | "connectionConfig"
+  | "timeoutSeconds"
+  | "skipHealthCheck"
+  | "readyTimeoutSeconds"
+  | "healthCheckPollingInterval"
+  | "healthCheck"
+  | "signal"
+>;
+
+export enum PooledSandboxCreateReason {
+  WARMUP = "WARMUP",
+  DIRECT_CREATE = "DIRECT_CREATE",
+}
+
+export interface PooledSandboxCreateContext {
+  poolName: string;
+  ownerId: string;
+  idleTimeoutSeconds: number;
+  reason: PooledSandboxCreateReason;
+  readyTimeoutSeconds: number;
+  healthCheckPollingIntervalMillis: number;
+  skipHealthCheck: boolean;
+  connectionConfig: ConnectionConfig;
+  creationSpec: PoolCreationSpec;
+  signal?: AbortSignal;
+}
+
+export type PooledSandboxCreator = (context: PooledSandboxCreateContext) => Promise<Sandbox>;
+export type PoolHealthCheck = (sandbox: Sandbox) => boolean | Promise<boolean>;
+export type PoolSandboxPreparer = (sandbox: Sandbox) => void | Promise<void>;
+
+export interface PoolLogger {
+  debug?(message: string, fields?: Record<string, unknown>): void;
+  info?(message: string, fields?: Record<string, unknown>): void;
+  warn?(message: string, fields?: Record<string, unknown>): void;
+}
+
+export interface SandboxPoolOptions {
+  poolName: string;
+  maxIdle: number;
+  connectionConfig: ConnectionConfig | ConnectionConfigOptions;
+  creationSpec?: PoolCreationSpec;
+  sandboxCreator?: PooledSandboxCreator;
+  stateStore?: PoolStateStore;
+  ownerId?: string;
+  warmupConcurrency?: number;
+  primaryLockTtlSeconds?: number;
+  reconcileIntervalSeconds?: number;
+  degradedThreshold?: number;
+  emptyBehavior?: AcquirePolicy;
+  idleTimeoutSeconds?: number;
+  drainTimeoutSeconds?: number;
+  acquireMinRemainingTtlSeconds?: number;
+  acquireReadyTimeoutSeconds?: number;
+  acquireHealthCheckPollingIntervalMillis?: number;
+  acquireHealthCheck?: PoolHealthCheck;
+  maxAcquireRetries?: number;
+  warmupReadyTimeoutSeconds?: number;
+  warmupHealthCheckPollingIntervalMillis?: number;
+  warmupHealthCheck?: PoolHealthCheck;
+  warmupPreparer?: PoolSandboxPreparer;
+  logger?: PoolLogger;
+}
+
+export interface SandboxAcquireOptions {
+  sandboxTimeoutSeconds?: number;
+  policy?: AcquirePolicy;
+  minRemainingTtlSeconds?: number;
+  skipHealthCheck?: boolean;
+  signal?: AbortSignal;
+}

--- a/sdks/sandbox/javascript/tests/pool.test.mjs
+++ b/sdks/sandbox/javascript/tests/pool.test.mjs
@@ -189,8 +189,12 @@ test("SandboxPool warms, acquires, renews, and replenishes an idle sandbox", asy
 test("SandboxPool does not close a caller-initialized connection transport", async () => {
   const fixture = createPoolFixture();
   const suppliedConfig = fixture.connectionConfig.withTransportIfMissing();
+  const closeTransport = suppliedConfig.closeTransport.bind(suppliedConfig);
   let closeCalls = 0;
-  suppliedConfig.closeTransport = async () => { closeCalls += 1; };
+  suppliedConfig.closeTransport = async () => {
+    closeCalls += 1;
+    await closeTransport();
+  };
   const pool = SandboxPool.create({
     poolName: "transport-ownership-pool",
     maxIdle: 1,
@@ -199,11 +203,15 @@ test("SandboxPool does not close a caller-initialized connection transport", asy
     sandboxCreator: fixture.sandboxCreator,
   });
 
-  await pool.start();
-  await eventually(async () => (await pool.snapshot()).idleCount === 1);
-  await pool.shutdown();
-  assert.equal(closeCalls, 0);
-  await suppliedConfig.closeTransport();
+  try {
+    await pool.start();
+    await eventually(async () => (await pool.snapshot()).idleCount === 1);
+    await pool.shutdown();
+    assert.equal(closeCalls, 0);
+  } finally {
+    await pool.shutdown(false).catch(() => undefined);
+    await suppliedConfig.closeTransport();
+  }
 });
 
 test("SandboxPool renews primary ownership while warmup creation is in flight", async () => {
@@ -301,9 +309,11 @@ test("custom creator receives the cross-language direct-create reason", async ()
 
 test("SandboxPool resize and releaseAllIdle update observable state", async () => {
   const fixture = createPoolFixture();
+  const store = new InMemoryPoolStateStore();
   const pool = SandboxPool.create({
     poolName: "resize-pool",
     maxIdle: 1,
+    stateStore: store,
     reconcileIntervalSeconds: 60,
     connectionConfig: fixture.connectionConfig,
     creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
@@ -313,6 +323,7 @@ test("SandboxPool resize and releaseAllIdle update observable state", async () =
   await eventually(async () => (await pool.snapshot()).idleCount === 1);
   await pool.resize(2);
   await eventually(async () => (await pool.snapshot()).idleCount === 2);
+  await store.setMaxIdle("resize-pool", 0);
   assert.equal(await pool.releaseAllIdle(), 2);
   assert.equal((await pool.snapshot()).idleCount, 0);
   await pool.shutdown(false);
@@ -347,6 +358,13 @@ test("retry-next-idle skips an unhealthy sandbox without duplicating acquisition
 test("renew failure is terminal and does not consume another idle sandbox", async () => {
   const fixture = createPoolFixture({ renewFailureIds: new Set(["first"]) });
   const store = new InMemoryPoolStateStore();
+  const tryTakeIdleWithMinTtl = store.tryTakeIdleWithMinTtl.bind(store);
+  const acquiredIds = [];
+  store.tryTakeIdleWithMinTtl = async (...args) => {
+    const result = await tryTakeIdleWithMinTtl(...args);
+    acquiredIds.push(result.sandboxId);
+    return result;
+  };
   const pool = SandboxPool.create({
     poolName: "renew-pool",
     maxIdle: 0,
@@ -367,7 +385,7 @@ test("renew failure is terminal and does not consume another idle sandbox", asyn
     }),
     /renew failed/,
   );
-  assert.equal(await store.tryTakeIdle("renew-pool"), "second");
+  assert.deepEqual(acquiredIds, ["first"]);
   await pool.shutdown();
 });
 

--- a/sdks/sandbox/javascript/tests/pool.test.mjs
+++ b/sdks/sandbox/javascript/tests/pool.test.mjs
@@ -1,0 +1,432 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AcquirePolicy,
+  ConnectionConfig,
+  InMemoryPoolStateStore,
+  PoolEmptyException,
+  PoolLifecycleState,
+  PooledSandboxCreateReason,
+  SandboxPool,
+} from "../dist/index.js";
+
+async function eventually(check, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail("condition did not become true before timeout");
+}
+
+function createPoolFixture({ healthById = {}, renewFailureIds = new Set() } = {}) {
+  const calls = [];
+  const sandboxes = {
+    async createSandbox(request) {
+      calls.push({ method: "create", request });
+      return { id: "direct-1" };
+    },
+    async getSandboxEndpoint(sandboxId, port) {
+      calls.push({ method: "endpoint", sandboxId, port });
+      return { endpoint: `${sandboxId}.internal:${port}`, headers: {} };
+    },
+    async renewSandboxExpiration(sandboxId, body) {
+      calls.push({ method: "renew", sandboxId, body });
+      if (renewFailureIds.has(sandboxId)) throw new Error("renew failed");
+      return { expiresAt: new Date(body.expiresAt) };
+    },
+    async deleteSandbox(sandboxId) {
+      calls.push({ method: "kill", sandboxId });
+    },
+  };
+  const adapterFactory = {
+    createLifecycleStack() {
+      return { sandboxes };
+    },
+    createExecdStack({ execdBaseUrl }) {
+      const sandboxId = new URL(execdBaseUrl).hostname.split(".")[0];
+      return {
+        commands: {},
+        files: {},
+        health: { async ping() { return healthById[sandboxId] ?? true; } },
+        metrics: {},
+      };
+    },
+    createEgressStack() {
+      return { egress: {} };
+    },
+  };
+  const connectionConfig = new ConnectionConfig({
+    domain: "http://127.0.0.1:8080",
+    disableMetrics: true,
+  });
+  let nextId = 0;
+  const created = [];
+  const sandboxCreator = async () => {
+    const id = `warm-${++nextId}`;
+    const sandbox = {
+      id,
+      async isHealthy() { return true; },
+      async renew(timeoutSeconds) { calls.push({ method: "warmup-renew", id, timeoutSeconds }); },
+      async kill() { calls.push({ method: "creator-kill", id }); },
+      async close() { calls.push({ method: "creator-close", id }); },
+    };
+    created.push(sandbox);
+    return sandbox;
+  };
+
+  return { adapterFactory, calls, connectionConfig, created, sandboxCreator, sandboxes };
+}
+
+test("InMemoryPoolStateStore atomically takes idle entries in FIFO order", async () => {
+  const store = new InMemoryPoolStateStore();
+  await store.setIdleEntryTtl("pool", 60);
+  await store.putIdle("pool", "one");
+  await store.putIdle("pool", "two");
+  await store.putIdle("pool", "one");
+
+  const [first, second] = await Promise.all([
+    store.tryTakeIdle("pool"),
+    store.tryTakeIdle("pool"),
+  ]);
+  assert.deepEqual([first, second], ["one", "two"]);
+  assert.equal(await store.tryTakeIdle("pool"), undefined);
+});
+
+test("InMemoryPoolStateStore enforces TTL filtering and primary ownership", async () => {
+  const store = new InMemoryPoolStateStore();
+  await store.setIdleEntryTtl("pool", 10);
+  await store.putIdle("pool", "near-expiry");
+
+  const taken = await store.tryTakeIdleWithMinTtl("pool", 20);
+  assert.equal(taken.sandboxId, undefined);
+  assert.deepEqual(taken.discardedAliveSandboxIds, ["near-expiry"]);
+
+  assert.equal(await store.tryAcquirePrimaryLock("pool", "owner-a", 60), true);
+  assert.equal(await store.tryAcquirePrimaryLock("pool", "owner-b", 60), false);
+  assert.equal(await store.renewPrimaryLock("pool", "owner-b", 60), false);
+  assert.equal(await store.tryAcquirePrimaryLock("pool", "owner-b", 60), false);
+  await store.releasePrimaryLock("pool", "owner-a");
+  assert.equal(await store.tryAcquirePrimaryLock("pool", "owner-b", 60), true);
+});
+
+test("InMemoryPoolStateStore removes stale FIFO positions before an id is reused", async () => {
+  const store = new InMemoryPoolStateStore();
+  await store.putIdle("pool", "one");
+  await store.putIdle("pool", "two");
+  await store.removeIdle("pool", "one");
+  await store.putIdle("pool", "one");
+
+  assert.equal(await store.tryTakeIdle("pool"), "two");
+  assert.equal(await store.tryTakeIdle("pool"), "one");
+});
+
+test("concurrent start calls wait for the same initialization", async () => {
+  const fixture = createPoolFixture();
+  const store = new InMemoryPoolStateStore();
+  const setMaxIdle = store.setMaxIdle.bind(store);
+  let setMaxIdleCalls = 0;
+  let initializationStarted;
+  const started = new Promise((resolve) => { initializationStarted = resolve; });
+  let releaseInitialization;
+  const gate = new Promise((resolve) => { releaseInitialization = resolve; });
+  store.setMaxIdle = async (...args) => {
+    setMaxIdleCalls += 1;
+    initializationStarted();
+    await gate;
+    await setMaxIdle(...args);
+  };
+  const pool = SandboxPool.create({
+    poolName: "concurrent-start-pool",
+    maxIdle: 0,
+    stateStore: store,
+    connectionConfig: fixture.connectionConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+    sandboxCreator: fixture.sandboxCreator,
+  });
+
+  const firstStart = pool.start();
+  let secondStartDone = false;
+  const secondStart = pool.start().then(() => { secondStartDone = true; });
+  await started;
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(secondStartDone, false);
+
+  releaseInitialization();
+  await Promise.all([firstStart, secondStart]);
+  assert.equal(setMaxIdleCalls, 1);
+  assert.equal((await pool.snapshot()).lifecycleState, PoolLifecycleState.RUNNING);
+  await pool.shutdown();
+});
+
+test("SandboxPool warms, acquires, renews, and replenishes an idle sandbox", async () => {
+  const fixture = createPoolFixture();
+  const pool = SandboxPool.create({
+    poolName: "unit-pool",
+    maxIdle: 2,
+    warmupConcurrency: 2,
+    reconcileIntervalSeconds: 60,
+    connectionConfig: fixture.connectionConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+    sandboxCreator: fixture.sandboxCreator,
+  });
+
+  await pool.start();
+  await eventually(async () => (await pool.snapshot()).idleCount === 2);
+
+  const sandbox = await pool.acquire({ sandboxTimeoutSeconds: 90 });
+  assert.equal(sandbox.id, "warm-1");
+  assert.ok(fixture.calls.some((call) => call.method === "renew" && call.sandboxId === "warm-1"));
+
+  await eventually(async () => (await pool.snapshot()).idleCount === 2);
+  assert.equal(fixture.created.length, 3);
+  await sandbox.close();
+  await pool.shutdown();
+  assert.equal((await pool.snapshot()).lifecycleState, PoolLifecycleState.STOPPED);
+});
+
+test("SandboxPool does not close a caller-initialized connection transport", async () => {
+  const fixture = createPoolFixture();
+  const suppliedConfig = fixture.connectionConfig.withTransportIfMissing();
+  let closeCalls = 0;
+  suppliedConfig.closeTransport = async () => { closeCalls += 1; };
+  const pool = SandboxPool.create({
+    poolName: "transport-ownership-pool",
+    maxIdle: 1,
+    connectionConfig: suppliedConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+    sandboxCreator: fixture.sandboxCreator,
+  });
+
+  await pool.start();
+  await eventually(async () => (await pool.snapshot()).idleCount === 1);
+  await pool.shutdown();
+  assert.equal(closeCalls, 0);
+  await suppliedConfig.closeTransport();
+});
+
+test("SandboxPool renews primary ownership while warmup creation is in flight", async () => {
+  const fixture = createPoolFixture();
+  const store = new InMemoryPoolStateStore();
+  const renewPrimaryLock = store.renewPrimaryLock.bind(store);
+  let renewCount = 0;
+  store.renewPrimaryLock = async (...args) => {
+    renewCount += 1;
+    return renewPrimaryLock(...args);
+  };
+  let creatorStarted;
+  const started = new Promise((resolve) => { creatorStarted = resolve; });
+  let releaseCreator;
+  const gate = new Promise((resolve) => { releaseCreator = resolve; });
+  const pool = SandboxPool.create({
+    poolName: "heartbeat-pool",
+    maxIdle: 1,
+    stateStore: store,
+    primaryLockTtlSeconds: 0.3,
+    reconcileIntervalSeconds: 60,
+    connectionConfig: fixture.connectionConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+    sandboxCreator: async (context) => {
+      creatorStarted();
+      await gate;
+      return fixture.sandboxCreator(context);
+    },
+  });
+
+  await pool.start();
+  await started;
+  await eventually(() => renewCount >= 2);
+  releaseCreator();
+  await eventually(async () => (await pool.snapshot()).idleCount === 1);
+  await pool.shutdown();
+});
+
+test("SandboxPool fail-fast acquire reports an empty pool", async () => {
+  const fixture = createPoolFixture();
+  const pool = SandboxPool.create({
+    poolName: "empty-pool",
+    maxIdle: 0,
+    connectionConfig: fixture.connectionConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+    sandboxCreator: fixture.sandboxCreator,
+  });
+  await pool.start();
+  await assert.rejects(
+    pool.acquire({ policy: AcquirePolicy.FAIL_FAST }),
+    PoolEmptyException,
+  );
+  await pool.shutdown();
+});
+
+test("direct-create fallback uses the pool idle TTL before applying the acquired TTL", async () => {
+  const fixture = createPoolFixture();
+  const pool = SandboxPool.create({
+    poolName: "direct-pool",
+    maxIdle: 0,
+    idleTimeoutSeconds: 120,
+    connectionConfig: fixture.connectionConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+  });
+  await pool.start();
+
+  const sandbox = await pool.acquire({ sandboxTimeoutSeconds: 45 });
+  assert.equal(sandbox.id, "direct-1");
+  assert.equal(fixture.calls.find((call) => call.method === "create").request.timeout, 120);
+  assert.ok(fixture.calls.some((call) => call.method === "renew" && call.sandboxId === "direct-1"));
+  await sandbox.close();
+  await pool.shutdown();
+});
+
+test("custom creator receives the cross-language direct-create reason", async () => {
+  const fixture = createPoolFixture();
+  let createContext;
+  const pool = SandboxPool.create({
+    poolName: "creator-context-pool",
+    maxIdle: 0,
+    connectionConfig: fixture.connectionConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+    sandboxCreator: async (context) => {
+      createContext = context;
+      return fixture.sandboxCreator(context);
+    },
+  });
+  await pool.start();
+
+  const sandbox = await pool.acquire();
+  assert.equal(createContext.reason, PooledSandboxCreateReason.DIRECT_CREATE);
+  await sandbox.close();
+  await pool.shutdown();
+});
+
+test("SandboxPool resize and releaseAllIdle update observable state", async () => {
+  const fixture = createPoolFixture();
+  const pool = SandboxPool.create({
+    poolName: "resize-pool",
+    maxIdle: 1,
+    reconcileIntervalSeconds: 60,
+    connectionConfig: fixture.connectionConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+    sandboxCreator: fixture.sandboxCreator,
+  });
+  await pool.start();
+  await eventually(async () => (await pool.snapshot()).idleCount === 1);
+  await pool.resize(2);
+  await eventually(async () => (await pool.snapshot()).idleCount === 2);
+  assert.equal(await pool.releaseAllIdle(), 2);
+  assert.equal((await pool.snapshot()).idleCount, 0);
+  await pool.shutdown(false);
+});
+
+test("retry-next-idle skips an unhealthy sandbox without duplicating acquisition", async () => {
+  const fixture = createPoolFixture({ healthById: { bad: false, good: true } });
+  const store = new InMemoryPoolStateStore();
+  const pool = SandboxPool.create({
+    poolName: "retry-pool",
+    maxIdle: 0,
+    stateStore: store,
+    maxAcquireRetries: 2,
+    acquireReadyTimeoutSeconds: 0.01,
+    acquireHealthCheckPollingIntervalMillis: 1,
+    connectionConfig: fixture.connectionConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+    sandboxCreator: fixture.sandboxCreator,
+  });
+  await pool.start();
+  await store.putIdle("retry-pool", "bad");
+  await store.putIdle("retry-pool", "good");
+
+  const sandbox = await pool.acquire({ policy: AcquirePolicy.RETRY_NEXT_IDLE });
+  assert.equal(sandbox.id, "good");
+  await eventually(async () => fixture.calls.some((call) => call.method === "kill" && call.sandboxId === "bad"));
+  assert.equal(await store.tryTakeIdle("retry-pool"), undefined);
+  await sandbox.close();
+  await pool.shutdown();
+});
+
+test("renew failure is terminal and does not consume another idle sandbox", async () => {
+  const fixture = createPoolFixture({ renewFailureIds: new Set(["first"]) });
+  const store = new InMemoryPoolStateStore();
+  const pool = SandboxPool.create({
+    poolName: "renew-pool",
+    maxIdle: 0,
+    stateStore: store,
+    maxAcquireRetries: 2,
+    connectionConfig: fixture.connectionConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+    sandboxCreator: fixture.sandboxCreator,
+  });
+  await pool.start();
+  await store.putIdle("renew-pool", "first");
+  await store.putIdle("renew-pool", "second");
+
+  await assert.rejects(
+    pool.acquire({
+      sandboxTimeoutSeconds: 60,
+      policy: AcquirePolicy.RETRY_NEXT_IDLE_THEN_CREATE,
+    }),
+    /renew failed/,
+  );
+  assert.equal(await store.tryTakeIdle("renew-pool"), "second");
+  await pool.shutdown();
+});
+
+test("forced shutdown does not wait for a creator that ignores cancellation", async () => {
+  const fixture = createPoolFixture();
+  let creatorStarted;
+  const started = new Promise((resolve) => { creatorStarted = resolve; });
+  let releaseCreator;
+  const creatorGate = new Promise((resolve) => { releaseCreator = resolve; });
+  const pool = SandboxPool.create({
+    poolName: "forced-shutdown-pool",
+    maxIdle: 1,
+    connectionConfig: fixture.connectionConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+    sandboxCreator: async () => {
+      creatorStarted();
+      await creatorGate;
+      return fixture.sandboxCreator();
+    },
+  });
+
+  await pool.start();
+  await started;
+  await pool.shutdown(false);
+  assert.equal((await pool.snapshot()).lifecycleState, PoolLifecycleState.STOPPED);
+
+  releaseCreator();
+  await eventually(async () => fixture.calls.some((call) => call.method === "creator-kill"));
+});
+
+test("acquire disposes a sandbox if forced shutdown retires the pool run", async () => {
+  const fixture = createPoolFixture();
+  const store = new InMemoryPoolStateStore();
+  const getSandboxEndpoint = fixture.sandboxes.getSandboxEndpoint.bind(fixture.sandboxes);
+  let connectStarted;
+  const started = new Promise((resolve) => { connectStarted = resolve; });
+  let releaseConnect;
+  const gate = new Promise((resolve) => { releaseConnect = resolve; });
+  fixture.sandboxes.getSandboxEndpoint = async (...args) => {
+    connectStarted();
+    await gate;
+    return getSandboxEndpoint(...args);
+  };
+  const pool = SandboxPool.create({
+    poolName: "shutdown-acquire-pool",
+    maxIdle: 0,
+    stateStore: store,
+    connectionConfig: fixture.connectionConfig,
+    creationSpec: { image: "ubuntu", adapterFactory: fixture.adapterFactory },
+    sandboxCreator: fixture.sandboxCreator,
+  });
+  await pool.start();
+  await store.putIdle("shutdown-acquire-pool", "idle");
+
+  const acquire = pool.acquire({ policy: AcquirePolicy.FAIL_FAST });
+  await started;
+  await pool.shutdown(false);
+  releaseConnect();
+
+  await assert.rejects(acquire, /is not running/);
+  await eventually(async () => fixture.calls.some((call) => call.method === "kill" && call.sandboxId === "idle"));
+});

--- a/sdks/sandbox/javascript/tests/public-exports.test.mjs
+++ b/sdks/sandbox/javascript/tests/public-exports.test.mjs
@@ -2,6 +2,23 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+function exportedDeclarationNames(declarations) {
+  const names = new Set(
+    [...declarations.matchAll(/export\s*(?:type\s+)?\{([^}]*)\}/g)].flatMap(([, body]) =>
+      body
+        .split(",")
+        .map((item) => item.trim().replace(/^type\s+/, "").split(/\s+as\s+/).at(-1))
+        .filter(Boolean),
+    ),
+  );
+  for (const [, name] of declarations.matchAll(
+    /export\s+(?:declare\s+)?(?:type|interface|class|const|function|enum)\s+([\w$]+)/g,
+  )) {
+    names.add(name);
+  }
+  return names;
+}
+
 test("public type declarations export credential substitution models", async () => {
   const declarations = await readFile(new URL("../dist/index.d.ts", import.meta.url), "utf8");
 
@@ -11,28 +28,32 @@ test("public type declarations export credential substitution models", async () 
 
 test("public type declarations export lifecycle models", async () => {
   const declarations = await readFile(new URL("../dist/index.d.ts", import.meta.url), "utf8");
-  const exportedNames = new Set(
-    [...declarations.matchAll(/export\s*(?:type\s+)?\{([^}]*)\}/g)].flatMap(([, body]) =>
-      body
-        .split(",")
-        .map((item) =>
-          item
-            .trim()
-            .replace(/^type\s+/, "")
-            .split(/\s+as\s+/)
-            .at(-1),
-        )
-        .filter(Boolean),
-    ),
-  );
-  for (const [, name] of declarations.matchAll(
-    /export\s+(?:declare\s+)?(?:type|interface|class|const|function|enum)\s+([\w$]+)/g,
-  )) {
-    exportedNames.add(name);
-  }
+  const exportedNames = exportedDeclarationNames(declarations);
 
   assert.ok(exportedNames.size > 0, "failed to parse any export clause from dist/index.d.ts");
   assert.equal(exportedNames.has("LifecycleHook"), true);
   assert.equal(exportedNames.has("PeriodicLifecycleHook"), true);
   assert.equal(exportedNames.has("SandboxLifecycle"), true);
+});
+
+test("public package exports client-side pool APIs", async () => {
+  const sdk = await import("../dist/index.js");
+  const declarations = await readFile(new URL("../dist/index.d.ts", import.meta.url), "utf8");
+
+  assert.equal(typeof sdk.SandboxPool, "function");
+  assert.equal(typeof sdk.InMemoryPoolStateStore, "function");
+  assert.equal(typeof sdk.PoolEmptyException, "function");
+  assert.equal(typeof sdk.PoolAcquireFailedException, "function");
+  assert.equal(typeof sdk.PoolNotRunningException, "function");
+  assert.equal(typeof sdk.PoolStateStoreUnavailableException, "function");
+  assert.equal(typeof sdk.AcquirePolicy, "object");
+  assert.equal(sdk.AcquirePolicy.DIRECT_CREATE, "DIRECT_CREATE");
+  assert.equal(sdk.PoolLifecycleState.RUNNING, "RUNNING");
+  assert.equal(sdk.PoolHealthState.HEALTHY, "HEALTHY");
+  assert.equal(sdk.PooledSandboxCreateReason.WARMUP, "WARMUP");
+  const exportedNames = exportedDeclarationNames(declarations);
+  assert.equal(exportedNames.has("SandboxPoolOptions"), true);
+  assert.equal(exportedNames.has("PoolStateStore"), true);
+  assert.equal(exportedNames.has("PoolSnapshot"), true);
+  assert.equal(exportedNames.has("PoolSandboxPreparer"), true);
 });

--- a/tests/javascript/tests/test_sandbox_pool_e2e.test.ts
+++ b/tests/javascript/tests/test_sandbox_pool_e2e.test.ts
@@ -62,7 +62,7 @@ test("client pool warms, acquires, drains, and falls back to direct create", asy
     });
     acquired.push(warm);
     const result = await warm.commands.run("echo js-pool-ok");
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
     expect(result.logs.stdout[0]?.text).toBe("js-pool-ok");
 
     await pool.resize(0);

--- a/tests/javascript/tests/test_sandbox_pool_e2e.test.ts
+++ b/tests/javascript/tests/test_sandbox_pool_e2e.test.ts
@@ -1,0 +1,89 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, test } from "vitest";
+
+import {
+  AcquirePolicy,
+  InMemoryPoolStateStore,
+  PoolEmptyException,
+  Sandbox,
+  SandboxPool,
+} from "@alibaba-group/opensandbox";
+
+import { createConnectionConfig, getSandboxImage } from "./base_e2e.ts";
+
+async function eventually(check: () => Promise<boolean>, timeoutMs = 120_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error("pool did not converge before timeout");
+}
+
+test("client pool warms, acquires, drains, and falls back to direct create", async () => {
+  const poolName = `js-pool-${Math.random().toString(16).slice(2, 10)}`;
+  const pool = SandboxPool.create({
+    poolName,
+    maxIdle: 1,
+    stateStore: new InMemoryPoolStateStore(),
+    connectionConfig: createConnectionConfig(),
+    creationSpec: {
+      image: getSandboxImage(),
+      metadata: { tag: poolName },
+      resource: { cpu: "1", memory: "2Gi" },
+    },
+    reconcileIntervalSeconds: 1,
+    idleTimeoutSeconds: 5 * 60,
+    warmupReadyTimeoutSeconds: 60,
+    acquireReadyTimeoutSeconds: 60,
+  });
+  const acquired: Sandbox[] = [];
+
+  try {
+    await pool.start();
+    await eventually(async () => (await pool.snapshot()).idleCount === 1);
+
+    const warm = await pool.acquire({
+      policy: AcquirePolicy.FAIL_FAST,
+      sandboxTimeoutSeconds: 5 * 60,
+    });
+    acquired.push(warm);
+    const result = await warm.commands.run("echo js-pool-ok");
+    expect(result.error).toBeNull();
+    expect(result.logs.stdout[0]?.text).toBe("js-pool-ok");
+
+    await pool.resize(0);
+    await pool.releaseAllIdle();
+    await expect(pool.acquire({ policy: AcquirePolicy.FAIL_FAST })).rejects.toBeInstanceOf(
+      PoolEmptyException,
+    );
+
+    const direct = await pool.acquire({
+      policy: AcquirePolicy.DIRECT_CREATE,
+      sandboxTimeoutSeconds: 5 * 60,
+    });
+    acquired.push(direct);
+    expect(await direct.isHealthy()).toBe(true);
+  } finally {
+    await pool.resize(0).catch(() => undefined);
+    await pool.releaseAllIdle().catch(() => undefined);
+    await pool.shutdown(false).catch(() => undefined);
+    for (const sandbox of acquired) {
+      await sandbox.kill().catch(() => undefined);
+      await sandbox.close().catch(() => undefined);
+    }
+  }
+}, 5 * 60_000);


### PR DESCRIPTION
# Summary
- Add a client-side `SandboxPool` for the JavaScript/TypeScript SDK, aligned with the existing Java pool lifecycle and acquisition policies.
- Provide pluggable `PoolStateStore` contracts plus a process-local `InMemoryPoolStateStore` implementation with FIFO idle acquisition, TTL filtering, and primary-owner coordination.
- Support warmup, resize, idle draining, health checks, direct-create fallback, graceful/forced shutdown, and public pool-specific exceptions and types.
- Document caller ownership: acquired sandboxes leave the pool permanently and must be killed/closed by the caller.
- Add focused unit coverage and a real Docker-backed E2E covering warmup, FAIL_FAST acquisition, command execution, drain, empty-pool behavior, DIRECT_CREATE fallback, and cleanup.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
  - `pnpm test` in `sdks/sandbox/javascript`: 128 passed
- [ ] Integration tests
- [x] e2e / manual verification
  - `pnpm exec vitest run tests/test_sandbox_pool_e2e.test.ts --reporter=verbose`: 1 passed
  - Verified the lifecycle API returned zero remaining sandboxes and Docker had no leaked sandbox containers after cleanup.
- [x] Static validation
  - JavaScript SDK ESLint passed
  - JavaScript SDK TypeScript check passed
  - JavaScript SDK build passed

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

The pool is additive. It does not change existing sandbox creation APIs or transfer caller-owned sandboxes back into the idle pool. The built-in state store is intentionally process-local; distributed implementations can provide the same atomic store contract.

Related to #1492