### PR TITLE
fix(server): coordinate snapshot recovery across replicas

### DIFF
--- a/.github/workflows/helm-release-test.yml
+++ b/.github/workflows/helm-release-test.yml
@@ -60,6 +60,22 @@ jobs:
         with:
           version: 'v3.21.3'
 
+      - name: Verify server snapshot-store replica safety
+        run: |
+          set -euo pipefail
+          chart_path="kubernetes/charts/opensandbox-server"
+          error_log="${RUNNER_TEMP}/opensandbox-server-sqlite-replica-error.log"
+          if helm template opensandbox-server "$chart_path" \
+            --set server.replicaCount=2 >/dev/null 2>"$error_log"; then
+            echo "::error::SQLite multi-replica render unexpectedly succeeded"
+            exit 1
+          fi
+          grep -F 'requires [store] type = "postgresql"' "$error_log"
+          helm template opensandbox-server "$chart_path" \
+            --set server.replicaCount=2 \
+            --set-string $'configToml=[store]\ntype = "postgresql"\n' \
+            >/dev/null
+
       - name: Install Kind
         run: |
           go install sigs.k8s.io/kind@v0.31.0

--- a/.github/workflows/helm-release-test.yml
+++ b/.github/workflows/helm-release-test.yml
@@ -87,6 +87,22 @@ jobs:
             exit 1
           fi
           grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
+          if helm template opensandbox-server "$chart_path" \
+            --set server.replicaCount=2 \
+            --set-string $'configToml=[runtime]\ntype = "docker"\n\n[[runtime.backends]]\ntype = "kubernetes"\n\n[store]\ntype = "sqlite"\n\n[[store.backends]]\ntype = "postgresql"\n' \
+            >/dev/null 2>"$error_log"; then
+            echo "::error::TOML array tables widened replica-safety sections"
+            exit 1
+          fi
+          grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
+          if helm template opensandbox-server "$chart_path" \
+            --set server.replicaCount=2 \
+            --set-string $'configToml=[runtime]\ntype = "docker"\nnote = """\ntype = "kubernetes"\n"""\n\n[store]\ntype = "sqlite"\nnote = """\ntype = "postgresql"\n"""\n' \
+            >/dev/null 2>"$error_log"; then
+            echo "::error::TOML multiline values widened replica-safety sections"
+            exit 1
+          fi
+          grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
           helm template opensandbox-server "$chart_path" \
             --set server.replicaCount=2 \
             --set-string $'configToml=[runtime] # active runtime\ntype = "kubernetes" # multi-replica\n\n[store] # active store\ntype = "postgresql" # shared database\n' \

--- a/.github/workflows/helm-release-test.yml
+++ b/.github/workflows/helm-release-test.yml
@@ -70,10 +70,18 @@ jobs:
             echo "::error::SQLite multi-replica render unexpectedly succeeded"
             exit 1
           fi
-          grep -F 'requires [store] type = "postgresql"' "$error_log"
+          grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
+          if helm template opensandbox-server "$chart_path" \
+            --set server.replicaCount=2 \
+            --set-string $'configToml=[runtime]\ntype = "docker"\n\n[store]\ntype = "postgresql"\n' \
+            >/dev/null 2>"$error_log"; then
+            echo "::error::Docker multi-replica render unexpectedly succeeded"
+            exit 1
+          fi
+          grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
           helm template opensandbox-server "$chart_path" \
             --set server.replicaCount=2 \
-            --set-string $'configToml=[store]\ntype = "postgresql"\n' \
+            --set-string $'configToml=[runtime]\ntype = "kubernetes"\n\n[store]\ntype = "postgresql"\n' \
             >/dev/null
 
       - name: Install Kind

--- a/.github/workflows/helm-release-test.yml
+++ b/.github/workflows/helm-release-test.yml
@@ -67,44 +67,28 @@ jobs:
           error_log="${RUNNER_TEMP}/opensandbox-server-sqlite-replica-error.log"
           if helm template opensandbox-server "$chart_path" \
             --set server.replicaCount=2 >/dev/null 2>"$error_log"; then
-            echo "::error::SQLite multi-replica render unexpectedly succeeded"
+            echo "::error::Undeclared multi-replica render unexpectedly succeeded"
             exit 1
           fi
-          grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
+          grep -F 'requires server.replicaSafetyMode = "postgresql-kubernetes"' "$error_log"
           if helm template opensandbox-server "$chart_path" \
             --set server.replicaCount=2 \
-            --set-string $'configToml=[runtime]\ntype = "docker"\n\n[store]\ntype = "postgresql"\n' \
+            --set-string $'configToml=note = """\n[runtime]\ntype = "kubernetes"\n[store]\ntype = "postgresql"\n"""\n\n[runtime]\ntype = "docker"\n\n[store]\ntype = "sqlite"\n' \
             >/dev/null 2>"$error_log"; then
-            echo "::error::Docker multi-replica render unexpectedly succeeded"
+            echo "::error::TOML string content bypassed the explicit replica declaration"
             exit 1
           fi
-          grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
+          grep -F 'requires server.replicaSafetyMode = "postgresql-kubernetes"' "$error_log"
           if helm template opensandbox-server "$chart_path" \
-            --set server.replicaCount=2 \
-            --set-string $'configToml=[runtime] # active runtime\ntype = "docker"\n\n[store] # active store\ntype = "sqlite"\n\n[unrelated]\ntype = "kubernetes"\n\n[unrelated.nested]\ntype = "postgresql"\n' \
+            --set-string server.replicaSafetyMode=postgresql-docker \
             >/dev/null 2>"$error_log"; then
-            echo "::error::Commented TOML headers widened replica-safety sections"
+            echo "::error::Unsupported replica safety mode unexpectedly succeeded"
             exit 1
           fi
-          grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
-          if helm template opensandbox-server "$chart_path" \
-            --set server.replicaCount=2 \
-            --set-string $'configToml=[runtime]\ntype = "docker"\n\n[[runtime.backends]]\ntype = "kubernetes"\n\n[store]\ntype = "sqlite"\n\n[[store.backends]]\ntype = "postgresql"\n' \
-            >/dev/null 2>"$error_log"; then
-            echo "::error::TOML array tables widened replica-safety sections"
-            exit 1
-          fi
-          grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
-          if helm template opensandbox-server "$chart_path" \
-            --set server.replicaCount=2 \
-            --set-string $'configToml=[runtime]\ntype = "docker"\nnote = """\ntype = "kubernetes"\n"""\n\n[store]\ntype = "sqlite"\nnote = """\ntype = "postgresql"\n"""\n' \
-            >/dev/null 2>"$error_log"; then
-            echo "::error::TOML multiline values widened replica-safety sections"
-            exit 1
-          fi
-          grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
+          grep -F 'server.replicaSafetyMode must be empty or "postgresql-kubernetes"' "$error_log"
           helm template opensandbox-server "$chart_path" \
             --set server.replicaCount=2 \
+            --set-string server.replicaSafetyMode=postgresql-kubernetes \
             --set-string $'configToml=[runtime] # active runtime\ntype = "kubernetes" # multi-replica\n\n[store] # active store\ntype = "postgresql" # shared database\n' \
             >/dev/null
 

--- a/.github/workflows/helm-release-test.yml
+++ b/.github/workflows/helm-release-test.yml
@@ -79,9 +79,17 @@ jobs:
             exit 1
           fi
           grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
+          if helm template opensandbox-server "$chart_path" \
+            --set server.replicaCount=2 \
+            --set-string $'configToml=[runtime] # active runtime\ntype = "docker"\n\n[store] # active store\ntype = "sqlite"\n\n[unrelated]\ntype = "kubernetes"\n\n[unrelated.nested]\ntype = "postgresql"\n' \
+            >/dev/null 2>"$error_log"; then
+            echo "::error::Commented TOML headers widened replica-safety sections"
+            exit 1
+          fi
+          grep -F 'requires [store] type = "postgresql" and [runtime] type = "kubernetes"' "$error_log"
           helm template opensandbox-server "$chart_path" \
             --set server.replicaCount=2 \
-            --set-string $'configToml=[runtime]\ntype = "kubernetes"\n\n[store]\ntype = "postgresql"\n' \
+            --set-string $'configToml=[runtime] # active runtime\ntype = "kubernetes" # multi-replica\n\n[store] # active store\ntype = "postgresql" # shared database\n' \
             >/dev/null
 
       - name: Install Kind

--- a/docs/components/server.md
+++ b/docs/components/server.md
@@ -88,9 +88,11 @@ export OPENSANDBOX_STORE_POSTGRESQL_DSN='postgresql://opensandbox:password@postg
 opensandbox-server
 ```
 
-::: warning
-Snapshot recovery is not coordinated across server processes. Run only one active server process against a PostgreSQL database.
+::: tip
+PostgreSQL coordinates server-managed Kubernetes snapshot operations across active Server processes with expiring leases and fenced terminal writes. SQLite remains limited to one active Server process. Docker snapshot execution also remains single-active because Docker image and registry side effects are not fenced across hosts.
 :::
+
+The coordination guarantee is one current database owner, takeover after lease expiry, and a unique fenced terminal database result. Kubernetes recovery observes the deterministic `SandboxSnapshot` before creating it. This is not an exactly-once guarantee across PostgreSQL, Kubernetes, and the image registry.
 
 For Kubernetes Secret and Helm values wiring, see [Kubernetes Deployment](/kubernetes/deployment#use-postgresql-for-server-persistence).
 

--- a/docs/kubernetes/deployment.md
+++ b/docs/kubernetes/deployment.md
@@ -56,7 +56,7 @@ Reference the Secret from a values file:
 ```yaml
 # values-server.yaml
 server:
-  replicaCount: 2
+  replicaCount: 1
   env:
     - name: OPENSANDBOX_SERVER_API_KEY
       valueFrom:
@@ -82,13 +82,13 @@ kubectl create secret generic opensandbox-postgresql \
 unset OPENSANDBOX_POSTGRESQL_DSN
 ```
 
-In `values-server.yaml`, set `server.replicaCount` to `1`, add the Secret-backed
-environment variable below, and add the shown `[store]` tables to the complete
-`configToml` value:
+In `values-server.yaml`, set the desired Server replica count, add the
+Secret-backed environment variable below, and add the shown `[store]` tables to
+the complete `configToml` value:
 
 ```yaml
 server:
-  replicaCount: 1
+  replicaCount: 2
   env:
     - name: OPENSANDBOX_STORE_POSTGRESQL_DSN
       valueFrom:
@@ -106,10 +106,24 @@ configToml: |
   max_pool_size = 10
 ```
 
-::: warning
-Snapshot recovery is not coordinated across server replicas. Keep
-`server.replicaCount: 1` when replicas use the same PostgreSQL database.
+::: info
+Multiple active Server replicas are supported for Kubernetes public snapshots
+when every replica uses the same PostgreSQL database. The chart rejects
+`server.replicaCount > 1` unless `configToml` selects PostgreSQL. It does not add
+session affinity because any healthy replica can read or restore a terminal
+snapshot.
 :::
+
+PostgreSQL operation leases select one worker for each `Creating` or `Deleting`
+snapshot. A surviving replica takes over after lease expiry. Kubernetes recovery
+reads the deterministic `SandboxSnapshot` before it creates anything, so an
+existing CR and its commit Job are observed instead of duplicated. Terminal
+database writes are fenced by owner and generation. These controls do not claim
+exactly-once behavior across PostgreSQL, the Kubernetes API, the controller, and
+the OCI registry.
+
+Docker public snapshots remain limited to one active Server because Docker image
+and registry side effects cannot be safely fenced by the PostgreSQL lease alone.
 
 ### Install and verify
 
@@ -152,7 +166,7 @@ curl --fail http://127.0.0.1:8080/health
 |-------|---------|-------|
 | `server.image.repository` | Server image registry and repository | Override for a private mirror or custom build. |
 | `server.image.tag` | Server image version | The release install command pins it to `APP_VERSION`. |
-| `server.replicaCount` | Number of server Pods | Defaults to `2`. |
+| `server.replicaCount` | Number of server Pods | Defaults to `1`. Values greater than `1` require `[store] type = "postgresql"` in `configToml`. |
 | `server.env` | Additional container environment variables | Use it with `secretKeyRef` for `OPENSANDBOX_SERVER_API_KEY`. |
 | `configToml` | Complete server configuration | Mounted at `/etc/opensandbox/config.toml`; overriding it replaces the complete default TOML, including the workload namespace. |
 | `server.gateway.enabled` | Deploy the ingress gateway with the server | Defaults to `false`. |

--- a/docs/kubernetes/deployment.md
+++ b/docs/kubernetes/deployment.md
@@ -89,6 +89,7 @@ the complete `configToml` value:
 ```yaml
 server:
   replicaCount: 2
+  replicaSafetyMode: postgresql-kubernetes
   env:
     - name: OPENSANDBOX_STORE_POSTGRESQL_DSN
       valueFrom:
@@ -109,9 +110,11 @@ configToml: |
 ::: info
 Multiple active Server replicas are supported for Kubernetes public snapshots
 when every replica uses the same PostgreSQL database. The chart rejects
-`server.replicaCount > 1` unless `configToml` selects both PostgreSQL and the
-Kubernetes runtime. It does not add session affinity because any healthy replica
-can read or restore a terminal snapshot.
+`server.replicaCount > 1` unless `server.replicaSafetyMode` explicitly declares
+`postgresql-kubernetes`. Set this declaration only when `configToml` selects
+both PostgreSQL and the Kubernetes runtime; Helm cannot safely parse arbitrary
+TOML to verify the declaration. The chart does not add session affinity because
+any healthy replica can read or restore a terminal snapshot.
 :::
 
 PostgreSQL operation leases select one worker for each `Creating` or `Deleting`
@@ -166,7 +169,8 @@ curl --fail http://127.0.0.1:8080/health
 |-------|---------|-------|
 | `server.image.repository` | Server image registry and repository | Override for a private mirror or custom build. |
 | `server.image.tag` | Server image version | The release install command pins it to `APP_VERSION`. |
-| `server.replicaCount` | Number of server Pods | Defaults to `1`. Values greater than `1` require `[store] type = "postgresql"` and `[runtime] type = "kubernetes"` in `configToml`. |
+| `server.replicaCount` | Number of server Pods | Defaults to `1`. Values greater than `1` require `server.replicaSafetyMode = "postgresql-kubernetes"` and matching PostgreSQL/Kubernetes settings in `configToml`. |
+| `server.replicaSafetyMode` | Explicit multi-replica snapshot topology declaration | Defaults to empty. Set to `postgresql-kubernetes` only when `configToml` selects PostgreSQL and the Kubernetes runtime. |
 | `server.env` | Additional container environment variables | Use it with `secretKeyRef` for `OPENSANDBOX_SERVER_API_KEY`. |
 | `configToml` | Complete server configuration | Mounted at `/etc/opensandbox/config.toml`; overriding it replaces the complete default TOML, including the workload namespace. |
 | `server.gateway.enabled` | Deploy the ingress gateway with the server | Defaults to `false`. |

--- a/docs/kubernetes/deployment.md
+++ b/docs/kubernetes/deployment.md
@@ -166,7 +166,7 @@ curl --fail http://127.0.0.1:8080/health
 |-------|---------|-------|
 | `server.image.repository` | Server image registry and repository | Override for a private mirror or custom build. |
 | `server.image.tag` | Server image version | The release install command pins it to `APP_VERSION`. |
-| `server.replicaCount` | Number of server Pods | Defaults to `1`. Values greater than `1` require `[store] type = "postgresql"` in `configToml`. |
+| `server.replicaCount` | Number of server Pods | Defaults to `1`. Values greater than `1` require `[store] type = "postgresql"` and `[runtime] type = "kubernetes"` in `configToml`. |
 | `server.env` | Additional container environment variables | Use it with `secretKeyRef` for `OPENSANDBOX_SERVER_API_KEY`. |
 | `configToml` | Complete server configuration | Mounted at `/etc/opensandbox/config.toml`; overriding it replaces the complete default TOML, including the workload namespace. |
 | `server.gateway.enabled` | Deploy the ingress gateway with the server | Defaults to `false`. |

--- a/docs/kubernetes/deployment.md
+++ b/docs/kubernetes/deployment.md
@@ -109,9 +109,9 @@ configToml: |
 ::: info
 Multiple active Server replicas are supported for Kubernetes public snapshots
 when every replica uses the same PostgreSQL database. The chart rejects
-`server.replicaCount > 1` unless `configToml` selects PostgreSQL. It does not add
-session affinity because any healthy replica can read or restore a terminal
-snapshot.
+`server.replicaCount > 1` unless `configToml` selects both PostgreSQL and the
+Kubernetes runtime. It does not add session affinity because any healthy replica
+can read or restore a terminal snapshot.
 :::
 
 PostgreSQL operation leases select one worker for each `Creating` or `Deleting`

--- a/docs/kubernetes/deployment.md
+++ b/docs/kubernetes/deployment.md
@@ -125,6 +125,11 @@ database writes are fenced by owner and generation. These controls do not claim
 exactly-once behavior across PostgreSQL, the Kubernetes API, the controller, and
 the OCI registry.
 
+The operation-attempt counter is incremented immediately before runtime side
+effects begin, rather than when a lease is claimed. This lets a queued snapshot
+whose execution never started use the normal create path when capacity becomes
+available, while a previously started operation uses observation-first recovery.
+
 Docker public snapshots remain limited to one active Server because Docker image
 and registry side effects cannot be safely fenced by the PostgreSQL lease alone.
 

--- a/docs/reference/snapshot-store-migration.md
+++ b/docs/reference/snapshot-store-migration.md
@@ -5,7 +5,7 @@ description: Migration guide for switching the server snapshot store from SQLite
 
 # Snapshot Store Migration Guide
 
-Feature: [#1653](https://github.com/opensandbox-group/OpenSandbox/pull/1653)
+Features: [PostgreSQL store #1653](https://github.com/opensandbox-group/OpenSandbox/pull/1653), [migration #1669](https://github.com/opensandbox-group/OpenSandbox/issues/1669)
 
 ## Background
 
@@ -62,6 +62,9 @@ Snapshots migrated: total=42, migrated=42, skipped=0
 - The PostgreSQL schema is created only on a real migration run, when the table does not
   already exist.
 - Timestamps stored as naive UTC in SQLite are written as `TIMESTAMPTZ` in UTC.
+- Operation generation and attempt counters are preserved, while any source
+  lease owner and expiry are cleared. Stop the SQLite Server before migration;
+  a lease from that stopped process must not block PostgreSQL recovery.
 
 ## Switch the server
 
@@ -79,7 +82,19 @@ dsn = "postgresql://user:password@localhost:5432/opensandbox"
 Restart the server. Snapshot lookups and restore requests now read the shared PostgreSQL
 catalog, including the migrated records.
 
+For Kubernetes public snapshots, you may then increase the active Server replica
+count. Every replica must use this same PostgreSQL database. Docker public
+snapshots remain limited to one active Server.
+
 ## Verify
 
 - `GET /v1/sandboxes/{id}/snapshots` returns the migrated snapshot records.
 - Restoring a sandbox with an existing `snapshotId` succeeds.
+
+## Roll back the Server version
+
+The PostgreSQL schema upgrade adds columns with backward-compatible defaults, so
+an older Server can still read the snapshot table. Before starting an older
+version, scale back to one active Server because versions without operation
+leases cannot coordinate in-flight snapshot work. The migration command is
+one-way and does not copy later PostgreSQL changes back to SQLite.

--- a/docs/reference/snapshot-store-migration.md
+++ b/docs/reference/snapshot-store-migration.md
@@ -65,6 +65,9 @@ Snapshots migrated: total=42, migrated=42, skipped=0
 - Operation generation and attempt counters are preserved, while any source
   lease owner and expiry are cleared. Stop the SQLite Server before migration;
   a lease from that stopped process must not block PostgreSQL recovery.
+- Legacy unfinished `Creating` rows that predate the attempt counter are
+  conservatively marked as already started, so recovery observes existing
+  runtime state instead of repeating external creation side effects.
 
 ## Switch the server
 

--- a/kubernetes/charts/opensandbox-server/README.md
+++ b/kubernetes/charts/opensandbox-server/README.md
@@ -58,9 +58,10 @@ helm install opensandbox-server "${CHART_URL}" \
 See the [Kubernetes deployment guide](../../../docs/kubernetes/deployment.md) for production configuration, verification, and upgrades.
 
 The chart defaults to one Server replica. Setting `server.replicaCount` above
-one requires `[store] type = "postgresql"` and `[runtime] type = "kubernetes"`
-in `configToml`; rendering fails closed for the default SQLite store and the
-Docker runtime. Docker snapshots remain single-active.
+one requires `server.replicaSafetyMode = "postgresql-kubernetes"`. This value is
+an explicit topology declaration; set it only when `configToml` selects
+`[store] type = "postgresql"` and `[runtime] type = "kubernetes"`. Rendering
+fails closed without the declaration. Docker snapshots remain single-active.
 
 ## Install from local source
 
@@ -159,7 +160,8 @@ The following table lists the configurable parameters of the chart and their def
 | server.podLabels | object | `{}` | Extra labels for the server pod. |
 | server.podSecurityContext | object | `{}` | Pod-level security context for the server pod. |
 | server.priorityClassName | string | `""` | Priority class name for the server pod. |
-| server.replicaCount | int | `1` | Number of server replicas. Values greater than 1 require PostgreSQL and the Kubernetes runtime in configToml. |
+| server.replicaCount | int | `1` | Number of server replicas. Values greater than 1 require replicaSafetyMode "postgresql-kubernetes" and matching configToml settings. |
+| server.replicaSafetyMode | string | `""` | Explicit snapshot topology declaration. Set to "postgresql-kubernetes" only when configToml selects PostgreSQL and the Kubernetes runtime; required when replicaCount is greater than 1. |
 | server.resources | object | `{"limits":{"cpu":"2","memory":"8Gi"},"requests":{"cpu":"1","memory":"4Gi"}}` | Resource requests and limits |
 | server.service.nodePort | string | `""` | Node port to bind when type is not ClusterIP. Empty lets Kubernetes allocate one from the cluster node-port range. |
 | server.service.type | string | `"ClusterIP"` | Service type for the server. Set to NodePort or LoadBalancer to reach the server from outside the cluster. |

--- a/kubernetes/charts/opensandbox-server/README.md
+++ b/kubernetes/charts/opensandbox-server/README.md
@@ -57,6 +57,12 @@ helm install opensandbox-server "${CHART_URL}" \
 
 See the [Kubernetes deployment guide](../../../docs/kubernetes/deployment.md) for production configuration, verification, and upgrades.
 
+The chart defaults to one Server replica. Setting `server.replicaCount` above
+one requires `[store] type = "postgresql"` in `configToml`; rendering fails
+closed for the default SQLite store. Multi-replica snapshot execution is
+supported for the Kubernetes runtime only. Docker snapshots remain
+single-active.
+
 ## Install from local source
 
 ```bash
@@ -154,7 +160,7 @@ The following table lists the configurable parameters of the chart and their def
 | server.podLabels | object | `{}` | Extra labels for the server pod. |
 | server.podSecurityContext | object | `{}` | Pod-level security context for the server pod. |
 | server.priorityClassName | string | `""` | Priority class name for the server pod. |
-| server.replicaCount | int | `2` | Number of server replicas |
+| server.replicaCount | int | `1` | Number of server replicas. Values greater than 1 require PostgreSQL in configToml. |
 | server.resources | object | `{"limits":{"cpu":"2","memory":"8Gi"},"requests":{"cpu":"1","memory":"4Gi"}}` | Resource requests and limits |
 | server.service.nodePort | string | `""` | Node port to bind when type is not ClusterIP. Empty lets Kubernetes allocate one from the cluster node-port range. |
 | server.service.type | string | `"ClusterIP"` | Service type for the server. Set to NodePort or LoadBalancer to reach the server from outside the cluster. |

--- a/kubernetes/charts/opensandbox-server/README.md
+++ b/kubernetes/charts/opensandbox-server/README.md
@@ -58,10 +58,9 @@ helm install opensandbox-server "${CHART_URL}" \
 See the [Kubernetes deployment guide](../../../docs/kubernetes/deployment.md) for production configuration, verification, and upgrades.
 
 The chart defaults to one Server replica. Setting `server.replicaCount` above
-one requires `[store] type = "postgresql"` in `configToml`; rendering fails
-closed for the default SQLite store. Multi-replica snapshot execution is
-supported for the Kubernetes runtime only. Docker snapshots remain
-single-active.
+one requires `[store] type = "postgresql"` and `[runtime] type = "kubernetes"`
+in `configToml`; rendering fails closed for the default SQLite store and the
+Docker runtime. Docker snapshots remain single-active.
 
 ## Install from local source
 
@@ -160,7 +159,7 @@ The following table lists the configurable parameters of the chart and their def
 | server.podLabels | object | `{}` | Extra labels for the server pod. |
 | server.podSecurityContext | object | `{}` | Pod-level security context for the server pod. |
 | server.priorityClassName | string | `""` | Priority class name for the server pod. |
-| server.replicaCount | int | `1` | Number of server replicas. Values greater than 1 require PostgreSQL in configToml. |
+| server.replicaCount | int | `1` | Number of server replicas. Values greater than 1 require PostgreSQL and the Kubernetes runtime in configToml. |
 | server.resources | object | `{"limits":{"cpu":"2","memory":"8Gi"},"requests":{"cpu":"1","memory":"4Gi"}}` | Resource requests and limits |
 | server.service.nodePort | string | `""` | Node port to bind when type is not ClusterIP. Empty lets Kubernetes allocate one from the cluster node-port range. |
 | server.service.type | string | `"ClusterIP"` | Service type for the server. Set to NodePort or LoadBalancer to reach the server from outside the cluster. |

--- a/kubernetes/charts/opensandbox-server/README.md.gotmpl
+++ b/kubernetes/charts/opensandbox-server/README.md.gotmpl
@@ -57,6 +57,12 @@ helm install opensandbox-server "${CHART_URL}" \
 
 See the [Kubernetes deployment guide](../../../docs/kubernetes/deployment.md) for production configuration, verification, and upgrades.
 
+The chart defaults to one Server replica. Setting `server.replicaCount` above
+one requires `[store] type = "postgresql"` in `configToml`; rendering fails
+closed for the default SQLite store. Multi-replica snapshot execution is
+supported for the Kubernetes runtime only. Docker snapshots remain
+single-active.
+
 ## Install from local source
 
 ```bash

--- a/kubernetes/charts/opensandbox-server/README.md.gotmpl
+++ b/kubernetes/charts/opensandbox-server/README.md.gotmpl
@@ -58,9 +58,10 @@ helm install opensandbox-server "${CHART_URL}" \
 See the [Kubernetes deployment guide](../../../docs/kubernetes/deployment.md) for production configuration, verification, and upgrades.
 
 The chart defaults to one Server replica. Setting `server.replicaCount` above
-one requires `[store] type = "postgresql"` and `[runtime] type = "kubernetes"`
-in `configToml`; rendering fails closed for the default SQLite store and the
-Docker runtime. Docker snapshots remain single-active.
+one requires `server.replicaSafetyMode = "postgresql-kubernetes"`. This value is
+an explicit topology declaration; set it only when `configToml` selects
+`[store] type = "postgresql"` and `[runtime] type = "kubernetes"`. Rendering
+fails closed without the declaration. Docker snapshots remain single-active.
 
 ## Install from local source
 

--- a/kubernetes/charts/opensandbox-server/README.md.gotmpl
+++ b/kubernetes/charts/opensandbox-server/README.md.gotmpl
@@ -58,10 +58,9 @@ helm install opensandbox-server "${CHART_URL}" \
 See the [Kubernetes deployment guide](../../../docs/kubernetes/deployment.md) for production configuration, verification, and upgrades.
 
 The chart defaults to one Server replica. Setting `server.replicaCount` above
-one requires `[store] type = "postgresql"` in `configToml`; rendering fails
-closed for the default SQLite store. Multi-replica snapshot execution is
-supported for the Kubernetes runtime only. Docker snapshots remain
-single-active.
+one requires `[store] type = "postgresql"` and `[runtime] type = "kubernetes"`
+in `configToml`; rendering fails closed for the default SQLite store and the
+Docker runtime. Docker snapshots remain single-active.
 
 ## Install from local source
 

--- a/kubernetes/charts/opensandbox-server/templates/_helpers.tpl
+++ b/kubernetes/charts/opensandbox-server/templates/_helpers.tpl
@@ -95,10 +95,10 @@ process-local, and Docker snapshot execution cannot coordinate active replicas.
 {{- define "opensandbox-server.validateSnapshotStoreReplicas" -}}
 {{- if gt (int .Values.server.replicaCount) 1 -}}
 {{- $configToml := printf "%s\n" .Values.configToml -}}
-{{- $storeSection := regexFind `(?ms)^[[:space:]]*\[store\][[:space:]]*(?:#.*)?$.*?(?:^[[:space:]]*\[[^]]+\][[:space:]]*(?:#.*)?$|\z)` $configToml -}}
-{{- $usesPostgreSQL := regexMatch `(?m)^[[:space:]]*type[[:space:]]*=[[:space:]]*["']postgresql["'][[:space:]]*(?:#.*)?$` $storeSection -}}
-{{- $runtimeSection := regexFind `(?ms)^[[:space:]]*\[runtime\][[:space:]]*(?:#.*)?$.*?(?:^[[:space:]]*\[[^]]+\][[:space:]]*(?:#.*)?$|\z)` $configToml -}}
-{{- $usesKubernetes := regexMatch `(?m)^[[:space:]]*type[[:space:]]*=[[:space:]]*["']kubernetes["'][[:space:]]*(?:#.*)?$` $runtimeSection -}}
+{{- $storeSection := regexFind `(?ms)^[[:space:]]*\[store\][[:space:]]*(?:#[^\r\n]*)?$.*?(?:^[[:space:]]*\[[^]]+\][[:space:]]*(?:#[^\r\n]*)?$|\z)` $configToml -}}
+{{- $usesPostgreSQL := regexMatch `(?m)^[[:space:]]*type[[:space:]]*=[[:space:]]*["']postgresql["'][[:space:]]*(?:#[^\r\n]*)?$` $storeSection -}}
+{{- $runtimeSection := regexFind `(?ms)^[[:space:]]*\[runtime\][[:space:]]*(?:#[^\r\n]*)?$.*?(?:^[[:space:]]*\[[^]]+\][[:space:]]*(?:#[^\r\n]*)?$|\z)` $configToml -}}
+{{- $usesKubernetes := regexMatch `(?m)^[[:space:]]*type[[:space:]]*=[[:space:]]*["']kubernetes["'][[:space:]]*(?:#[^\r\n]*)?$` $runtimeSection -}}
 {{- if or (not $usesPostgreSQL) (not $usesKubernetes) -}}
 {{- fail "server.replicaCount greater than 1 requires [store] type = \"postgresql\" and [runtime] type = \"kubernetes\" in configToml; SQLite and Docker snapshot execution support one active server replica" -}}
 {{- end -}}

--- a/kubernetes/charts/opensandbox-server/templates/_helpers.tpl
+++ b/kubernetes/charts/opensandbox-server/templates/_helpers.tpl
@@ -89,14 +89,18 @@ Image pull policy
 
 {{/*
 Reject multiple server replicas unless the effective [store] section selects
-PostgreSQL. SQLite is process-local and cannot coordinate active replicas.
+PostgreSQL and the effective [runtime] section selects Kubernetes. SQLite is
+process-local, and Docker snapshot execution cannot coordinate active replicas.
 */}}
 {{- define "opensandbox-server.validateSnapshotStoreReplicas" -}}
 {{- if gt (int .Values.server.replicaCount) 1 -}}
-{{- $storeSection := regexFind `(?ms)^[[:space:]]*\[store\][[:space:]]*(?:#.*)?$.*?(?:^[[:space:]]*\[[^]]+\][[:space:]]*(?:#.*)?$|\z)` (printf "%s\n" .Values.configToml) -}}
+{{- $configToml := printf "%s\n" .Values.configToml -}}
+{{- $storeSection := regexFind `(?ms)^[[:space:]]*\[store\][[:space:]]*(?:#.*)?$.*?(?:^[[:space:]]*\[[^]]+\][[:space:]]*(?:#.*)?$|\z)` $configToml -}}
 {{- $usesPostgreSQL := regexMatch `(?m)^[[:space:]]*type[[:space:]]*=[[:space:]]*["']postgresql["'][[:space:]]*(?:#.*)?$` $storeSection -}}
-{{- if not $usesPostgreSQL -}}
-{{- fail "server.replicaCount greater than 1 requires [store] type = \"postgresql\" in configToml; SQLite supports one active server replica" -}}
+{{- $runtimeSection := regexFind `(?ms)^[[:space:]]*\[runtime\][[:space:]]*(?:#.*)?$.*?(?:^[[:space:]]*\[[^]]+\][[:space:]]*(?:#.*)?$|\z)` $configToml -}}
+{{- $usesKubernetes := regexMatch `(?m)^[[:space:]]*type[[:space:]]*=[[:space:]]*["']kubernetes["'][[:space:]]*(?:#.*)?$` $runtimeSection -}}
+{{- if or (not $usesPostgreSQL) (not $usesKubernetes) -}}
+{{- fail "server.replicaCount greater than 1 requires [store] type = \"postgresql\" and [runtime] type = \"kubernetes\" in configToml; SQLite and Docker snapshot execution support one active server replica" -}}
 {{- end -}}
 {{- end -}}
 {{- end }}

--- a/kubernetes/charts/opensandbox-server/templates/_helpers.tpl
+++ b/kubernetes/charts/opensandbox-server/templates/_helpers.tpl
@@ -88,6 +88,20 @@ Image pull policy
 {{- end }}
 
 {{/*
+Reject multiple server replicas unless the effective [store] section selects
+PostgreSQL. SQLite is process-local and cannot coordinate active replicas.
+*/}}
+{{- define "opensandbox-server.validateSnapshotStoreReplicas" -}}
+{{- if gt (int .Values.server.replicaCount) 1 -}}
+{{- $storeSection := regexFind `(?ms)^[[:space:]]*\[store\][[:space:]]*(?:#.*)?$.*?(?:^[[:space:]]*\[[^]]+\][[:space:]]*(?:#.*)?$|\z)` (printf "%s\n" .Values.configToml) -}}
+{{- $usesPostgreSQL := regexMatch `(?m)^[[:space:]]*type[[:space:]]*=[[:space:]]*["']postgresql["'][[:space:]]*(?:#.*)?$` $storeSection -}}
+{{- if not $usesPostgreSQL -}}
+{{- fail "server.replicaCount greater than 1 requires [store] type = \"postgresql\" in configToml; SQLite supports one active server replica" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 RBAC apiVersion
 */}}
 {{- define "opensandbox-server.rbac.apiVersion" -}}

--- a/kubernetes/charts/opensandbox-server/templates/_helpers.tpl
+++ b/kubernetes/charts/opensandbox-server/templates/_helpers.tpl
@@ -88,17 +88,18 @@ Image pull policy
 {{- end }}
 
 {{/*
-Reject multiple server replicas unless the effective [store] section selects
-PostgreSQL and the effective [runtime] section selects Kubernetes. SQLite is
-process-local, and Docker snapshot execution cannot coordinate active replicas.
+Reject multiple server replicas unless the operator explicitly declares the
+supported PostgreSQL plus Kubernetes snapshot topology. Helm cannot safely
+parse arbitrary TOML, so this declaration must match configToml.
 */}}
 {{- define "opensandbox-server.validateSnapshotStoreReplicas" -}}
+{{- $mode := .Values.server.replicaSafetyMode | default "" -}}
+{{- if and (ne $mode "") (ne $mode "postgresql-kubernetes") -}}
+{{- fail "server.replicaSafetyMode must be empty or \"postgresql-kubernetes\"" -}}
+{{- end -}}
 {{- if gt (int .Values.server.replicaCount) 1 -}}
-{{- $configToml := printf "%s\n" .Values.configToml -}}
-{{- $usesPostgreSQL := regexMatch `(?m)^[ \t]*\[store\][ \t]*(?:#[^\r\n]*)?\r?\n(?:[ \t]*(?:#[^\r\n]*)?\r?\n)*[ \t]*type[ \t]*=[ \t]*["']postgresql["'][ \t]*(?:#[^\r\n]*)?\r?$` $configToml -}}
-{{- $usesKubernetes := regexMatch `(?m)^[ \t]*\[runtime\][ \t]*(?:#[^\r\n]*)?\r?\n(?:[ \t]*(?:#[^\r\n]*)?\r?\n)*[ \t]*type[ \t]*=[ \t]*["']kubernetes["'][ \t]*(?:#[^\r\n]*)?\r?$` $configToml -}}
-{{- if or (not $usesPostgreSQL) (not $usesKubernetes) -}}
-{{- fail "server.replicaCount greater than 1 requires [store] type = \"postgresql\" and [runtime] type = \"kubernetes\" in configToml; SQLite and Docker snapshot execution support one active server replica" -}}
+{{- if ne $mode "postgresql-kubernetes" -}}
+{{- fail "server.replicaCount greater than 1 requires server.replicaSafetyMode = \"postgresql-kubernetes\" and matching [store] and [runtime] settings in configToml; SQLite and Docker snapshot execution support one active server replica" -}}
 {{- end -}}
 {{- end -}}
 {{- end }}

--- a/kubernetes/charts/opensandbox-server/templates/_helpers.tpl
+++ b/kubernetes/charts/opensandbox-server/templates/_helpers.tpl
@@ -95,10 +95,8 @@ process-local, and Docker snapshot execution cannot coordinate active replicas.
 {{- define "opensandbox-server.validateSnapshotStoreReplicas" -}}
 {{- if gt (int .Values.server.replicaCount) 1 -}}
 {{- $configToml := printf "%s\n" .Values.configToml -}}
-{{- $storeSection := regexFind `(?ms)^[[:space:]]*\[store\][[:space:]]*(?:#[^\r\n]*)?$.*?(?:^[[:space:]]*\[[^]]+\][[:space:]]*(?:#[^\r\n]*)?$|\z)` $configToml -}}
-{{- $usesPostgreSQL := regexMatch `(?m)^[[:space:]]*type[[:space:]]*=[[:space:]]*["']postgresql["'][[:space:]]*(?:#[^\r\n]*)?$` $storeSection -}}
-{{- $runtimeSection := regexFind `(?ms)^[[:space:]]*\[runtime\][[:space:]]*(?:#[^\r\n]*)?$.*?(?:^[[:space:]]*\[[^]]+\][[:space:]]*(?:#[^\r\n]*)?$|\z)` $configToml -}}
-{{- $usesKubernetes := regexMatch `(?m)^[[:space:]]*type[[:space:]]*=[[:space:]]*["']kubernetes["'][[:space:]]*(?:#[^\r\n]*)?$` $runtimeSection -}}
+{{- $usesPostgreSQL := regexMatch `(?m)^[ \t]*\[store\][ \t]*(?:#[^\r\n]*)?\r?\n(?:[ \t]*(?:#[^\r\n]*)?\r?\n)*[ \t]*type[ \t]*=[ \t]*["']postgresql["'][ \t]*(?:#[^\r\n]*)?\r?$` $configToml -}}
+{{- $usesKubernetes := regexMatch `(?m)^[ \t]*\[runtime\][ \t]*(?:#[^\r\n]*)?\r?\n(?:[ \t]*(?:#[^\r\n]*)?\r?\n)*[ \t]*type[ \t]*=[ \t]*["']kubernetes["'][ \t]*(?:#[^\r\n]*)?\r?$` $configToml -}}
 {{- if or (not $usesPostgreSQL) (not $usesKubernetes) -}}
 {{- fail "server.replicaCount greater than 1 requires [store] type = \"postgresql\" and [runtime] type = \"kubernetes\" in configToml; SQLite and Docker snapshot execution support one active server replica" -}}
 {{- end -}}

--- a/kubernetes/charts/opensandbox-server/templates/server.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/server.yaml
@@ -1,5 +1,6 @@
 # Copyright 2026 Alibaba Group Holding Ltd.
 # Server resources: ServiceAccount, ClusterRole, ClusterRoleBinding, ConfigMap, Deployment, Service.
+{{- include "opensandbox-server.validateSnapshotStoreReplicas" . }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -29,8 +29,11 @@ server:
     # -- Server image tag. Defaults to the chart appVersion when empty.
     tag: "v0.2.2"
 
-  # -- Number of server replicas. Values greater than 1 require PostgreSQL and the Kubernetes runtime in configToml.
+  # -- Number of server replicas. Values greater than 1 require replicaSafetyMode "postgresql-kubernetes" and matching configToml settings.
   replicaCount: 1
+
+  # -- Explicit snapshot topology declaration. Set to "postgresql-kubernetes" only when configToml selects PostgreSQL and the Kubernetes runtime; required when replicaCount is greater than 1.
+  replicaSafetyMode: ""
 
   # -- Resource requests and limits
   resources:

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -29,8 +29,8 @@ server:
     # -- Server image tag. Defaults to the chart appVersion when empty.
     tag: "v0.2.2"
 
-  # -- Number of server replicas
-  replicaCount: 2
+  # -- Number of server replicas. Values greater than 1 require PostgreSQL in configToml.
+  replicaCount: 1
 
   # -- Resource requests and limits
   resources:

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -29,7 +29,7 @@ server:
     # -- Server image tag. Defaults to the chart appVersion when empty.
     tag: "v0.2.2"
 
-  # -- Number of server replicas. Values greater than 1 require PostgreSQL in configToml.
+  # -- Number of server replicas. Values greater than 1 require PostgreSQL and the Kubernetes runtime in configToml.
   replicaCount: 1
 
   # -- Resource requests and limits

--- a/kubernetes/charts/opensandbox/README.md
+++ b/kubernetes/charts/opensandbox/README.md
@@ -72,7 +72,7 @@ The following table lists the configurable parameters of the chart and their def
 | opensandbox-controller.controller.snapshot.resumePullSecret | string | `""` | Secret name injected into resumed sandboxes for pulling snapshot images. |
 | opensandbox-controller.controller.snapshot.snapshotPushSecret | string | `""` | Secret name used by commit Jobs to push snapshot images. |
 | opensandbox-node-agent.enabled | bool | `false` | Whether the node agent is enabled. |
-| opensandbox-server.server.replicaCount | int | `2` | Number of server replicas. |
+| opensandbox-server.server.replicaCount | int | `1` | Number of server replicas. |
 
 ### Override Sub-chart Values
 
@@ -104,7 +104,7 @@ opensandbox-controller:
 
 opensandbox-server:
   server:
-    replicaCount: 2
+    replicaCount: 1
     gateway:
       enabled: true
       host: gateway.example.com

--- a/kubernetes/charts/opensandbox/README.md.gotmpl
+++ b/kubernetes/charts/opensandbox/README.md.gotmpl
@@ -86,7 +86,7 @@ opensandbox-controller:
 
 opensandbox-server:
   server:
-    replicaCount: 2
+    replicaCount: 1
     gateway:
       enabled: true
       host: gateway.example.com

--- a/kubernetes/charts/opensandbox/values.yaml
+++ b/kubernetes/charts/opensandbox/values.yaml
@@ -33,7 +33,7 @@ opensandbox-server:
   # Override specific server settings here if needed.
   server:
     # -- Number of server replicas.
-    replicaCount: 2
+    replicaCount: 1
 
 # Optional node-level sandbox log collection. Configure the target in the
 # sub-chart values before enabling it.

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -286,10 +286,19 @@ the same backend.
 **Notes**
 
 - The default SQLite backend gives local and single-node deployments persistent
-  metadata without requiring an external database service.
-- PostgreSQL provides externally managed persistence, but snapshot recovery is
-  not coordinated across server processes. Run only one active server process
-  against a PostgreSQL database.
+  metadata without requiring an external database service. Run one active Server
+  process when SQLite is selected.
+- PostgreSQL coordinates Kubernetes public snapshot creation and deletion across
+  active Server processes with expiring operation leases, periodic takeover, and
+  owner/generation-fenced terminal writes. Runtime work never holds a database
+  transaction open.
+- Docker snapshot execution remains single-active. PostgreSQL fencing prevents a
+  stale database write but cannot fence Docker image or registry side effects
+  across hosts.
+- Kubernetes recovery observes the deterministic `SandboxSnapshot` before create.
+  The resulting guarantee is one current operation owner and one fenced terminal
+  database result, not exactly-once behavior across the database, Kubernetes, and
+  the OCI registry.
 - `OPENSANDBOX_STORE_POSTGRESQL_DSN` overrides `postgresql.dsn`, keeping database
   credentials out of configuration files and Kubernetes ConfigMaps.
 - Switching backends does not copy existing snapshot metadata. Start with an
@@ -298,6 +307,9 @@ the same backend.
   resources must survive process restarts.
 - Higher-level components should depend on repository abstractions rather than
   importing `sqlite3` directly.
+- Existing PostgreSQL tables are upgraded in place with additive lease columns.
+  Older Server versions ignore these columns, but a rollback must first return to
+  one active Server because older versions do not enforce operation ownership.
 
 Example:
 

--- a/server/opensandbox_server/examples/example.config.k8s.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.toml
@@ -56,7 +56,9 @@ volume_default_size = "1Gi"
 type = "sqlite"
 path = "~/.opensandbox/opensandbox.db"
 # To use PostgreSQL, set type = "postgresql", configure [store.postgresql], and
-# inject OPENSANDBOX_STORE_POSTGRESQL_DSN. Use only one active server replica.
+# inject OPENSANDBOX_STORE_POSTGRESQL_DSN. PostgreSQL coordinates public
+# Kubernetes snapshots across active server replicas. SQLite and Docker snapshot
+# execution remain single-active.
 
 [kubernetes]
 # Path to kubeconfig file. Leave as null to use in-cluster configuration

--- a/server/opensandbox_server/examples/example.config.k8s.zh.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.zh.toml
@@ -55,7 +55,8 @@ volume_default_size = "1Gi"
 type = "sqlite"
 path = "~/.opensandbox/opensandbox.db"
 # 如需使用 PostgreSQL，请设置 type = "postgresql"，在 [store.postgresql]
-# 配置连接池，并通过 OPENSANDBOX_STORE_POSTGRESQL_DSN 注入连接串。只能运行一个活跃 Server 副本。
+# 配置连接池，并通过 OPENSANDBOX_STORE_POSTGRESQL_DSN 注入连接串。PostgreSQL 可协调
+# 多个活跃 Server 副本的公共 Kubernetes Snapshot；SQLite 和 Docker Snapshot 执行仍只支持单活。
 
 [kubernetes]
 # Path to kubeconfig file. Leave as null to use in-cluster configuration

--- a/server/opensandbox_server/repositories/snapshots/migrate.py
+++ b/server/opensandbox_server/repositories/snapshots/migrate.py
@@ -238,8 +238,28 @@ def _write_postgresql_snapshots(dsn: str, records: list[dict[str, Any]]) -> int:
             "SELECT pg_advisory_xact_lock(hashtext(%s))",
             (_SCHEMA_LOCK_NAME,),
         )
+        operation_attempt_row = conn.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = 'snapshots'
+                  AND column_name = 'operation_attempt'
+            )
+            """
+        ).fetchone()
+        operation_attempt_existed = bool(
+            operation_attempt_row is not None and operation_attempt_row[0]
+        )
         for statement in _CREATE_SCHEMA_STATEMENTS:
             conn.execute(statement)
+        if not operation_attempt_existed:
+            conn.execute(
+                "UPDATE snapshots SET operation_attempt = 1 "
+                "WHERE state = %s AND operation_attempt = 0",
+                ("Creating",),
+            )
         for record in records:
             source_operation_attempt = record["operation_attempt"]
             params = {

--- a/server/opensandbox_server/repositories/snapshots/migrate.py
+++ b/server/opensandbox_server/repositories/snapshots/migrate.py
@@ -241,6 +241,7 @@ def _write_postgresql_snapshots(dsn: str, records: list[dict[str, Any]]) -> int:
         for statement in _CREATE_SCHEMA_STATEMENTS:
             conn.execute(statement)
         for record in records:
+            source_operation_attempt = record["operation_attempt"]
             params = {
                 **record,
                 "restore_config": Jsonb(json.loads(record["restore_config"])),
@@ -250,7 +251,11 @@ def _write_postgresql_snapshots(dsn: str, records: list[dict[str, Any]]) -> int:
                 "operation_generation": int(record["operation_generation"] or 0),
                 "lease_owner": None,
                 "lease_expires_at": None,
-                "operation_attempt": int(record["operation_attempt"] or 0),
+                "operation_attempt": (
+                    int(source_operation_attempt)
+                    if source_operation_attempt is not None
+                    else int(record["state"] == "Creating")
+                ),
             }
             if conn.execute(_INSERT_SNAPSHOT, params).fetchone() is not None:
                 migrated += 1

--- a/server/opensandbox_server/repositories/snapshots/migrate.py
+++ b/server/opensandbox_server/repositories/snapshots/migrate.py
@@ -51,6 +51,10 @@ _SNAPSHOT_TABLE_COLUMNS = (
     "last_transition_at",
     "created_at",
     "updated_at",
+    "operation_generation",
+    "lease_owner",
+    "lease_expires_at",
+    "operation_attempt",
 )
 
 _CREATE_SCHEMA_STATEMENTS = (
@@ -67,13 +71,22 @@ _CREATE_SCHEMA_STATEMENTS = (
         message TEXT,
         last_transition_at TIMESTAMPTZ,
         created_at TIMESTAMPTZ NOT NULL,
-        updated_at TIMESTAMPTZ NOT NULL
+        updated_at TIMESTAMPTZ NOT NULL,
+        operation_generation BIGINT NOT NULL DEFAULT 0,
+        lease_owner TEXT,
+        lease_expires_at TIMESTAMPTZ,
+        operation_attempt BIGINT NOT NULL DEFAULT 0
     )
     """,
+    "ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS operation_generation BIGINT NOT NULL DEFAULT 0",
+    "ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS lease_owner TEXT",
+    "ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ",
+    "ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS operation_attempt BIGINT NOT NULL DEFAULT 0",
     "CREATE INDEX IF NOT EXISTS idx_snapshots_source_sandbox_id ON snapshots(source_sandbox_id)",
     "CREATE INDEX IF NOT EXISTS idx_snapshots_state ON snapshots(state)",
     "CREATE INDEX IF NOT EXISTS idx_snapshots_created_at ON snapshots(created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_snapshots_name_namespace ON snapshots(name, namespace)",
+    "CREATE INDEX IF NOT EXISTS idx_snapshots_operation_recovery ON snapshots(state, lease_expires_at) WHERE state IN ('Creating', 'Deleting')",
 )
 
 _INSERT_SNAPSHOT = """
@@ -89,7 +102,11 @@ _INSERT_SNAPSHOT = """
         message,
         last_transition_at,
         created_at,
-        updated_at
+        updated_at,
+        operation_generation,
+        lease_owner,
+        lease_expires_at,
+        operation_attempt
     ) VALUES (
         %(id)s,
         %(source_sandbox_id)s,
@@ -102,7 +119,11 @@ _INSERT_SNAPSHOT = """
         %(message)s,
         %(last_transition_at)s,
         %(created_at)s,
-        %(updated_at)s
+        %(updated_at)s,
+        %(operation_generation)s,
+        %(lease_owner)s,
+        %(lease_expires_at)s,
+        %(operation_attempt)s
     )
     ON CONFLICT (id) DO NOTHING
     RETURNING id
@@ -226,6 +247,10 @@ def _write_postgresql_snapshots(dsn: str, records: list[dict[str, Any]]) -> int:
                 "last_transition_at": _normalize_datetime(record["last_transition_at"]),
                 "created_at": _require_datetime(record["created_at"]),
                 "updated_at": _require_datetime(record["updated_at"]),
+                "operation_generation": int(record["operation_generation"] or 0),
+                "lease_owner": None,
+                "lease_expires_at": None,
+                "operation_attempt": int(record["operation_attempt"] or 0),
             }
             if conn.execute(_INSERT_SNAPSHOT, params).fetchone() is not None:
                 migrated += 1

--- a/server/opensandbox_server/repositories/snapshots/postgresql.py
+++ b/server/opensandbox_server/repositories/snapshots/postgresql.py
@@ -285,7 +285,6 @@ class PostgreSQLSnapshotRepository:
                 UPDATE snapshots
                 SET
                     operation_generation = operation_generation + 1,
-                    operation_attempt = operation_attempt + 1,
                     lease_owner = %(lease_owner)s,
                     lease_expires_at = CURRENT_TIMESTAMP + %(lease_duration)s
                 WHERE id = %(id)s
@@ -335,6 +334,34 @@ class PostgreSQLSnapshotRepository:
                 },
             ).fetchone()
         return row is not None
+
+    def mark_operation_started(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+    ) -> SnapshotRecord | None:
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                f"""
+                UPDATE snapshots
+                SET operation_attempt = operation_attempt + 1
+                WHERE id = %(id)s
+                  AND state = %(expected_state)s
+                  AND lease_owner = %(lease_owner)s
+                  AND operation_generation = %(operation_generation)s
+                  AND lease_expires_at > CURRENT_TIMESTAMP
+                RETURNING {_SELECT_COLUMNS}
+                """,
+                {
+                    "id": snapshot_id,
+                    "expected_state": expected_state.value,
+                    "lease_owner": lease_owner,
+                    "operation_generation": operation_generation,
+                },
+            ).fetchone()
+        return self._row_to_record(row) if row is not None else None
 
     def update_if_operation_owner(
         self,
@@ -425,6 +452,17 @@ class PostgreSQLSnapshotRepository:
                 )
                 """
             )
+            operation_attempt_exists = conn.execute(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_schema = current_schema()
+                      AND table_name = 'snapshots'
+                      AND column_name = 'operation_attempt'
+                ) AS present
+                """
+            ).fetchone()
             conn.execute(
                 "ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS "
                 "operation_generation BIGINT NOT NULL DEFAULT 0"
@@ -439,6 +477,12 @@ class PostgreSQLSnapshotRepository:
                 "ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS "
                 "operation_attempt BIGINT NOT NULL DEFAULT 0"
             )
+            if operation_attempt_exists is not None and not operation_attempt_exists["present"]:
+                conn.execute(
+                    "UPDATE snapshots SET operation_attempt = 1 "
+                    "WHERE state = %s AND operation_attempt = 0",
+                    (SnapshotState.CREATING.value,),
+                )
             conn.execute(
                 """
                 CREATE INDEX IF NOT EXISTS idx_snapshots_source_sandbox_id

--- a/server/opensandbox_server/repositories/snapshots/postgresql.py
+++ b/server/opensandbox_server/repositories/snapshots/postgresql.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, overload
 
 from psycopg import sql
@@ -50,7 +50,11 @@ _SELECT_COLUMNS = """
     message,
     last_transition_at,
     created_at,
-    updated_at
+    updated_at,
+    operation_generation,
+    lease_owner,
+    lease_expires_at,
+    operation_attempt
 """
 
 _UPDATE_COLUMNS = """
@@ -64,7 +68,11 @@ _UPDATE_COLUMNS = """
     message = %(message)s,
     last_transition_at = %(last_transition_at)s,
     created_at = %(created_at)s,
-    updated_at = %(updated_at)s
+    updated_at = %(updated_at)s,
+    operation_generation = %(operation_generation)s,
+    lease_owner = %(lease_owner)s,
+    lease_expires_at = %(lease_expires_at)s,
+    operation_attempt = %(operation_attempt)s
 """
 
 
@@ -98,6 +106,10 @@ class PostgreSQLSnapshotRepository:
             self._pool.close()
             raise
 
+    @property
+    def supports_distributed_leases(self) -> bool:
+        return True
+
     def create(self, record: SnapshotRecord) -> SnapshotRecord:
         with self._pool.connection() as conn:
             conn.execute(
@@ -114,7 +126,11 @@ class PostgreSQLSnapshotRepository:
                     message,
                     last_transition_at,
                     created_at,
-                    updated_at
+                    updated_at,
+                    operation_generation,
+                    lease_owner,
+                    lease_expires_at,
+                    operation_attempt
                 ) VALUES (
                     %(id)s,
                     %(source_sandbox_id)s,
@@ -127,7 +143,11 @@ class PostgreSQLSnapshotRepository:
                     %(message)s,
                     %(last_transition_at)s,
                     %(created_at)s,
-                    %(updated_at)s
+                    %(updated_at)s,
+                    %(operation_generation)s,
+                    %(lease_owner)s,
+                    %(lease_expires_at)s,
+                    %(operation_attempt)s
                 )
                 """,
                 self._to_db_params(record),
@@ -223,6 +243,128 @@ class PostgreSQLSnapshotRepository:
         with self._pool.connection() as conn:
             conn.execute("DELETE FROM snapshots WHERE id = %s", (snapshot_id,))
 
+    def claim_operation(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        lease_duration: timedelta,
+    ) -> SnapshotRecord | None:
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                f"""
+                UPDATE snapshots
+                SET
+                    operation_generation = operation_generation + 1,
+                    operation_attempt = operation_attempt + 1,
+                    lease_owner = %(lease_owner)s,
+                    lease_expires_at = CURRENT_TIMESTAMP + %(lease_duration)s
+                WHERE id = %(id)s
+                  AND state = %(expected_state)s
+                  AND (
+                      lease_owner IS NULL
+                      OR lease_expires_at IS NULL
+                      OR lease_expires_at <= CURRENT_TIMESTAMP
+                  )
+                RETURNING {_SELECT_COLUMNS}
+                """,
+                {
+                    "id": snapshot_id,
+                    "expected_state": expected_state.value,
+                    "lease_owner": lease_owner,
+                    "lease_duration": lease_duration,
+                },
+            ).fetchone()
+        return self._row_to_record(row) if row is not None else None
+
+    def renew_operation(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+        lease_duration: timedelta,
+    ) -> bool:
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                """
+                UPDATE snapshots
+                SET lease_expires_at = CURRENT_TIMESTAMP + %(lease_duration)s
+                WHERE id = %(id)s
+                  AND state = %(expected_state)s
+                  AND lease_owner = %(lease_owner)s
+                  AND operation_generation = %(operation_generation)s
+                  AND lease_expires_at > CURRENT_TIMESTAMP
+                RETURNING id
+                """,
+                {
+                    "id": snapshot_id,
+                    "expected_state": expected_state.value,
+                    "lease_owner": lease_owner,
+                    "operation_generation": operation_generation,
+                    "lease_duration": lease_duration,
+                },
+            ).fetchone()
+        return row is not None
+
+    def update_if_operation_owner(
+        self,
+        record: SnapshotRecord,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+    ) -> bool:
+        params = self._to_db_params(record)
+        params.update(
+            {
+                "expected_state": expected_state.value,
+                "expected_lease_owner": lease_owner,
+                "expected_operation_generation": operation_generation,
+            }
+        )
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                f"""
+                UPDATE snapshots
+                SET {_UPDATE_COLUMNS}
+                WHERE id = %(id)s
+                  AND state = %(expected_state)s
+                  AND lease_owner = %(expected_lease_owner)s
+                  AND operation_generation = %(expected_operation_generation)s
+                  AND lease_expires_at > CURRENT_TIMESTAMP
+                RETURNING id
+                """,
+                params,
+            ).fetchone()
+        return row is not None
+
+    def delete_if_operation_owner(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+    ) -> bool:
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                """
+                DELETE FROM snapshots
+                WHERE id = %(id)s
+                  AND state = %(expected_state)s
+                  AND lease_owner = %(lease_owner)s
+                  AND operation_generation = %(operation_generation)s
+                  AND lease_expires_at > CURRENT_TIMESTAMP
+                RETURNING id
+                """,
+                {
+                    "id": snapshot_id,
+                    "expected_state": expected_state.value,
+                    "lease_owner": lease_owner,
+                    "operation_generation": operation_generation,
+                },
+            ).fetchone()
+        return row is not None
+
     def close(self) -> None:
         self._pool.close()
 
@@ -246,9 +388,27 @@ class PostgreSQLSnapshotRepository:
                     message TEXT,
                     last_transition_at TIMESTAMPTZ,
                     created_at TIMESTAMPTZ NOT NULL,
-                    updated_at TIMESTAMPTZ NOT NULL
+                    updated_at TIMESTAMPTZ NOT NULL,
+                    operation_generation BIGINT NOT NULL DEFAULT 0,
+                    lease_owner TEXT,
+                    lease_expires_at TIMESTAMPTZ,
+                    operation_attempt BIGINT NOT NULL DEFAULT 0
                 )
                 """
+            )
+            conn.execute(
+                "ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS "
+                "operation_generation BIGINT NOT NULL DEFAULT 0"
+            )
+            conn.execute(
+                "ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS lease_owner TEXT"
+            )
+            conn.execute(
+                "ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ"
+            )
+            conn.execute(
+                "ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS "
+                "operation_attempt BIGINT NOT NULL DEFAULT 0"
             )
             conn.execute(
                 """
@@ -274,6 +434,13 @@ class PostgreSQLSnapshotRepository:
                     ON snapshots(name, namespace)
                 """
             )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_snapshots_operation_recovery
+                    ON snapshots(state, lease_expires_at)
+                    WHERE state IN ('Creating', 'Deleting')
+                """
+            )
 
     @staticmethod
     def _to_db_params(record: SnapshotRecord) -> dict[str, Any]:
@@ -292,6 +459,12 @@ class PostgreSQLSnapshotRepository:
             ),
             "created_at": PostgreSQLSnapshotRepository._normalize_datetime(record.created_at),
             "updated_at": PostgreSQLSnapshotRepository._normalize_datetime(record.updated_at),
+            "operation_generation": record.operation_generation,
+            "lease_owner": record.lease_owner,
+            "lease_expires_at": PostgreSQLSnapshotRepository._normalize_datetime(
+                record.lease_expires_at
+            ),
+            "operation_attempt": record.operation_attempt,
         }
 
     @staticmethod
@@ -330,6 +503,12 @@ class PostgreSQLSnapshotRepository:
             ),
             created_at=PostgreSQLSnapshotRepository._normalize_datetime(row["created_at"]),
             updated_at=PostgreSQLSnapshotRepository._normalize_datetime(row["updated_at"]),
+            operation_generation=int(row["operation_generation"]),
+            lease_owner=row["lease_owner"],
+            lease_expires_at=PostgreSQLSnapshotRepository._normalize_datetime(
+                row["lease_expires_at"]
+            ),
+            operation_attempt=int(row["operation_attempt"]),
         )
 
 

--- a/server/opensandbox_server/repositories/snapshots/postgresql.py
+++ b/server/opensandbox_server/repositories/snapshots/postgresql.py
@@ -208,6 +208,35 @@ class PostgreSQLSnapshotRepository:
             total_items=int(total_row["total_items"]) if total_row is not None else 0,
         )
 
+    def list_recoverable_operations(
+        self,
+        states: list[SnapshotState],
+        limit: int,
+    ) -> list[SnapshotRecord]:
+        if not states or limit <= 0:
+            return []
+
+        with self._pool.connection() as conn:
+            rows = conn.execute(
+                sql.SQL("""
+                SELECT {}
+                FROM snapshots
+                WHERE state = ANY(%(states)s)
+                  AND (
+                      lease_owner IS NULL
+                      OR lease_expires_at IS NULL
+                      OR lease_expires_at <= CURRENT_TIMESTAMP
+                  )
+                ORDER BY created_at ASC, id ASC
+                LIMIT %(limit)s
+                """).format(sql.SQL(_SELECT_COLUMNS)),
+                {
+                    "states": [state.value for state in states],
+                    "limit": limit,
+                },
+            ).fetchall()
+        return [self._row_to_record(row) for row in rows]
+
     def update(self, record: SnapshotRecord) -> SnapshotRecord:
         with self._pool.connection() as conn:
             conn.execute(

--- a/server/opensandbox_server/repositories/snapshots/sqlite.py
+++ b/server/opensandbox_server/repositories/snapshots/sqlite.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import sqlite3
+from datetime import datetime, timedelta, timezone
 
 from opensandbox_server.services.snapshot_models import (
     SnapshotRecord,
@@ -47,6 +48,10 @@ class SQLiteSnapshotRepository:
         self._initialize_schema()
 
     @property
+    def supports_distributed_leases(self) -> bool:
+        return False
+
+    @property
     def db_path(self) -> Path:
         return self._db_path
 
@@ -66,8 +71,12 @@ class SQLiteSnapshotRepository:
                     message,
                     last_transition_at,
                     created_at,
-                    updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    updated_at,
+                    operation_generation,
+                    lease_owner,
+                    lease_expires_at,
+                    operation_attempt
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 self._to_db_tuple(record),
             )
@@ -89,7 +98,11 @@ class SQLiteSnapshotRepository:
                     message,
                     last_transition_at,
                     created_at,
-                    updated_at
+                    updated_at,
+                    operation_generation,
+                    lease_owner,
+                    lease_expires_at,
+                    operation_attempt
                 FROM snapshots
                 WHERE id = ?
                 """,
@@ -141,7 +154,11 @@ class SQLiteSnapshotRepository:
                     message,
                     last_transition_at,
                     created_at,
-                    updated_at
+                    updated_at,
+                    operation_generation,
+                    lease_owner,
+                    lease_expires_at,
+                    operation_attempt
                 FROM snapshots
                 {where_clause}
                 ORDER BY created_at DESC, id DESC
@@ -171,7 +188,11 @@ class SQLiteSnapshotRepository:
                     message = ?,
                     last_transition_at = ?,
                     created_at = ?,
-                    updated_at = ?
+                    updated_at = ?,
+                    operation_generation = ?,
+                    lease_owner = ?,
+                    lease_expires_at = ?,
+                    operation_attempt = ?
                 WHERE id = ?
                 """,
                 (
@@ -186,6 +207,10 @@ class SQLiteSnapshotRepository:
                     self._datetime_to_str(record.status.last_transition_at),
                     self._datetime_to_str(record.created_at),
                     self._datetime_to_str(record.updated_at),
+                    record.operation_generation,
+                    record.lease_owner,
+                    self._datetime_to_str(record.lease_expires_at),
+                    record.operation_attempt,
                     record.id,
                 ),
             )
@@ -211,7 +236,11 @@ class SQLiteSnapshotRepository:
                     message = ?,
                     last_transition_at = ?,
                     created_at = ?,
-                    updated_at = ?
+                    updated_at = ?,
+                    operation_generation = ?,
+                    lease_owner = ?,
+                    lease_expires_at = ?,
+                    operation_attempt = ?
                 WHERE id = ? AND state = ?
                 """,
                 (
@@ -226,6 +255,10 @@ class SQLiteSnapshotRepository:
                     self._datetime_to_str(record.status.last_transition_at),
                     self._datetime_to_str(record.created_at),
                     self._datetime_to_str(record.updated_at),
+                    record.operation_generation,
+                    record.lease_owner,
+                    self._datetime_to_str(record.lease_expires_at),
+                    record.operation_attempt,
                     record.id,
                     expected_state.value,
                 ),
@@ -235,6 +268,161 @@ class SQLiteSnapshotRepository:
     def delete(self, snapshot_id: str) -> None:
         with self._connect() as conn:
             conn.execute("DELETE FROM snapshots WHERE id = ?", (snapshot_id,))
+
+    def claim_operation(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        lease_duration: timedelta,
+    ) -> SnapshotRecord | None:
+        now = datetime.now(timezone.utc)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE snapshots
+                SET
+                    operation_generation = operation_generation + 1,
+                    operation_attempt = operation_attempt + 1,
+                    lease_owner = ?,
+                    lease_expires_at = ?
+                WHERE id = ?
+                  AND state = ?
+                  AND (
+                      lease_owner IS NULL
+                      OR lease_expires_at IS NULL
+                      OR lease_expires_at <= ?
+                  )
+                """,
+                (
+                    lease_owner,
+                    self._datetime_to_str(now + lease_duration),
+                    snapshot_id,
+                    expected_state.value,
+                    self._datetime_to_str(now),
+                ),
+            )
+            if cursor.rowcount != 1:
+                return None
+        return self.get(snapshot_id)
+
+    def renew_operation(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+        lease_duration: timedelta,
+    ) -> bool:
+        now = datetime.now(timezone.utc)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE snapshots
+                SET lease_expires_at = ?
+                WHERE id = ?
+                  AND state = ?
+                  AND lease_owner = ?
+                  AND operation_generation = ?
+                  AND lease_expires_at > ?
+                """,
+                (
+                    self._datetime_to_str(now + lease_duration),
+                    snapshot_id,
+                    expected_state.value,
+                    lease_owner,
+                    operation_generation,
+                    self._datetime_to_str(now),
+                ),
+            )
+            return cursor.rowcount == 1
+
+    def update_if_operation_owner(
+        self,
+        record: SnapshotRecord,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+    ) -> bool:
+        now = datetime.now(timezone.utc)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE snapshots
+                SET
+                    source_sandbox_id = ?,
+                    namespace = ?,
+                    name = ?,
+                    description = ?,
+                    restore_config = ?,
+                    state = ?,
+                    reason = ?,
+                    message = ?,
+                    last_transition_at = ?,
+                    created_at = ?,
+                    updated_at = ?,
+                    operation_generation = ?,
+                    lease_owner = ?,
+                    lease_expires_at = ?,
+                    operation_attempt = ?
+                WHERE id = ?
+                  AND state = ?
+                  AND lease_owner = ?
+                  AND operation_generation = ?
+                  AND lease_expires_at > ?
+                """,
+                (
+                    record.source_sandbox_id,
+                    record.namespace,
+                    record.name,
+                    record.description,
+                    json.dumps(record.restore_config.to_dict(), sort_keys=True),
+                    record.status.state.value,
+                    record.status.reason,
+                    record.status.message,
+                    self._datetime_to_str(record.status.last_transition_at),
+                    self._datetime_to_str(record.created_at),
+                    self._datetime_to_str(record.updated_at),
+                    record.operation_generation,
+                    record.lease_owner,
+                    self._datetime_to_str(record.lease_expires_at),
+                    record.operation_attempt,
+                    record.id,
+                    expected_state.value,
+                    lease_owner,
+                    operation_generation,
+                    self._datetime_to_str(now),
+                ),
+            )
+            return cursor.rowcount == 1
+
+    def delete_if_operation_owner(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+    ) -> bool:
+        now = datetime.now(timezone.utc)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                DELETE FROM snapshots
+                WHERE id = ?
+                  AND state = ?
+                  AND lease_owner = ?
+                  AND operation_generation = ?
+                  AND lease_expires_at > ?
+                """,
+                (
+                    snapshot_id,
+                    expected_state.value,
+                    lease_owner,
+                    operation_generation,
+                    self._datetime_to_str(now),
+                ),
+            )
+            return cursor.rowcount == 1
 
     def close(self) -> None:
         """SQLite connections are scoped to individual operations."""
@@ -255,7 +443,11 @@ class SQLiteSnapshotRepository:
                     message TEXT,
                     last_transition_at TEXT,
                     created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL
+                    updated_at TEXT NOT NULL,
+                    operation_generation INTEGER NOT NULL DEFAULT 0,
+                    lease_owner TEXT,
+                    lease_expires_at TEXT,
+                    operation_attempt INTEGER NOT NULL DEFAULT 0
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_snapshots_source_sandbox_id
@@ -269,6 +461,7 @@ class SQLiteSnapshotRepository:
                 """
             )
             self._migrate_add_namespace(conn)
+            self._migrate_add_operation_leases(conn)
             self._migrate_namespace_nullable(conn)
             conn.execute(
                 """
@@ -284,6 +477,20 @@ class SQLiteSnapshotRepository:
         columns = {row["name"] for row in rows}
         if "namespace" not in columns:
             conn.execute("ALTER TABLE snapshots ADD COLUMN namespace TEXT DEFAULT NULL")
+
+    @staticmethod
+    def _migrate_add_operation_leases(conn: sqlite3.Connection) -> None:
+        rows = conn.execute("PRAGMA table_info(snapshots)").fetchall()
+        columns = {row["name"] for row in rows}
+        additions = {
+            "operation_generation": "INTEGER NOT NULL DEFAULT 0",
+            "lease_owner": "TEXT",
+            "lease_expires_at": "TEXT",
+            "operation_attempt": "INTEGER NOT NULL DEFAULT 0",
+        }
+        for column, definition in additions.items():
+            if column not in columns:
+                conn.execute(f"ALTER TABLE snapshots ADD COLUMN {column} {definition}")
 
     @staticmethod
     def _migrate_namespace_nullable(conn: sqlite3.Connection) -> None:
@@ -305,16 +512,24 @@ class SQLiteSnapshotRepository:
                         message TEXT,
                         last_transition_at TEXT,
                         created_at TEXT NOT NULL,
-                        updated_at TEXT NOT NULL
+                        updated_at TEXT NOT NULL,
+                        operation_generation INTEGER NOT NULL DEFAULT 0,
+                        lease_owner TEXT,
+                        lease_expires_at TEXT,
+                        operation_attempt INTEGER NOT NULL DEFAULT 0
                     );
                     INSERT INTO snapshots_new (
                         id, source_sandbox_id, namespace, name, description,
                         restore_config, state, reason, message,
-                        last_transition_at, created_at, updated_at
+                        last_transition_at, created_at, updated_at,
+                        operation_generation, lease_owner, lease_expires_at,
+                        operation_attempt
                     ) SELECT
                         id, source_sandbox_id, namespace, name, description,
                         restore_config, state, reason, message,
-                        last_transition_at, created_at, updated_at
+                        last_transition_at, created_at, updated_at,
+                        operation_generation, lease_owner, lease_expires_at,
+                        operation_attempt
                     FROM snapshots;
                     DROP TABLE snapshots;
                     ALTER TABLE snapshots_new RENAME TO snapshots;
@@ -349,6 +564,10 @@ class SQLiteSnapshotRepository:
             self._datetime_to_str(record.status.last_transition_at),
             self._datetime_to_str(record.created_at),
             self._datetime_to_str(record.updated_at),
+            record.operation_generation,
+            record.lease_owner,
+            self._datetime_to_str(record.lease_expires_at),
+            record.operation_attempt,
         )
 
     @staticmethod
@@ -373,15 +592,23 @@ class SQLiteSnapshotRepository:
                     row["last_transition_at"]
                 ),
             ),
-            created_at=SQLiteSnapshotRepository._str_to_datetime(row["created_at"]),
-            updated_at=SQLiteSnapshotRepository._str_to_datetime(row["updated_at"]),
+            created_at=SQLiteSnapshotRepository._require_datetime(row["created_at"]),
+            updated_at=SQLiteSnapshotRepository._require_datetime(row["updated_at"]),
+            operation_generation=int(row["operation_generation"]),
+            lease_owner=row["lease_owner"],
+            lease_expires_at=SQLiteSnapshotRepository._str_to_datetime(
+                row["lease_expires_at"]
+            ),
+            operation_attempt=int(row["operation_attempt"]),
         )
 
     @staticmethod
     def _str_to_datetime(value: str | None):
-        from datetime import datetime
-
         return datetime.fromisoformat(value) if value is not None else None
+
+    @staticmethod
+    def _require_datetime(value: str) -> datetime:
+        return datetime.fromisoformat(value)
 
 
 __all__ = [

--- a/server/opensandbox_server/repositories/snapshots/sqlite.py
+++ b/server/opensandbox_server/repositories/snapshots/sqlite.py
@@ -172,6 +172,51 @@ class SQLiteSnapshotRepository:
             total_items=total_items,
         )
 
+    def list_recoverable_operations(
+        self,
+        states: list[SnapshotState],
+        limit: int,
+    ) -> list[SnapshotRecord]:
+        if not states or limit <= 0:
+            return []
+
+        state_values = [state.value for state in states]
+        placeholders = ", ".join("?" for _ in state_values)
+        now = self._datetime_to_str(datetime.now(timezone.utc))
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT
+                    id,
+                    source_sandbox_id,
+                    namespace,
+                    name,
+                    description,
+                    restore_config,
+                    state,
+                    reason,
+                    message,
+                    last_transition_at,
+                    created_at,
+                    updated_at,
+                    operation_generation,
+                    lease_owner,
+                    lease_expires_at,
+                    operation_attempt
+                FROM snapshots
+                WHERE state IN ({placeholders})
+                  AND (
+                      lease_owner IS NULL
+                      OR lease_expires_at IS NULL
+                      OR lease_expires_at <= ?
+                  )
+                ORDER BY created_at ASC, id ASC
+                LIMIT ?
+                """,
+                tuple([*state_values, now, limit]),
+            ).fetchall()
+        return [self._row_to_record(row) for row in rows]
+
     def update(self, record: SnapshotRecord) -> SnapshotRecord:
         with self._connect() as conn:
             conn.execute(

--- a/server/opensandbox_server/repositories/snapshots/sqlite.py
+++ b/server/opensandbox_server/repositories/snapshots/sqlite.py
@@ -328,7 +328,6 @@ class SQLiteSnapshotRepository:
                 UPDATE snapshots
                 SET
                     operation_generation = operation_generation + 1,
-                    operation_attempt = operation_attempt + 1,
                     lease_owner = ?,
                     lease_expires_at = ?
                 WHERE id = ?
@@ -381,6 +380,37 @@ class SQLiteSnapshotRepository:
                 ),
             )
             return cursor.rowcount == 1
+
+    def mark_operation_started(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+    ) -> SnapshotRecord | None:
+        now = datetime.now(timezone.utc)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE snapshots
+                SET operation_attempt = operation_attempt + 1
+                WHERE id = ?
+                  AND state = ?
+                  AND lease_owner = ?
+                  AND operation_generation = ?
+                  AND lease_expires_at > ?
+                """,
+                (
+                    snapshot_id,
+                    expected_state.value,
+                    lease_owner,
+                    operation_generation,
+                    self._datetime_to_str(now),
+                ),
+            )
+            if cursor.rowcount != 1:
+                return None
+        return self.get(snapshot_id)
 
     def update_if_operation_owner(
         self,
@@ -527,6 +557,7 @@ class SQLiteSnapshotRepository:
     def _migrate_add_operation_leases(conn: sqlite3.Connection) -> None:
         rows = conn.execute("PRAGMA table_info(snapshots)").fetchall()
         columns = {row["name"] for row in rows}
+        had_operation_attempt = "operation_attempt" in columns
         additions = {
             "operation_generation": "INTEGER NOT NULL DEFAULT 0",
             "lease_owner": "TEXT",
@@ -536,6 +567,12 @@ class SQLiteSnapshotRepository:
         for column, definition in additions.items():
             if column not in columns:
                 conn.execute(f"ALTER TABLE snapshots ADD COLUMN {column} {definition}")
+        if not had_operation_attempt:
+            conn.execute(
+                "UPDATE snapshots SET operation_attempt = 1 "
+                "WHERE state = ? AND operation_attempt = 0",
+                (SnapshotState.CREATING.value,),
+            )
 
     @staticmethod
     def _migrate_namespace_nullable(conn: sqlite3.Connection) -> None:

--- a/server/opensandbox_server/services/docker/snapshot_runtime.py
+++ b/server/opensandbox_server/services/docker/snapshot_runtime.py
@@ -64,6 +64,18 @@ class DockerSnapshotRuntime:
     def get_snapshot_status(self, snapshot_id: str) -> Optional[SnapshotRuntimeStatus]:
         return None
 
+    def recover_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        image: Optional[str] = None,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        # Re-running docker commit after lease takeover can race registry side
+        # effects, so Docker recovery remains observe-only and single-active.
+        return self.inspect_snapshot(snapshot_id, image=image, namespace=namespace)
+
     def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> None:
         image_ref = image or build_snapshot_image_ref(snapshot_id)
         try:

--- a/server/opensandbox_server/services/k8s/snapshot_runtime.py
+++ b/server/opensandbox_server/services/k8s/snapshot_runtime.py
@@ -180,7 +180,14 @@ class KubernetesSnapshotRuntime:
             )
 
         if time.monotonic() >= deadline:
-            return self._timeout_status(snapshot_id)
+            return SnapshotRuntimeStatus(
+                state=SnapshotState.CREATING,
+                reason="snapshot_runtime_timeout",
+                message=(
+                    "Kubernetes SandboxSnapshot was created, but the observation "
+                    "deadline elapsed before terminal status; recovery will continue."
+                ),
+            )
         return self._wait_for_terminal_snapshot(
             snapshot_id,
             namespace=ns,

--- a/server/opensandbox_server/services/k8s/snapshot_runtime.py
+++ b/server/opensandbox_server/services/k8s/snapshot_runtime.py
@@ -92,9 +92,14 @@ class KubernetesSnapshotRuntime:
         snapshot_name = build_public_snapshot_name(snapshot_id)
         ns = namespace if namespace is not None else self._namespace
         self._snapshot_namespaces[snapshot_id] = ns
+        deadline = time.monotonic() + self._wait_timeout_seconds
         body = self._build_snapshot_body(snapshot_id, sandbox_id, snapshot_name, namespace=ns)
 
-        observed, current = self._observe_snapshot(snapshot_name, namespace=ns)
+        observed, current = self._observe_snapshot(
+            snapshot_name,
+            namespace=ns,
+            deadline=deadline,
+        )
         if not observed:
             return SnapshotRuntimeStatus(
                 state=SnapshotState.CREATING,
@@ -112,7 +117,11 @@ class KubernetesSnapshotRuntime:
                 "Kubernetes SandboxSnapshot %s already exists; resuming observation",
                 snapshot_name,
             )
-            return self._wait_for_terminal_snapshot(snapshot_id, namespace=ns)
+            return self._wait_for_terminal_snapshot(
+                snapshot_id,
+                namespace=ns,
+                deadline=deadline,
+            )
 
         try:
             self._k8s_client.create_custom_object(
@@ -130,7 +139,11 @@ class KubernetesSnapshotRuntime:
                     message=f"Failed to create Kubernetes SandboxSnapshot {snapshot_name}: {exc}",
                 )
             logger.info("Kubernetes SandboxSnapshot %s won the create race", snapshot_name)
-            observed, current = self._observe_snapshot(snapshot_name, namespace=ns)
+            observed, current = self._observe_snapshot(
+                snapshot_name,
+                namespace=ns,
+                deadline=deadline,
+            )
             if not observed:
                 return SnapshotRuntimeStatus(
                     state=SnapshotState.CREATING,
@@ -151,7 +164,11 @@ class KubernetesSnapshotRuntime:
                 message=f"Failed to create Kubernetes SandboxSnapshot {snapshot_name}: {exc}",
             )
 
-        return self._wait_for_terminal_snapshot(snapshot_id, namespace=ns)
+        return self._wait_for_terminal_snapshot(
+            snapshot_id,
+            namespace=ns,
+            deadline=deadline,
+        )
 
     def get_snapshot_status(self, snapshot_id: str) -> Optional[SnapshotRuntimeStatus]:
         ns = self._snapshot_namespaces.get(snapshot_id)
@@ -248,8 +265,8 @@ class KubernetesSnapshotRuntime:
         snapshot_name: str,
         *,
         namespace: str,
+        deadline: float,
     ) -> tuple[bool, Optional[dict]]:
-        deadline = time.monotonic() + self._wait_timeout_seconds
         while True:
             try:
                 return True, self._get_snapshot_cr(snapshot_name, namespace=namespace)
@@ -284,8 +301,13 @@ class KubernetesSnapshotRuntime:
             ),
         )
 
-    def _wait_for_terminal_snapshot(self, snapshot_id: str, *, namespace: str | None = None) -> SnapshotRuntimeStatus:
-        deadline = time.monotonic() + self._wait_timeout_seconds
+    def _wait_for_terminal_snapshot(
+        self,
+        snapshot_id: str,
+        *,
+        namespace: str | None = None,
+        deadline: float,
+    ) -> SnapshotRuntimeStatus:
         while True:
             runtime_status = self.inspect_snapshot(snapshot_id, namespace=namespace)
             if runtime_status.state in (SnapshotState.READY, SnapshotState.FAILED):

--- a/server/opensandbox_server/services/k8s/snapshot_runtime.py
+++ b/server/opensandbox_server/services/k8s/snapshot_runtime.py
@@ -95,11 +95,13 @@ class KubernetesSnapshotRuntime:
         deadline = time.monotonic() + self._wait_timeout_seconds
         body = self._build_snapshot_body(snapshot_id, sandbox_id, snapshot_name, namespace=ns)
 
-        observed, current = self._observe_snapshot(
+        observed, current, observation_error = self._observe_snapshot(
             snapshot_name,
             namespace=ns,
             deadline=deadline,
         )
+        if observation_error is not None:
+            return observation_error
         if not observed:
             return SnapshotRuntimeStatus(
                 state=SnapshotState.CREATING,
@@ -139,11 +141,13 @@ class KubernetesSnapshotRuntime:
                     message=f"Failed to create Kubernetes SandboxSnapshot {snapshot_name}: {exc}",
                 )
             logger.info("Kubernetes SandboxSnapshot %s won the create race", snapshot_name)
-            observed, current = self._observe_snapshot(
+            observed, current, observation_error = self._observe_snapshot(
                 snapshot_name,
                 namespace=ns,
                 deadline=deadline,
             )
+            if observation_error is not None:
+                return observation_error
             if not observed:
                 return SnapshotRuntimeStatus(
                     state=SnapshotState.CREATING,
@@ -266,10 +270,37 @@ class KubernetesSnapshotRuntime:
         *,
         namespace: str,
         deadline: float,
-    ) -> tuple[bool, Optional[dict]]:
+    ) -> tuple[bool, Optional[dict], Optional[SnapshotRuntimeStatus]]:
         while True:
             try:
-                return True, self._get_snapshot_cr(snapshot_name, namespace=namespace)
+                return True, self._get_snapshot_cr(snapshot_name, namespace=namespace), None
+            except ApiException as exc:
+                if not self._is_retryable_observation_error(exc):
+                    logger.error(
+                        "Failed to observe Kubernetes SandboxSnapshot %s: %s",
+                        snapshot_name,
+                        exc,
+                    )
+                    return (
+                        False,
+                        None,
+                        SnapshotRuntimeStatus(
+                            state=SnapshotState.FAILED,
+                            reason="snapshot_runtime_inspect_failed",
+                            message=(
+                                "Failed to inspect Kubernetes SandboxSnapshot "
+                                f"{snapshot_name}: {exc}"
+                            ),
+                        ),
+                    )
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "Failed to observe Kubernetes SandboxSnapshot %s before create: %s",
+                        snapshot_name,
+                        exc,
+                    )
+                    return False, None, None
+                time.sleep(self._poll_interval_seconds)
             except Exception as exc:  # noqa: BLE001
                 if time.monotonic() >= deadline:
                     logger.warning(
@@ -277,8 +308,13 @@ class KubernetesSnapshotRuntime:
                         snapshot_name,
                         exc,
                     )
-                    return False, None
+                    return False, None, None
                 time.sleep(self._poll_interval_seconds)
+
+    @staticmethod
+    def _is_retryable_observation_error(exc: ApiException) -> bool:
+        api_status = exc.status or 0
+        return api_status == 0 or api_status in (408, 409, 425, 429) or api_status >= 500
 
     def _validate_existing_source(self, snapshot: Optional[dict], sandbox_id: str) -> Optional[SnapshotRuntimeStatus]:
         if snapshot is None:

--- a/server/opensandbox_server/services/k8s/snapshot_runtime.py
+++ b/server/opensandbox_server/services/k8s/snapshot_runtime.py
@@ -93,7 +93,26 @@ class KubernetesSnapshotRuntime:
         ns = namespace if namespace is not None else self._namespace
         self._snapshot_namespaces[snapshot_id] = ns
         body = self._build_snapshot_body(snapshot_id, sandbox_id, snapshot_name, namespace=ns)
-        should_validate_existing_source = False
+
+        observed, current = self._observe_snapshot(snapshot_name, namespace=ns)
+        if not observed:
+            return SnapshotRuntimeStatus(
+                state=SnapshotState.CREATING,
+                reason="snapshot_runtime_inspect_failed",
+                message=(
+                    "Could not determine whether Kubernetes SandboxSnapshot "
+                    f"{snapshot_name} already exists."
+                ),
+            )
+        if current is not None:
+            conflict = self._validate_existing_source(current, sandbox_id)
+            if conflict is not None:
+                return conflict
+            logger.info(
+                "Kubernetes SandboxSnapshot %s already exists; resuming observation",
+                snapshot_name,
+            )
+            return self._wait_for_terminal_snapshot(snapshot_id, namespace=ns)
 
         try:
             self._k8s_client.create_custom_object(
@@ -110,8 +129,20 @@ class KubernetesSnapshotRuntime:
                     reason="snapshot_runtime_create_failed",
                     message=f"Failed to create Kubernetes SandboxSnapshot {snapshot_name}: {exc}",
                 )
-            logger.info("Kubernetes SandboxSnapshot %s already exists; continuing", snapshot_name)
-            should_validate_existing_source = True
+            logger.info("Kubernetes SandboxSnapshot %s won the create race", snapshot_name)
+            observed, current = self._observe_snapshot(snapshot_name, namespace=ns)
+            if not observed:
+                return SnapshotRuntimeStatus(
+                    state=SnapshotState.CREATING,
+                    reason="snapshot_runtime_inspect_failed",
+                    message=(
+                        "Could not inspect Kubernetes SandboxSnapshot "
+                        f"{snapshot_name} after a create conflict."
+                    ),
+                )
+            conflict = self._validate_existing_source(current, sandbox_id)
+            if conflict is not None:
+                return conflict
         except Exception as exc:  # noqa: BLE001
             logger.exception("Failed to create Kubernetes SandboxSnapshot %s: %s", snapshot_name, exc)
             return SnapshotRuntimeStatus(
@@ -120,25 +151,30 @@ class KubernetesSnapshotRuntime:
                 message=f"Failed to create Kubernetes SandboxSnapshot {snapshot_name}: {exc}",
             )
 
-        if should_validate_existing_source:
-            try:
-                current = self._get_snapshot_cr(snapshot_name, namespace=ns)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "Failed to inspect existing Kubernetes SandboxSnapshot %s after create conflict: %s",
-                    snapshot_name,
-                    exc,
-                )
-            else:
-                conflict = self._validate_existing_source(current, sandbox_id)
-                if conflict is not None:
-                    return conflict
-
         return self._wait_for_terminal_snapshot(snapshot_id, namespace=ns)
 
     def get_snapshot_status(self, snapshot_id: str) -> Optional[SnapshotRuntimeStatus]:
         ns = self._snapshot_namespaces.get(snapshot_id)
         return self.inspect_snapshot(snapshot_id, namespace=ns)
+
+    def recover_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        image: Optional[str] = None,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        # create_snapshot observes the deterministic CR first and creates it
+        # only when the live API confirms that it is absent.
+        result = self.create_snapshot(snapshot_id, sandbox_id, namespace=namespace)
+        if result is None:
+            return SnapshotRuntimeStatus(
+                state=SnapshotState.CREATING,
+                reason="snapshot_runtime_missing_result",
+                message="Kubernetes snapshot recovery did not return a status.",
+            )
+        return result
 
     def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> None:
         snapshot_name = build_public_snapshot_name(snapshot_id)
@@ -206,6 +242,26 @@ class KubernetesSnapshotRuntime:
             plural=_PLURAL,
             name=snapshot_name,
         )
+
+    def _observe_snapshot(
+        self,
+        snapshot_name: str,
+        *,
+        namespace: str,
+    ) -> tuple[bool, Optional[dict]]:
+        deadline = time.monotonic() + self._wait_timeout_seconds
+        while True:
+            try:
+                return True, self._get_snapshot_cr(snapshot_name, namespace=namespace)
+            except Exception as exc:  # noqa: BLE001
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "Failed to observe Kubernetes SandboxSnapshot %s before create: %s",
+                        snapshot_name,
+                        exc,
+                    )
+                    return False, None
+                time.sleep(self._poll_interval_seconds)
 
     def _validate_existing_source(self, snapshot: Optional[dict], sandbox_id: str) -> Optional[SnapshotRuntimeStatus]:
         if snapshot is None:

--- a/server/opensandbox_server/services/k8s/snapshot_runtime.py
+++ b/server/opensandbox_server/services/k8s/snapshot_runtime.py
@@ -124,6 +124,8 @@ class KubernetesSnapshotRuntime:
                 namespace=ns,
                 deadline=deadline,
             )
+        if time.monotonic() >= deadline:
+            return self._timeout_status(snapshot_id)
 
         try:
             self._k8s_client.create_custom_object(
@@ -350,16 +352,20 @@ class KubernetesSnapshotRuntime:
                 return runtime_status
 
             if time.monotonic() >= deadline:
-                return SnapshotRuntimeStatus(
-                    state=SnapshotState.FAILED,
-                    reason="snapshot_runtime_timeout",
-                    message=(
-                        "Timed out waiting for Kubernetes SandboxSnapshot "
-                        f"{build_public_snapshot_name(snapshot_id)} to complete."
-                    ),
-                )
+                return self._timeout_status(snapshot_id)
 
             time.sleep(self._poll_interval_seconds)
+
+    @staticmethod
+    def _timeout_status(snapshot_id: str) -> SnapshotRuntimeStatus:
+        return SnapshotRuntimeStatus(
+            state=SnapshotState.FAILED,
+            reason="snapshot_runtime_timeout",
+            message=(
+                "Timed out waiting for Kubernetes SandboxSnapshot "
+                f"{build_public_snapshot_name(snapshot_id)} to complete."
+            ),
+        )
 
     def _snapshot_status_from_cr(self, snapshot: dict) -> SnapshotRuntimeStatus:
         status = snapshot.get("status", {})

--- a/server/opensandbox_server/services/k8s/snapshot_runtime.py
+++ b/server/opensandbox_server/services/k8s/snapshot_runtime.py
@@ -119,6 +119,11 @@ class KubernetesSnapshotRuntime:
                 "Kubernetes SandboxSnapshot %s already exists; resuming observation",
                 snapshot_name,
             )
+            current_status = self._snapshot_status_from_cr(current)
+            if current_status.state in (SnapshotState.READY, SnapshotState.FAILED):
+                return current_status
+            if time.monotonic() >= deadline:
+                return self._timeout_status(snapshot_id)
             return self._wait_for_terminal_snapshot(
                 snapshot_id,
                 namespace=ns,
@@ -162,6 +167,10 @@ class KubernetesSnapshotRuntime:
             conflict = self._validate_existing_source(current, sandbox_id)
             if conflict is not None:
                 return conflict
+            if current is not None:
+                current_status = self._snapshot_status_from_cr(current)
+                if current_status.state in (SnapshotState.READY, SnapshotState.FAILED):
+                    return current_status
         except Exception as exc:  # noqa: BLE001
             logger.exception("Failed to create Kubernetes SandboxSnapshot %s: %s", snapshot_name, exc)
             return SnapshotRuntimeStatus(
@@ -170,6 +179,8 @@ class KubernetesSnapshotRuntime:
                 message=f"Failed to create Kubernetes SandboxSnapshot {snapshot_name}: {exc}",
             )
 
+        if time.monotonic() >= deadline:
+            return self._timeout_status(snapshot_id)
         return self._wait_for_terminal_snapshot(
             snapshot_id,
             namespace=ns,

--- a/server/opensandbox_server/services/snapshot_models.py
+++ b/server/opensandbox_server/services/snapshot_models.py
@@ -87,6 +87,10 @@ class SnapshotRecord:
     )
     created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: datetime = field(default_factory=datetime.utcnow)
+    operation_generation: int = 0
+    lease_owner: str | None = None
+    lease_expires_at: datetime | None = None
+    operation_attempt: int = 0
 
 
 __all__ = [

--- a/server/opensandbox_server/services/snapshot_repository.py
+++ b/server/opensandbox_server/services/snapshot_repository.py
@@ -17,6 +17,7 @@ Repository abstraction for persisted snapshot records.
 """
 
 from dataclasses import dataclass, field
+from datetime import timedelta
 from typing import Protocol
 
 from opensandbox_server.services.snapshot_models import SnapshotRecord, SnapshotState
@@ -55,21 +56,25 @@ class SnapshotRepository(Protocol):
         """
         Persist a new snapshot record.
         """
+        ...
 
     def get(self, snapshot_id: str) -> SnapshotRecord | None:
         """
         Fetch a snapshot record by id.
         """
+        ...
 
     def list(self, query: SnapshotListQuery) -> SnapshotListResult:
         """
         List snapshot records with optional filtering and pagination.
         """
+        ...
 
     def update(self, record: SnapshotRecord) -> SnapshotRecord:
         """
         Replace the persisted contents of an existing snapshot record.
         """
+        ...
 
     def update_if_state(
         self,
@@ -79,16 +84,65 @@ class SnapshotRepository(Protocol):
         """
         Replace a snapshot record only if its current state matches the expected state.
         """
+        ...
 
     def delete(self, snapshot_id: str) -> None:
         """
         Delete a snapshot record by id.
         """
+        ...
+
+    @property
+    def supports_distributed_leases(self) -> bool:
+        """Whether operation leases coordinate independent server processes."""
+        ...
+
+    def claim_operation(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        lease_duration: timedelta,
+    ) -> SnapshotRecord | None:
+        """Atomically claim an unowned or expired snapshot operation."""
+        ...
+
+    def renew_operation(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+        lease_duration: timedelta,
+    ) -> bool:
+        """Extend a live operation lease owned by the supplied generation."""
+        ...
+
+    def update_if_operation_owner(
+        self,
+        record: SnapshotRecord,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+    ) -> bool:
+        """Update only while the caller still owns the live operation lease."""
+        ...
+
+    def delete_if_operation_owner(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+    ) -> bool:
+        """Delete only while the caller still owns the live operation lease."""
+        ...
 
     def close(self) -> None:
         """
         Release resources owned by the repository.
         """
+        ...
 
 
 __all__ = [

--- a/server/opensandbox_server/services/snapshot_repository.py
+++ b/server/opensandbox_server/services/snapshot_repository.py
@@ -16,6 +16,8 @@
 Repository abstraction for persisted snapshot records.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Protocol
@@ -68,6 +70,14 @@ class SnapshotRepository(Protocol):
         """
         List snapshot records with optional filtering and pagination.
         """
+        ...
+
+    def list_recoverable_operations(
+        self,
+        states: list[SnapshotState],
+        limit: int,
+    ) -> list[SnapshotRecord]:
+        """List a bounded set of unowned or expired operations."""
         ...
 
     def update(self, record: SnapshotRecord) -> SnapshotRecord:

--- a/server/opensandbox_server/services/snapshot_repository.py
+++ b/server/opensandbox_server/services/snapshot_repository.py
@@ -128,6 +128,16 @@ class SnapshotRepository(Protocol):
         """Extend a live operation lease owned by the supplied generation."""
         ...
 
+    def mark_operation_started(
+        self,
+        snapshot_id: str,
+        expected_state: SnapshotState,
+        lease_owner: str,
+        operation_generation: int,
+    ) -> SnapshotRecord | None:
+        """Record that the fenced owner is about to begin runtime side effects."""
+        ...
+
     def update_if_operation_owner(
         self,
         record: SnapshotRecord,

--- a/server/opensandbox_server/services/snapshot_runtime.py
+++ b/server/opensandbox_server/services/snapshot_runtime.py
@@ -41,11 +41,13 @@ class SnapshotRuntime(Protocol):
         """
         Whether this runtime supports creating snapshots.
         """
+        ...
 
     def create_snapshot_unsupported_message(self) -> str:
         """
         Human-readable message used when snapshot creation is unsupported.
         """
+        ...
 
     def create_snapshot(
         self,
@@ -57,21 +59,36 @@ class SnapshotRuntime(Protocol):
         """
         Create a snapshot for a sandbox and return the final runtime status.
         """
+        ...
 
     def get_snapshot_status(self, snapshot_id: str) -> Optional[SnapshotRuntimeStatus]:
         """
         Return the most recent runtime view for a snapshot if known.
         """
+        ...
+
+    def recover_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        image: Optional[str] = None,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        """Observe or safely resume an interrupted snapshot creation."""
+        ...
 
     def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> None:
         """
         Delete runtime-managed artifacts for a snapshot.
         """
+        ...
 
     def inspect_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> SnapshotRuntimeStatus:
         """
         Inspect runtime-managed artifacts for startup recovery.
         """
+        ...
 
 
 class NoopSnapshotRuntime:
@@ -96,6 +113,16 @@ class NoopSnapshotRuntime:
 
     def get_snapshot_status(self, snapshot_id: str) -> Optional[SnapshotRuntimeStatus]:
         return None
+
+    def recover_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        image: Optional[str] = None,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        return self.inspect_snapshot(snapshot_id, image=image, namespace=namespace)
 
     def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> None:
         return None

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -461,6 +461,7 @@ class PersistedSnapshotService(SnapshotService):
         if record.status.state == SnapshotState.DELETING:
             claimed = self._claim_operation(record)
             if claimed is None:
+                self._ensure_recovery_thread()
                 return False
             return self._delete_snapshot_worker(claimed, propagate=False)
 
@@ -557,6 +558,7 @@ class PersistedSnapshotService(SnapshotService):
             claimed = self._claim_operation(record)
             if claimed is None:
                 self._worker_slots.release()
+                self._ensure_recovery_thread()
                 return False
             self._submit_claimed_create_worker(claimed, recovery=recovery)
         except BaseException as exc:

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -259,7 +259,7 @@ class PersistedSnapshotService(SnapshotService):
         """
         self._recovery_stop.set()
         if self._recovery_thread is not None:
-            self._recovery_thread.join(timeout=self._recovery_interval_seconds + 1)
+            self._recovery_thread.join()
         self._snapshot_executor.shutdown(wait=True)
 
     @staticmethod

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -133,6 +133,8 @@ class PersistedSnapshotService(SnapshotService):
             thread_name_prefix="snapshot-create",
         )
         self._worker_slots = BoundedSemaphore(SNAPSHOT_WORKER_MAX_WORKERS)
+        self._active_operations_lock = Lock()
+        self._active_operations: set[tuple[str, int]] = set()
         self._operation_owner = operation_owner or self._default_operation_owner()
         self._operation_lease_duration = timedelta(seconds=operation_lease_seconds)
         self._lease_renew_interval_seconds = lease_renew_interval_seconds
@@ -337,6 +339,9 @@ class PersistedSnapshotService(SnapshotService):
         release_worker_slot: bool = False,
     ) -> None:
         active_heartbeat = heartbeat or self._start_lease_heartbeat(record)
+        operation_key = (record.id, record.operation_generation)
+        with self._active_operations_lock:
+            self._active_operations.add(operation_key)
         try:
             resume_runtime = recovery and record.operation_attempt > 0
             try:
@@ -397,6 +402,8 @@ class PersistedSnapshotService(SnapshotService):
 
             self._complete_snapshot(record, runtime_status)
         finally:
+            with self._active_operations_lock:
+                self._active_operations.discard(operation_key)
             self._stop_lease_heartbeat(active_heartbeat)
             if release_worker_slot:
                 self._worker_slots.release()
@@ -491,6 +498,9 @@ class PersistedSnapshotService(SnapshotService):
 
     def _recover_unfinished_snapshot(self, record: SnapshotRecord) -> bool:
         if record.status.state == SnapshotState.CREATING:
+            if self._is_locally_active_operation(record):
+                self._ensure_recovery_thread()
+                return False
             return self._try_start_create_operation(record, recovery=True)
 
         if record.status.state == SnapshotState.DELETING:
@@ -591,6 +601,12 @@ class PersistedSnapshotService(SnapshotService):
             record.lease_owner,
             record.operation_generation,
         )
+
+    def _is_locally_active_operation(self, record: SnapshotRecord) -> bool:
+        if record.lease_owner != self._operation_owner:
+            return False
+        with self._active_operations_lock:
+            return (record.id, record.operation_generation) in self._active_operations
 
     def _try_start_create_operation(
         self,

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -29,7 +29,7 @@ import logging
 from math import ceil
 import os
 import socket
-from threading import Event, Thread
+from threading import BoundedSemaphore, Event, Lock, Thread
 from uuid import uuid4
 
 from fastapi import HTTPException, status
@@ -132,21 +132,18 @@ class PersistedSnapshotService(SnapshotService):
             max_workers=SNAPSHOT_WORKER_MAX_WORKERS,
             thread_name_prefix="snapshot-create",
         )
+        self._worker_slots = BoundedSemaphore(SNAPSHOT_WORKER_MAX_WORKERS)
         self._operation_owner = operation_owner or self._default_operation_owner()
         self._operation_lease_duration = timedelta(seconds=operation_lease_seconds)
         self._lease_renew_interval_seconds = lease_renew_interval_seconds
         self._recovery_interval_seconds = recovery_interval_seconds
         self._recovery_stop = Event()
+        self._recovery_thread_lock = Lock()
         self._recovery_thread: Thread | None = None
         if recover_unfinished_snapshots:
             self.recover_unfinished_snapshots()
             if self._snapshot_repository.supports_distributed_leases:
-                self._recovery_thread = Thread(
-                    target=self._recovery_loop,
-                    name="snapshot-recovery",
-                    daemon=True,
-                )
-                self._recovery_thread.start()
+                self._ensure_recovery_thread()
 
     def create_snapshot(self, sandbox_id: str, request: CreateSnapshotRequest) -> Snapshot:
         sandbox = self._sandbox_service.get_sandbox(sandbox_id)
@@ -178,9 +175,7 @@ class PersistedSnapshotService(SnapshotService):
             updated_at=now,
         )
         self._snapshot_repository.create(record)
-        claimed = self._claim_operation(record)
-        if claimed is not None:
-            self._submit_create_worker(claimed, recovery=False)
+        self._try_start_create_operation(record, recovery=False)
         return self._to_snapshot_response(record)
 
     def list_snapshots(self, request: ListSnapshotsRequest) -> ListSnapshotsResponse:
@@ -336,44 +331,45 @@ class PersistedSnapshotService(SnapshotService):
         record: SnapshotRecord,
         recovery: bool = False,
         heartbeat: tuple[Event, Thread | None] | None = None,
+        release_worker_slot: bool = False,
     ) -> None:
         active_heartbeat = heartbeat or self._start_lease_heartbeat(record)
         try:
-            if recovery:
-                recover_snapshot = getattr(self._snapshot_runtime, "recover_snapshot", None)
-                if recover_snapshot is None:
-                    runtime_status = self._snapshot_runtime.inspect_snapshot(
-                        record.id,
-                        image=record.restore_config.image,
-                        namespace=record.namespace,
-                    )
+            try:
+                if recovery:
+                    recover_snapshot = getattr(self._snapshot_runtime, "recover_snapshot", None)
+                    if recover_snapshot is None:
+                        runtime_status = self._snapshot_runtime.inspect_snapshot(
+                            record.id,
+                            image=record.restore_config.image,
+                            namespace=record.namespace,
+                        )
+                    else:
+                        runtime_status = recover_snapshot(
+                            record.id,
+                            record.source_sandbox_id,
+                            image=record.restore_config.image,
+                            namespace=record.namespace,
+                        )
                 else:
-                    runtime_status = recover_snapshot(
+                    runtime_status = self._snapshot_runtime.create_snapshot(
                         record.id,
                         record.source_sandbox_id,
-                        image=record.restore_config.image,
                         namespace=record.namespace,
                     )
-            else:
-                runtime_status = self._snapshot_runtime.create_snapshot(
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "Failed to create snapshot %s from sandbox %s: %s",
                     record.id,
                     record.source_sandbox_id,
-                    namespace=record.namespace,
+                    exc,
                 )
-        except Exception as exc:  # noqa: BLE001
-            logger.exception(
-                "Failed to create snapshot %s from sandbox %s: %s",
-                record.id,
-                record.source_sandbox_id,
-                exc,
-            )
-            runtime_status = SnapshotRuntimeStatus(
-                state=SnapshotState.FAILED,
-                reason="snapshot_runtime_failed",
-                message=str(exc),
-            )
+                runtime_status = SnapshotRuntimeStatus(
+                    state=SnapshotState.FAILED,
+                    reason="snapshot_runtime_failed",
+                    message=str(exc),
+                )
 
-        try:
             if runtime_status is None:
                 runtime_status = SnapshotRuntimeStatus(
                     state=SnapshotState.FAILED,
@@ -384,6 +380,8 @@ class PersistedSnapshotService(SnapshotService):
             self._complete_snapshot(record, runtime_status)
         finally:
             self._stop_lease_heartbeat(active_heartbeat)
+            if release_worker_slot:
+                self._worker_slots.release()
 
     def _log_worker_failure(self, future: Future) -> None:
         try:
@@ -418,13 +416,7 @@ class PersistedSnapshotService(SnapshotService):
 
     def recover_unfinished_snapshots(self) -> None:
         page = 1
-        claimed_count = 0
-        claim_limit = (
-            SNAPSHOT_WORKER_MAX_WORKERS
-            if self._snapshot_repository.supports_distributed_leases
-            else None
-        )
-        while claim_limit is None or claimed_count < claim_limit:
+        while True:
             result = self._snapshot_repository.list(
                 SnapshotListQuery(
                     page=page,
@@ -437,10 +429,7 @@ class PersistedSnapshotService(SnapshotService):
 
             for record in result.items:
                 try:
-                    if self._recover_unfinished_snapshot(record):
-                        claimed_count += 1
-                        if claim_limit is not None and claimed_count >= claim_limit:
-                            return
+                    self._recover_unfinished_snapshot(record)
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "Failed to recover unfinished snapshot %s: %s",
@@ -454,15 +443,13 @@ class PersistedSnapshotService(SnapshotService):
             page += 1
 
     def _recover_unfinished_snapshot(self, record: SnapshotRecord) -> bool:
-        claimed = self._claim_operation(record)
-        if claimed is None:
-            return False
+        if record.status.state == SnapshotState.CREATING:
+            return self._try_start_create_operation(record, recovery=True)
 
-        if claimed.status.state == SnapshotState.CREATING:
-            self._submit_create_worker(claimed, recovery=True)
-            return True
-
-        if claimed.status.state == SnapshotState.DELETING:
+        if record.status.state == SnapshotState.DELETING:
+            claimed = self._claim_operation(record)
+            if claimed is None:
+                return False
             self._delete_snapshot_worker(claimed, propagate=False)
             return True
 
@@ -544,17 +531,44 @@ class PersistedSnapshotService(SnapshotService):
             self._operation_lease_duration,
         )
 
-    def _submit_create_worker(self, record: SnapshotRecord, *, recovery: bool) -> None:
-        heartbeat = self._start_lease_heartbeat(record)
+    def _try_start_create_operation(
+        self,
+        record: SnapshotRecord,
+        *,
+        recovery: bool,
+    ) -> bool:
+        if not self._worker_slots.acquire(blocking=False):
+            self._ensure_recovery_thread()
+            return False
+
+        claimed = None
         try:
+            claimed = self._claim_operation(record)
+            if claimed is None:
+                self._worker_slots.release()
+                return False
+            self._submit_claimed_create_worker(claimed, recovery=recovery)
+        except BaseException:
+            if claimed is None:
+                self._worker_slots.release()
+            raise
+        return True
+
+    def _submit_claimed_create_worker(self, record: SnapshotRecord, *, recovery: bool) -> None:
+        heartbeat: tuple[Event, Thread | None] | None = None
+        try:
+            heartbeat = self._start_lease_heartbeat(record)
             future = self._snapshot_executor.submit(
                 self._create_snapshot_worker,
                 record,
                 recovery,
                 heartbeat,
+                True,
             )
         except BaseException:
-            self._stop_lease_heartbeat(heartbeat)
+            if heartbeat is not None:
+                self._stop_lease_heartbeat(heartbeat)
+            self._worker_slots.release()
             raise
         future.add_done_callback(self._log_worker_failure)
 
@@ -643,6 +657,19 @@ class PersistedSnapshotService(SnapshotService):
                 self.recover_unfinished_snapshots()
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Snapshot recovery scan failed: %s", exc, exc_info=True)
+
+    def _ensure_recovery_thread(self) -> None:
+        if self._recovery_stop.is_set():
+            return
+        with self._recovery_thread_lock:
+            if self._recovery_thread is not None and self._recovery_thread.is_alive():
+                return
+            self._recovery_thread = Thread(
+                target=self._recovery_loop,
+                name="snapshot-recovery",
+                daemon=True,
+            )
+            self._recovery_thread.start()
 
     @staticmethod
     def _default_operation_owner() -> str:

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -421,6 +421,7 @@ class PersistedSnapshotService(SnapshotService):
             self._ensure_recovery_thread()
 
     def recover_unfinished_snapshots(self) -> None:
+        records: list[SnapshotRecord] = []
         page = 1
         while True:
             result = self._snapshot_repository.list(
@@ -431,33 +432,22 @@ class PersistedSnapshotService(SnapshotService):
                 )
             )
             if not result.items:
-                return
-
-            result_set_changed = False
-            for record in result.items:
-                try:
-                    recovered = self._recover_unfinished_snapshot(record)
-                    if recovered:
-                        current = self._snapshot_repository.get(record.id)
-                        if current is None or current.status.state not in (
-                            SnapshotState.CREATING,
-                            SnapshotState.DELETING,
-                        ):
-                            result_set_changed = True
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning(
-                        "Failed to recover unfinished snapshot %s: %s",
-                        record.id,
-                        exc,
-                        exc_info=True,
-                    )
-
-            if result_set_changed:
-                page = 1
-                continue
+                break
+            records.extend(result.items)
             if page * SNAPSHOT_RECOVERY_PAGE_SIZE >= result.total_items:
-                return
+                break
             page += 1
+
+        for record in records:
+            try:
+                self._recover_unfinished_snapshot(record)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to recover unfinished snapshot %s: %s",
+                    record.id,
+                    exc,
+                    exc_info=True,
+                )
 
     def _recover_unfinished_snapshot(self, record: SnapshotRecord) -> bool:
         if record.status.state == SnapshotState.CREATING:

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -24,9 +24,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import logging
 from math import ceil
+import os
+import socket
+from threading import Event, Thread
 from uuid import uuid4
 
 from fastapi import HTTPException, status
@@ -62,6 +65,9 @@ from opensandbox_server.tenants.context import get_current_tenant
 logger = logging.getLogger(__name__)
 SNAPSHOT_RECOVERY_PAGE_SIZE = 200
 SNAPSHOT_WORKER_MAX_WORKERS = 2
+SNAPSHOT_OPERATION_LEASE_SECONDS = 30.0
+SNAPSHOT_LEASE_RENEW_INTERVAL_SECONDS = 10.0
+SNAPSHOT_RECOVERY_INTERVAL_SECONDS = 5.0
 
 
 class SnapshotService(ABC):
@@ -104,7 +110,21 @@ class PersistedSnapshotService(SnapshotService):
         snapshot_executor=None,
         *,
         recover_unfinished_snapshots: bool = True,
+        operation_owner: str | None = None,
+        operation_lease_seconds: float = SNAPSHOT_OPERATION_LEASE_SECONDS,
+        lease_renew_interval_seconds: float = SNAPSHOT_LEASE_RENEW_INTERVAL_SECONDS,
+        recovery_interval_seconds: float = SNAPSHOT_RECOVERY_INTERVAL_SECONDS,
     ) -> None:
+        if operation_lease_seconds <= 0:
+            raise ValueError("operation_lease_seconds must be greater than zero")
+        if not 0 < lease_renew_interval_seconds < operation_lease_seconds:
+            raise ValueError(
+                "lease_renew_interval_seconds must be greater than zero and less than "
+                "operation_lease_seconds"
+            )
+        if recovery_interval_seconds <= 0:
+            raise ValueError("recovery_interval_seconds must be greater than zero")
+
         self._snapshot_repository = snapshot_repository
         self._sandbox_service = sandbox_service
         self._snapshot_runtime = snapshot_runtime or NoopSnapshotRuntime()
@@ -112,8 +132,21 @@ class PersistedSnapshotService(SnapshotService):
             max_workers=SNAPSHOT_WORKER_MAX_WORKERS,
             thread_name_prefix="snapshot-create",
         )
+        self._operation_owner = operation_owner or self._default_operation_owner()
+        self._operation_lease_duration = timedelta(seconds=operation_lease_seconds)
+        self._lease_renew_interval_seconds = lease_renew_interval_seconds
+        self._recovery_interval_seconds = recovery_interval_seconds
+        self._recovery_stop = Event()
+        self._recovery_thread: Thread | None = None
         if recover_unfinished_snapshots:
             self.recover_unfinished_snapshots()
+            if self._snapshot_repository.supports_distributed_leases:
+                self._recovery_thread = Thread(
+                    target=self._recovery_loop,
+                    name="snapshot-recovery",
+                    daemon=True,
+                )
+                self._recovery_thread.start()
 
     def create_snapshot(self, sandbox_id: str, request: CreateSnapshotRequest) -> Snapshot:
         sandbox = self._sandbox_service.get_sandbox(sandbox_id)
@@ -145,11 +178,9 @@ class PersistedSnapshotService(SnapshotService):
             updated_at=now,
         )
         self._snapshot_repository.create(record)
-        future = self._snapshot_executor.submit(
-            self._create_snapshot_worker,
-            record,
-        )
-        future.add_done_callback(self._log_worker_failure)
+        claimed = self._claim_operation(record)
+        if claimed is not None:
+            self._submit_create_worker(claimed, recovery=False)
         return self._to_snapshot_response(record)
 
     def list_snapshots(self, request: ListSnapshotsRequest) -> ListSnapshotsResponse:
@@ -217,17 +248,18 @@ class PersistedSnapshotService(SnapshotService):
             if record is None:
                 return
 
-        self._snapshot_runtime.delete_snapshot(
-            snapshot_id,
-            image=record.restore_config.image,
-            namespace=record.namespace,
-        )
-        self._snapshot_repository.delete(snapshot_id)
+        claimed = self._claim_operation(record)
+        if claimed is None:
+            return
+        self._delete_snapshot_worker(claimed, propagate=True)
 
     def close(self) -> None:
         """
         Stop accepting new snapshot work and wait for in-flight workers.
         """
+        self._recovery_stop.set()
+        if self._recovery_thread is not None:
+            self._recovery_thread.join(timeout=self._recovery_interval_seconds + 1)
         self._snapshot_executor.shutdown(wait=True)
 
     @staticmethod
@@ -238,7 +270,7 @@ class PersistedSnapshotService(SnapshotService):
     def _default_pagination():
         from opensandbox_server.api.schema import PaginationRequest
 
-        return PaginationRequest()
+        return PaginationRequest(page=1, pageSize=20)
 
     @staticmethod
     def _get_tenant_namespace() -> str | None:
@@ -276,6 +308,8 @@ class PersistedSnapshotService(SnapshotService):
             ),
             created_at=record.created_at,
             updated_at=now,
+            operation_generation=record.operation_generation,
+            operation_attempt=record.operation_attempt,
         )
         if self._snapshot_repository.update_if_state(
             deleting_record,
@@ -297,13 +331,35 @@ class PersistedSnapshotService(SnapshotService):
             },
         )
 
-    def _create_snapshot_worker(self, record: SnapshotRecord) -> None:
+    def _create_snapshot_worker(
+        self,
+        record: SnapshotRecord,
+        recovery: bool = False,
+        heartbeat: tuple[Event, Thread | None] | None = None,
+    ) -> None:
+        active_heartbeat = heartbeat or self._start_lease_heartbeat(record)
         try:
-            runtime_status = self._snapshot_runtime.create_snapshot(
-                record.id,
-                record.source_sandbox_id,
-                namespace=record.namespace,
-            )
+            if recovery:
+                recover_snapshot = getattr(self._snapshot_runtime, "recover_snapshot", None)
+                if recover_snapshot is None:
+                    runtime_status = self._snapshot_runtime.inspect_snapshot(
+                        record.id,
+                        image=record.restore_config.image,
+                        namespace=record.namespace,
+                    )
+                else:
+                    runtime_status = recover_snapshot(
+                        record.id,
+                        record.source_sandbox_id,
+                        image=record.restore_config.image,
+                        namespace=record.namespace,
+                    )
+            else:
+                runtime_status = self._snapshot_runtime.create_snapshot(
+                    record.id,
+                    record.source_sandbox_id,
+                    namespace=record.namespace,
+                )
         except Exception as exc:  # noqa: BLE001
             logger.exception(
                 "Failed to create snapshot %s from sandbox %s: %s",
@@ -316,17 +372,18 @@ class PersistedSnapshotService(SnapshotService):
                 reason="snapshot_runtime_failed",
                 message=str(exc),
             )
+
+        try:
+            if runtime_status is None:
+                runtime_status = SnapshotRuntimeStatus(
+                    state=SnapshotState.FAILED,
+                    reason="snapshot_runtime_missing_result",
+                    message="Snapshot runtime did not return a final status.",
+                )
+
             self._complete_snapshot(record, runtime_status)
-            return
-
-        if runtime_status is None:
-            runtime_status = SnapshotRuntimeStatus(
-                state=SnapshotState.FAILED,
-                reason="snapshot_runtime_missing_result",
-                message="Snapshot runtime did not return a final status.",
-            )
-
-        self._complete_snapshot(record, runtime_status)
+        finally:
+            self._stop_lease_heartbeat(active_heartbeat)
 
     def _log_worker_failure(self, future: Future) -> None:
         try:
@@ -335,38 +392,37 @@ class PersistedSnapshotService(SnapshotService):
             logger.exception("Snapshot worker exited unexpectedly: %s", exc)
 
     def _complete_snapshot(self, record: SnapshotRecord, runtime_status) -> None:
-        current_record = self._snapshot_repository.get(record.id)
-        if current_record is None:
-            self._cleanup_runtime_artifact(record.id, runtime_status.image, record.namespace)
+        if record.lease_owner is None:
+            logger.warning(
+                "Snapshot %s worker completed without an operation lease; skipping update",
+                record.id,
+            )
             return
 
-        if current_record.status.state == SnapshotState.DELETING:
-            self._cleanup_runtime_artifact(current_record.id, runtime_status.image, current_record.namespace)
-            self._snapshot_repository.delete(current_record.id)
-            return
-
-        if current_record.status.state != SnapshotState.CREATING:
-            return
-
-        updated = self._build_runtime_status_record(current_record, runtime_status)
+        updated = self._build_runtime_status_record(record, runtime_status)
         if updated is None:
             return
 
-        updated_applied = self._snapshot_repository.update_if_state(
+        updated_applied = self._snapshot_repository.update_if_operation_owner(
             updated,
             SnapshotState.CREATING,
+            record.lease_owner,
+            record.operation_generation,
         )
         if not updated_applied:
             logger.info(
-                "Snapshot %s was already transitioned before worker completion; skipping update",
-                current_record.id,
+                "Snapshot %s lease generation %s is stale; skipping terminal update",
+                record.id,
+                record.operation_generation,
             )
 
     def recover_unfinished_snapshots(self) -> None:
-        while True:
+        page = 1
+        claimed_count = 0
+        while claimed_count < SNAPSHOT_WORKER_MAX_WORKERS:
             result = self._snapshot_repository.list(
                 SnapshotListQuery(
-                    page=1,
+                    page=page,
                     page_size=SNAPSHOT_RECOVERY_PAGE_SIZE,
                     states=[SnapshotState.CREATING.value, SnapshotState.DELETING.value],
                 )
@@ -374,10 +430,12 @@ class PersistedSnapshotService(SnapshotService):
             if not result.items:
                 return
 
-            progressed = False
             for record in result.items:
                 try:
-                    progressed = self._recover_unfinished_snapshot(record) or progressed
+                    if self._recover_unfinished_snapshot(record):
+                        claimed_count += 1
+                        if claimed_count >= SNAPSHOT_WORKER_MAX_WORKERS:
+                            return
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "Failed to recover unfinished snapshot %s: %s",
@@ -385,51 +443,22 @@ class PersistedSnapshotService(SnapshotService):
                         exc,
                         exc_info=True,
                     )
-                    failed_status = SnapshotRuntimeStatus(
-                        state=SnapshotState.FAILED,
-                        reason="snapshot_recovery_failed",
-                        message=f"Failed to recover unfinished snapshot: {exc}",
-                    )
-                    self._complete_snapshot(record, failed_status)
-                    progressed = True
 
-            if not progressed:
+            if page * SNAPSHOT_RECOVERY_PAGE_SIZE >= result.total_items:
                 return
+            page += 1
 
     def _recover_unfinished_snapshot(self, record: SnapshotRecord) -> bool:
-        if record.status.state == SnapshotState.CREATING:
-            runtime_status = self._snapshot_runtime.inspect_snapshot(
-                record.id,
-                image=record.restore_config.image,
-                namespace=record.namespace,
-            )
-            if runtime_status.state == SnapshotState.CREATING:
-                future = self._snapshot_executor.submit(
-                    self._create_snapshot_worker,
-                    record,
-                )
-                future.add_done_callback(self._log_worker_failure)
-                return False
-            self._complete_snapshot(record, runtime_status)
+        claimed = self._claim_operation(record)
+        if claimed is None:
+            return False
+
+        if claimed.status.state == SnapshotState.CREATING:
+            self._submit_create_worker(claimed, recovery=True)
             return True
 
-        if record.status.state == SnapshotState.DELETING:
-            try:
-                self._snapshot_runtime.delete_snapshot(
-                    record.id,
-                    image=record.restore_config.image,
-                    namespace=record.namespace,
-                )
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "Failed to recover deleting snapshot %s: %s",
-                    record.id,
-                    exc,
-                    exc_info=True,
-                )
-                return False
-
-            self._snapshot_repository.delete(record.id)
+        if claimed.status.state == SnapshotState.DELETING:
+            self._delete_snapshot_worker(claimed, propagate=False)
             return True
 
         return False
@@ -457,6 +486,8 @@ class PersistedSnapshotService(SnapshotService):
                     ),
                     created_at=record.created_at,
                     updated_at=now,
+                    operation_generation=record.operation_generation,
+                    operation_attempt=record.operation_attempt,
                 )
 
             return SnapshotRecord(
@@ -474,6 +505,8 @@ class PersistedSnapshotService(SnapshotService):
                 ),
                 created_at=record.created_at,
                 updated_at=now,
+                operation_generation=record.operation_generation,
+                operation_attempt=record.operation_attempt,
             )
 
         if runtime_status.state == SnapshotState.FAILED:
@@ -492,23 +525,123 @@ class PersistedSnapshotService(SnapshotService):
                 ),
                 created_at=record.created_at,
                 updated_at=now,
+                operation_generation=record.operation_generation,
+                operation_attempt=record.operation_attempt,
             )
 
         return None
 
-    def _cleanup_runtime_artifact(self, snapshot_id: str, image: str | None, namespace: str = "default") -> None:
-        if not image:
-            return
+    def _claim_operation(self, record: SnapshotRecord) -> SnapshotRecord | None:
+        return self._snapshot_repository.claim_operation(
+            record.id,
+            record.status.state,
+            self._operation_owner,
+            self._operation_lease_duration,
+        )
 
+    def _submit_create_worker(self, record: SnapshotRecord, *, recovery: bool) -> None:
+        heartbeat = self._start_lease_heartbeat(record)
         try:
-            self._snapshot_runtime.delete_snapshot(snapshot_id, image=image, namespace=namespace)
+            future = self._snapshot_executor.submit(
+                self._create_snapshot_worker,
+                record,
+                recovery,
+                heartbeat,
+            )
+        except BaseException:
+            self._stop_lease_heartbeat(heartbeat)
+            raise
+        future.add_done_callback(self._log_worker_failure)
+
+    def _delete_snapshot_worker(self, record: SnapshotRecord, *, propagate: bool) -> None:
+        heartbeat = self._start_lease_heartbeat(record)
+        try:
+            self._snapshot_runtime.delete_snapshot(
+                record.id,
+                image=record.restore_config.image,
+                namespace=record.namespace,
+            )
+            deleted = self._snapshot_repository.delete_if_operation_owner(
+                record.id,
+                SnapshotState.DELETING,
+                record.lease_owner or "",
+                record.operation_generation,
+            )
+            if not deleted:
+                logger.info(
+                    "Snapshot %s lease generation %s is stale; retaining metadata for recovery",
+                    record.id,
+                    record.operation_generation,
+                )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
-                "Failed to cleanup snapshot artifact for %s: %s",
-                snapshot_id,
+                "Failed to delete snapshot %s while holding generation %s: %s",
+                record.id,
+                record.operation_generation,
                 exc,
                 exc_info=True,
             )
+            if propagate:
+                raise
+            return
+        finally:
+            self._stop_lease_heartbeat(heartbeat)
+
+    def _start_lease_heartbeat(self, record: SnapshotRecord) -> tuple[Event, Thread | None]:
+        stop = Event()
+        if record.lease_owner is None:
+            return stop, None
+
+        def renew() -> None:
+            while not stop.wait(self._lease_renew_interval_seconds):
+                try:
+                    renewed = self._snapshot_repository.renew_operation(
+                        record.id,
+                        record.status.state,
+                        record.lease_owner or "",
+                        record.operation_generation,
+                        self._operation_lease_duration,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "Failed to renew snapshot %s lease generation %s: %s",
+                        record.id,
+                        record.operation_generation,
+                        exc,
+                    )
+                    continue
+                if not renewed:
+                    logger.info(
+                        "Snapshot %s lease generation %s is no longer owned by this worker",
+                        record.id,
+                        record.operation_generation,
+                    )
+                    return
+
+        thread = Thread(
+            target=renew,
+            name=f"snapshot-lease-{record.id[:8]}",
+            daemon=True,
+        )
+        thread.start()
+        return stop, thread
+
+    def _stop_lease_heartbeat(self, heartbeat: tuple[Event, Thread | None]) -> None:
+        stop, thread = heartbeat
+        stop.set()
+        if thread is not None:
+            thread.join(timeout=self._lease_renew_interval_seconds + 1)
+
+    def _recovery_loop(self) -> None:
+        while not self._recovery_stop.wait(self._recovery_interval_seconds):
+            try:
+                self.recover_unfinished_snapshots()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Snapshot recovery scan failed: %s", exc, exc_info=True)
+
+    @staticmethod
+    def _default_operation_owner() -> str:
+        return f"{socket.gethostname()}:{os.getpid()}:{uuid4()}"
 
     @staticmethod
     def _ensure_source_sandbox_running(sandbox) -> None:

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -399,6 +399,7 @@ class PersistedSnapshotService(SnapshotService):
 
         updated = self._build_runtime_status_record(record, runtime_status)
         if updated is None:
+            self._ensure_recovery_thread()
             return
 
         updated_applied = self._snapshot_repository.update_if_operation_owner(

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -433,12 +433,17 @@ class PersistedSnapshotService(SnapshotService):
             if not result.items:
                 return
 
-            deleted_any = False
+            result_set_changed = False
             for record in result.items:
                 try:
                     recovered = self._recover_unfinished_snapshot(record)
-                    if record.status.state == SnapshotState.DELETING and recovered:
-                        deleted_any = True
+                    if recovered:
+                        current = self._snapshot_repository.get(record.id)
+                        if current is None or current.status.state not in (
+                            SnapshotState.CREATING,
+                            SnapshotState.DELETING,
+                        ):
+                            result_set_changed = True
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "Failed to recover unfinished snapshot %s: %s",
@@ -447,7 +452,7 @@ class PersistedSnapshotService(SnapshotService):
                         exc_info=True,
                     )
 
-            if deleted_any:
+            if result_set_changed:
                 page = 1
                 continue
             if page * SNAPSHOT_RECOVERY_PAGE_SIZE >= result.total_items:

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -458,7 +458,11 @@ class PersistedSnapshotService(SnapshotService):
             return self._try_start_create_operation(record, recovery=True)
 
         if record.status.state == SnapshotState.DELETING:
-            claimed = self._claim_operation(record)
+            try:
+                claimed = self._claim_operation(record)
+            except Exception:
+                self._ensure_recovery_thread()
+                raise
             if claimed is None:
                 self._ensure_recovery_thread()
                 return False

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -338,8 +338,23 @@ class PersistedSnapshotService(SnapshotService):
     ) -> None:
         active_heartbeat = heartbeat or self._start_lease_heartbeat(record)
         try:
+            resume_runtime = recovery and record.operation_attempt > 0
             try:
-                if recovery:
+                started = self._mark_operation_started(record)
+            except Exception:
+                self._ensure_recovery_thread()
+                raise
+            if started is None:
+                logger.info(
+                    "Snapshot %s lease generation %s became stale before runtime execution",
+                    record.id,
+                    record.operation_generation,
+                )
+                self._ensure_recovery_thread()
+                return
+            record = started
+            try:
+                if resume_runtime:
                     recover_snapshot = getattr(self._snapshot_runtime, "recover_snapshot", None)
                     if recover_snapshot is None:
                         runtime_status = self._snapshot_runtime.inspect_snapshot(
@@ -567,6 +582,16 @@ class PersistedSnapshotService(SnapshotService):
             self._operation_lease_duration,
         )
 
+    def _mark_operation_started(self, record: SnapshotRecord) -> SnapshotRecord | None:
+        if record.lease_owner is None:
+            return None
+        return self._snapshot_repository.mark_operation_started(
+            record.id,
+            record.status.state,
+            record.lease_owner,
+            record.operation_generation,
+        )
+
     def _try_start_create_operation(
         self,
         record: SnapshotRecord,
@@ -614,6 +639,16 @@ class PersistedSnapshotService(SnapshotService):
     def _delete_snapshot_worker(self, record: SnapshotRecord, *, propagate: bool) -> bool:
         heartbeat = self._start_lease_heartbeat(record)
         try:
+            started = self._mark_operation_started(record)
+            if started is None:
+                logger.info(
+                    "Snapshot %s lease generation %s became stale before runtime deletion",
+                    record.id,
+                    record.operation_generation,
+                )
+                self._ensure_recovery_thread()
+                return False
+            record = started
             self._snapshot_runtime.delete_snapshot(
                 record.id,
                 image=record.restore_config.image,

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -427,9 +427,12 @@ class PersistedSnapshotService(SnapshotService):
             if not result.items:
                 return
 
+            deleted_any = False
             for record in result.items:
                 try:
-                    self._recover_unfinished_snapshot(record)
+                    recovered = self._recover_unfinished_snapshot(record)
+                    if record.status.state == SnapshotState.DELETING and recovered:
+                        deleted_any = True
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "Failed to recover unfinished snapshot %s: %s",
@@ -438,6 +441,9 @@ class PersistedSnapshotService(SnapshotService):
                         exc_info=True,
                     )
 
+            if deleted_any:
+                page = 1
+                continue
             if page * SNAPSHOT_RECOVERY_PAGE_SIZE >= result.total_items:
                 return
             page += 1
@@ -450,8 +456,7 @@ class PersistedSnapshotService(SnapshotService):
             claimed = self._claim_operation(record)
             if claimed is None:
                 return False
-            self._delete_snapshot_worker(claimed, propagate=False)
-            return True
+            return self._delete_snapshot_worker(claimed, propagate=False)
 
         return False
 
@@ -572,7 +577,7 @@ class PersistedSnapshotService(SnapshotService):
             raise
         future.add_done_callback(self._log_worker_failure)
 
-    def _delete_snapshot_worker(self, record: SnapshotRecord, *, propagate: bool) -> None:
+    def _delete_snapshot_worker(self, record: SnapshotRecord, *, propagate: bool) -> bool:
         heartbeat = self._start_lease_heartbeat(record)
         try:
             self._snapshot_runtime.delete_snapshot(
@@ -592,6 +597,7 @@ class PersistedSnapshotService(SnapshotService):
                     record.id,
                     record.operation_generation,
                 )
+            return deleted
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "Failed to delete snapshot %s while holding generation %s: %s",
@@ -600,9 +606,10 @@ class PersistedSnapshotService(SnapshotService):
                 exc,
                 exc_info=True,
             )
+            self._ensure_recovery_thread()
             if propagate:
                 raise
-            return
+            return False
         finally:
             self._stop_lease_heartbeat(heartbeat)
 

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -142,8 +142,7 @@ class PersistedSnapshotService(SnapshotService):
         self._recovery_thread: Thread | None = None
         if recover_unfinished_snapshots:
             self.recover_unfinished_snapshots()
-            if self._snapshot_repository.supports_distributed_leases:
-                self._ensure_recovery_thread()
+            self._ensure_recovery_thread()
 
     def create_snapshot(self, sandbox_id: str, request: CreateSnapshotRequest) -> Snapshot:
         sandbox = self._sandbox_service.get_sandbox(sandbox_id)
@@ -425,33 +424,55 @@ class PersistedSnapshotService(SnapshotService):
             self._ensure_recovery_thread()
 
     def recover_unfinished_snapshots(self) -> None:
-        records: list[SnapshotRecord] = []
-        page = 1
-        while True:
-            result = self._snapshot_repository.list(
-                SnapshotListQuery(
-                    page=page,
-                    page_size=SNAPSHOT_RECOVERY_PAGE_SIZE,
-                    states=[SnapshotState.CREATING.value, SnapshotState.DELETING.value],
-                )
-            )
-            if not result.items:
-                break
-            records.extend(result.items)
-            if page * SNAPSHOT_RECOVERY_PAGE_SIZE >= result.total_items:
-                break
-            page += 1
+        self._recover_creating_snapshots()
+        self._recover_deleting_snapshots()
 
+    def _recover_creating_snapshots(self) -> None:
+        while self._has_available_worker_slot():
+            records = self._snapshot_repository.list_recoverable_operations(
+                [SnapshotState.CREATING],
+                SNAPSHOT_WORKER_MAX_WORKERS,
+            )
+            if not records:
+                return
+            if not self._recover_records(records):
+                self._ensure_recovery_thread()
+                return
+        self._ensure_recovery_thread()
+
+    def _recover_deleting_snapshots(self) -> None:
+        while True:
+            records = self._snapshot_repository.list_recoverable_operations(
+                [SnapshotState.DELETING],
+                SNAPSHOT_RECOVERY_PAGE_SIZE,
+            )
+            if not records:
+                return
+            if not self._recover_records(records):
+                self._ensure_recovery_thread()
+                return
+
+    def _recover_records(self, records: list[SnapshotRecord]) -> bool:
+        all_progressed = True
         for record in records:
             try:
-                self._recover_unfinished_snapshot(record)
+                if not self._recover_unfinished_snapshot(record):
+                    all_progressed = False
             except Exception as exc:  # noqa: BLE001
+                all_progressed = False
                 logger.warning(
                     "Failed to recover unfinished snapshot %s: %s",
                     record.id,
                     exc,
                     exc_info=True,
                 )
+        return all_progressed
+
+    def _has_available_worker_slot(self) -> bool:
+        if not self._worker_slots.acquire(blocking=False):
+            return False
+        self._worker_slots.release()
+        return True
 
     def _recover_unfinished_snapshot(self, record: SnapshotRecord) -> bool:
         if record.status.state == SnapshotState.CREATING:

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -559,9 +559,11 @@ class PersistedSnapshotService(SnapshotService):
                 self._worker_slots.release()
                 return False
             self._submit_claimed_create_worker(claimed, recovery=recovery)
-        except BaseException:
+        except BaseException as exc:
             if claimed is None:
                 self._worker_slots.release()
+            if isinstance(exc, Exception):
+                self._ensure_recovery_thread()
             raise
         return True
 

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -419,7 +419,12 @@ class PersistedSnapshotService(SnapshotService):
     def recover_unfinished_snapshots(self) -> None:
         page = 1
         claimed_count = 0
-        while claimed_count < SNAPSHOT_WORKER_MAX_WORKERS:
+        claim_limit = (
+            SNAPSHOT_WORKER_MAX_WORKERS
+            if self._snapshot_repository.supports_distributed_leases
+            else None
+        )
+        while claim_limit is None or claimed_count < claim_limit:
             result = self._snapshot_repository.list(
                 SnapshotListQuery(
                     page=page,
@@ -434,7 +439,7 @@ class PersistedSnapshotService(SnapshotService):
                 try:
                     if self._recover_unfinished_snapshot(record):
                         claimed_count += 1
-                        if claimed_count >= SNAPSHOT_WORKER_MAX_WORKERS:
+                        if claim_limit is not None and claimed_count >= claim_limit:
                             return
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -402,12 +402,16 @@ class PersistedSnapshotService(SnapshotService):
             self._ensure_recovery_thread()
             return
 
-        updated_applied = self._snapshot_repository.update_if_operation_owner(
-            updated,
-            SnapshotState.CREATING,
-            record.lease_owner,
-            record.operation_generation,
-        )
+        try:
+            updated_applied = self._snapshot_repository.update_if_operation_owner(
+                updated,
+                SnapshotState.CREATING,
+                record.lease_owner,
+                record.operation_generation,
+            )
+        except Exception:
+            self._ensure_recovery_thread()
+            raise
         if not updated_applied:
             logger.info(
                 "Snapshot %s lease generation %s is stale; skipping terminal update",

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -243,7 +243,11 @@ class PersistedSnapshotService(SnapshotService):
             if record is None:
                 return
 
-        claimed = self._claim_operation(record)
+        try:
+            claimed = self._claim_operation(record)
+        except Exception:
+            self._ensure_recovery_thread()
+            raise
         if claimed is None:
             return
         self._delete_snapshot_worker(claimed, propagate=True)

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -414,6 +414,7 @@ class PersistedSnapshotService(SnapshotService):
                 record.id,
                 record.operation_generation,
             )
+            self._ensure_recovery_thread()
 
     def recover_unfinished_snapshots(self) -> None:
         page = 1
@@ -598,6 +599,7 @@ class PersistedSnapshotService(SnapshotService):
                     record.id,
                     record.operation_generation,
                 )
+                self._ensure_recovery_thread()
             return deleted
         except Exception as exc:  # noqa: BLE001
             logger.warning(

--- a/server/tests/snapshot_repository_contract.py
+++ b/server/tests/snapshot_repository_contract.py
@@ -200,7 +200,7 @@ class SnapshotRepositoryContract:
 
         assert claim is not None
         assert claim.operation_generation == 1
-        assert claim.operation_attempt == 1
+        assert claim.operation_attempt == 0
         assert claim.lease_owner == "server-a"
         assert claim.lease_expires_at is not None
         assert repository.claim_operation(
@@ -216,6 +216,20 @@ class SnapshotRepositoryContract:
             claim.operation_generation,
             timedelta(seconds=30),
         ) is True
+        assert repository.mark_operation_started(
+            original.id,
+            SnapshotState.CREATING,
+            "server-b",
+            claim.operation_generation,
+        ) is None
+        started = repository.mark_operation_started(
+            original.id,
+            SnapshotState.CREATING,
+            "server-a",
+            claim.operation_generation,
+        )
+        assert started is not None
+        assert started.operation_attempt == 1
 
         ready = snapshot_record(
             original.id,
@@ -224,7 +238,7 @@ class SnapshotRepositoryContract:
             SnapshotState.READY,
         )
         ready.operation_generation = claim.operation_generation
-        ready.operation_attempt = claim.operation_attempt
+        ready.operation_attempt = started.operation_attempt
         assert repository.update_if_operation_owner(
             ready,
             SnapshotState.CREATING,

--- a/server/tests/snapshot_repository_contract.py
+++ b/server/tests/snapshot_repository_contract.py
@@ -182,3 +182,64 @@ class SnapshotRepositoryContract:
         repository.delete(original.id)
         repository.delete(original.id)
         assert repository.get(original.id) is None
+
+    def test_operation_lease_claim_renew_and_fenced_completion(
+        self,
+        repository: SnapshotRepository,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        original = snapshot_record("snap-lease", "sbx-001", now)
+        repository.create(original)
+
+        claim = repository.claim_operation(
+            original.id,
+            SnapshotState.CREATING,
+            "server-a",
+            timedelta(seconds=30),
+        )
+
+        assert claim is not None
+        assert claim.operation_generation == 1
+        assert claim.operation_attempt == 1
+        assert claim.lease_owner == "server-a"
+        assert claim.lease_expires_at is not None
+        assert repository.claim_operation(
+            original.id,
+            SnapshotState.CREATING,
+            "server-b",
+            timedelta(seconds=30),
+        ) is None
+        assert repository.renew_operation(
+            original.id,
+            SnapshotState.CREATING,
+            "server-a",
+            claim.operation_generation,
+            timedelta(seconds=30),
+        ) is True
+
+        ready = snapshot_record(
+            original.id,
+            original.source_sandbox_id,
+            original.created_at,
+            SnapshotState.READY,
+        )
+        ready.operation_generation = claim.operation_generation
+        ready.operation_attempt = claim.operation_attempt
+        assert repository.update_if_operation_owner(
+            ready,
+            SnapshotState.CREATING,
+            "server-b",
+            claim.operation_generation,
+        ) is False
+        assert repository.update_if_operation_owner(
+            ready,
+            SnapshotState.CREATING,
+            "server-a",
+            claim.operation_generation,
+        ) is True
+
+        stored = repository.get(original.id)
+        assert stored is not None
+        assert stored.status.state == SnapshotState.READY
+        assert stored.lease_owner is None
+        assert stored.lease_expires_at is None

--- a/server/tests/snapshot_repository_contract.py
+++ b/server/tests/snapshot_repository_contract.py
@@ -243,3 +243,68 @@ class SnapshotRepositoryContract:
         assert stored.status.state == SnapshotState.READY
         assert stored.lease_owner is None
         assert stored.lease_expires_at is None
+
+    def test_lists_bounded_recoverable_operations(
+        self,
+        repository: SnapshotRepository,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        deleting = snapshot_record(
+            "snap-deleting",
+            "sbx-001",
+            now,
+            SnapshotState.DELETING,
+        )
+        expired = snapshot_record(
+            "snap-expired",
+            "sbx-001",
+            now + timedelta(seconds=1),
+        )
+        active = snapshot_record(
+            "snap-active",
+            "sbx-001",
+            now + timedelta(seconds=2),
+        )
+        ready = snapshot_record(
+            "snap-ready",
+            "sbx-001",
+            now + timedelta(seconds=3),
+            SnapshotState.READY,
+        )
+        for record in (deleting, expired, active, ready):
+            repository.create(record)
+
+        assert repository.claim_operation(
+            expired.id,
+            SnapshotState.CREATING,
+            "stopped-server",
+            timedelta(seconds=-1),
+        ) is not None
+        assert repository.claim_operation(
+            active.id,
+            SnapshotState.CREATING,
+            "active-server",
+            timedelta(seconds=30),
+        ) is not None
+
+        recoverable = repository.list_recoverable_operations(
+            [SnapshotState.CREATING, SnapshotState.DELETING],
+            2,
+        )
+        assert [record.id for record in recoverable] == [deleting.id, expired.id]
+        assert [
+            record.id
+            for record in repository.list_recoverable_operations(
+                [SnapshotState.CREATING, SnapshotState.DELETING],
+                1,
+            )
+        ] == [deleting.id]
+        assert [
+            record.id
+            for record in repository.list_recoverable_operations(
+                [SnapshotState.CREATING],
+                10,
+            )
+        ] == [expired.id]
+        assert repository.list_recoverable_operations([], 10) == []
+        assert repository.list_recoverable_operations([SnapshotState.CREATING], 0) == []

--- a/server/tests/test_k8s_snapshot_runtime.py
+++ b/server/tests/test_k8s_snapshot_runtime.py
@@ -284,6 +284,29 @@ def test_create_snapshot_rechecks_deadline_before_creating_missing_cr(monkeypatc
     assert k8s_client.created == []
 
 
+def test_create_snapshot_leaves_slow_success_recoverable(monkeypatch) -> None:
+    k8s_client = FakeK8sClient()
+    ticks = iter([0.0, 1.0, 11.0])
+    monkeypatch.setattr(
+        "opensandbox_server.services.k8s.snapshot_runtime.time.monotonic",
+        lambda: next(ticks),
+    )
+    runtime = KubernetesSnapshotRuntime(
+        k8s_client,
+        namespace="default",
+        wait_timeout_seconds=10,
+        poll_interval_seconds=0,
+    )
+
+    status = runtime.create_snapshot(SNAPSHOT_ID, SANDBOX_ID)
+
+    assert status.state == SnapshotState.CREATING
+    assert status.reason == "snapshot_runtime_timeout"
+    assert "recovery will continue" in (status.message or "")
+    assert len(k8s_client.created) == 1
+    assert build_public_snapshot_name(SNAPSHOT_ID) in k8s_client.objects
+
+
 def test_create_snapshot_observes_the_winner_after_create_race() -> None:
     k8s_client = CreateRaceK8sClient(
         _snapshot_cr(

--- a/server/tests/test_k8s_snapshot_runtime.py
+++ b/server/tests/test_k8s_snapshot_runtime.py
@@ -228,6 +228,27 @@ def test_create_snapshot_creates_cr_only_after_observing_it_is_missing() -> None
     assert status.image == "registry/sandbox:snap"
 
 
+def test_create_snapshot_rechecks_deadline_before_creating_missing_cr(monkeypatch) -> None:
+    k8s_client = ReadyOnCreateK8sClient()
+    ticks = iter([0.0, 11.0])
+    monkeypatch.setattr(
+        "opensandbox_server.services.k8s.snapshot_runtime.time.monotonic",
+        lambda: next(ticks),
+    )
+    runtime = KubernetesSnapshotRuntime(
+        k8s_client,
+        namespace="default",
+        wait_timeout_seconds=10,
+        poll_interval_seconds=0,
+    )
+
+    status = runtime.create_snapshot(SNAPSHOT_ID, SANDBOX_ID)
+
+    assert status.state == SnapshotState.FAILED
+    assert status.reason == "snapshot_runtime_timeout"
+    assert k8s_client.created == []
+
+
 def test_create_snapshot_observes_the_winner_after_create_race() -> None:
     k8s_client = CreateRaceK8sClient(
         _snapshot_cr(

--- a/server/tests/test_k8s_snapshot_runtime.py
+++ b/server/tests/test_k8s_snapshot_runtime.py
@@ -75,6 +75,16 @@ class TransientGetK8sClient(FakeK8sClient):
         )
 
 
+class ForbiddenGetK8sClient(FakeK8sClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.get_calls = 0
+
+    def get_custom_object(self, **kwargs):
+        self.get_calls += 1
+        raise ApiException(status=403, reason="forbidden")
+
+
 class TransientThenReadyK8sClient(TransientGetK8sClient):
     def get_custom_object(self, *, group: str, version: str, namespace: str, plural: str, name: str):
         obj = super().get_custom_object(
@@ -314,6 +324,29 @@ def test_create_snapshot_retries_transient_inspect_error_until_controller_ready(
 
     assert status.state == SnapshotState.READY
     assert status.image == "registry/sandbox:snap"
+
+
+def test_create_snapshot_fails_fast_on_permanent_inspect_error(monkeypatch) -> None:
+    k8s_client = ForbiddenGetK8sClient()
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "opensandbox_server.services.k8s.snapshot_runtime.time.sleep",
+        sleep_calls.append,
+    )
+    runtime = KubernetesSnapshotRuntime(
+        k8s_client,
+        namespace="default",
+        wait_timeout_seconds=900,
+        poll_interval_seconds=2,
+    )
+
+    status = runtime.create_snapshot(SNAPSHOT_ID, SANDBOX_ID)
+
+    assert status.state == SnapshotState.FAILED
+    assert status.reason == "snapshot_runtime_inspect_failed"
+    assert "forbidden" in (status.message or "")
+    assert k8s_client.get_calls == 1
+    assert sleep_calls == []
 
 
 def test_create_snapshot_uses_one_deadline_for_observation_and_completion(monkeypatch) -> None:

--- a/server/tests/test_k8s_snapshot_runtime.py
+++ b/server/tests/test_k8s_snapshot_runtime.py
@@ -57,6 +57,16 @@ class FakeK8sClient:
         del self.objects[name]
 
 
+class CountingK8sClient(FakeK8sClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.get_calls = 0
+
+    def get_custom_object(self, **kwargs):
+        self.get_calls += 1
+        return super().get_custom_object(**kwargs)
+
+
 class TransientGetK8sClient(FakeK8sClient):
     def __init__(self, *, failures: int) -> None:
         super().__init__()
@@ -209,6 +219,31 @@ def test_create_snapshot_observes_existing_cr_without_duplicate_create() -> None
     assert status.state == SnapshotState.READY
     assert status.image == "registry/sandbox:snap"
     assert status.reason == "snapshot_runtime_ready"
+
+
+def test_create_snapshot_checks_deadline_before_following_existing_cr(monkeypatch) -> None:
+    k8s_client = CountingK8sClient()
+    k8s_client.objects[build_public_snapshot_name(SNAPSHOT_ID)] = _snapshot_cr(
+        phase="Pending",
+    )
+    ticks = iter([0.0, 11.0])
+    monkeypatch.setattr(
+        "opensandbox_server.services.k8s.snapshot_runtime.time.monotonic",
+        lambda: next(ticks),
+    )
+    runtime = KubernetesSnapshotRuntime(
+        k8s_client,
+        namespace="default",
+        wait_timeout_seconds=10,
+        poll_interval_seconds=0,
+    )
+
+    status = runtime.create_snapshot(SNAPSHOT_ID, SANDBOX_ID)
+
+    assert status.state == SnapshotState.FAILED
+    assert status.reason == "snapshot_runtime_timeout"
+    assert k8s_client.get_calls == 1
+    assert k8s_client.created == []
 
 
 def test_create_snapshot_creates_cr_only_after_observing_it_is_missing() -> None:
@@ -393,7 +428,7 @@ def test_create_snapshot_uses_one_deadline_for_observation_and_completion(monkey
 
     assert status.state == SnapshotState.FAILED
     assert status.reason == "snapshot_runtime_timeout"
-    assert k8s_client.get_calls == 3
+    assert k8s_client.get_calls == 2
     assert sleep_calls == [1]
 
 

--- a/server/tests/test_k8s_snapshot_runtime.py
+++ b/server/tests/test_k8s_snapshot_runtime.py
@@ -95,6 +95,37 @@ class TransientThenReadyK8sClient(TransientGetK8sClient):
         return obj
 
 
+class ReadyOnCreateK8sClient(FakeK8sClient):
+    def create_custom_object(self, **kwargs):
+        stored = super().create_custom_object(**kwargs)
+        name = stored["metadata"]["name"]
+        stored["status"] = {
+            "phase": "Succeed",
+            "containers": [
+                {"containerName": "sandbox", "imageUri": "registry/sandbox:snap"},
+            ],
+        }
+        self.objects[name] = deepcopy(stored)
+        return stored
+
+
+class CreateRaceK8sClient(FakeK8sClient):
+    def __init__(self, existing: dict) -> None:
+        super().__init__()
+        self.existing = deepcopy(existing)
+        self.get_calls = 0
+
+    def get_custom_object(self, **kwargs):
+        self.get_calls += 1
+        if self.get_calls == 1:
+            return None
+        return deepcopy(self.existing)
+
+    def create_custom_object(self, **kwargs):
+        self.created.append(deepcopy(kwargs["body"]))
+        raise ApiException(status=409, reason="Already Exists")
+
+
 def _snapshot_cr(*, phase: str, containers: list[dict] | None = None, sandbox_id: str = SANDBOX_ID) -> dict:
     name = build_public_snapshot_name(SNAPSHOT_ID)
     return {
@@ -124,7 +155,7 @@ def test_public_snapshot_name_and_tag_are_derived_from_snapshot_id() -> None:
     assert build_public_snapshot_tag(SNAPSHOT_ID) == f"snap-{SNAPSHOT_HEX}"
 
 
-def test_create_snapshot_creates_cr_and_maps_succeed_to_ready() -> None:
+def test_create_snapshot_observes_existing_cr_without_duplicate_create() -> None:
     k8s_client = FakeK8sClient()
     snapshot_name = build_public_snapshot_name(SNAPSHOT_ID)
     k8s_client.objects[snapshot_name] = _snapshot_cr(
@@ -143,27 +174,50 @@ def test_create_snapshot_creates_cr_and_maps_succeed_to_ready() -> None:
 
     status = runtime.create_snapshot(SNAPSHOT_ID, SANDBOX_ID)
 
-    assert k8s_client.created == [
-        {
-            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
-            "kind": "SandboxSnapshot",
-            "metadata": {
-                "name": snapshot_name,
-                "namespace": "default",
-                "labels": {
-                    "opensandbox.io/snapshot-id": SNAPSHOT_ID,
-                    "opensandbox.io/source-sandbox-id": SANDBOX_ID,
-                    "opensandbox.io/snapshot-scope": "public",
-                },
-            },
-            "spec": {
-                "sandboxName": SANDBOX_ID,
-            },
-        }
-    ]
+    assert k8s_client.created == []
     assert status.state == SnapshotState.READY
     assert status.image == "registry/sandbox:snap"
     assert status.reason == "snapshot_runtime_ready"
+
+
+def test_create_snapshot_creates_cr_only_after_observing_it_is_missing() -> None:
+    k8s_client = ReadyOnCreateK8sClient()
+    snapshot_name = build_public_snapshot_name(SNAPSHOT_ID)
+    runtime = KubernetesSnapshotRuntime(
+        k8s_client,
+        namespace="default",
+        wait_timeout_seconds=1,
+        poll_interval_seconds=0,
+    )
+
+    status = runtime.create_snapshot(SNAPSHOT_ID, SANDBOX_ID)
+
+    assert [item["metadata"]["name"] for item in k8s_client.created] == [snapshot_name]
+    assert status.state == SnapshotState.READY
+    assert status.image == "registry/sandbox:snap"
+
+
+def test_create_snapshot_observes_the_winner_after_create_race() -> None:
+    k8s_client = CreateRaceK8sClient(
+        _snapshot_cr(
+            phase="Succeed",
+            containers=[
+                {"containerName": "sandbox", "imageUri": "registry/sandbox:snap"},
+            ],
+        )
+    )
+    runtime = KubernetesSnapshotRuntime(
+        k8s_client,
+        namespace="default",
+        wait_timeout_seconds=1,
+        poll_interval_seconds=0,
+    )
+
+    status = runtime.create_snapshot(SNAPSHOT_ID, SANDBOX_ID)
+
+    assert len(k8s_client.created) == 1
+    assert status.state == SnapshotState.READY
+    assert status.image == "registry/sandbox:snap"
 
 
 def test_inspect_snapshot_keeps_pending_snapshot_creating() -> None:

--- a/server/tests/test_k8s_snapshot_runtime.py
+++ b/server/tests/test_k8s_snapshot_runtime.py
@@ -95,6 +95,27 @@ class TransientThenReadyK8sClient(TransientGetK8sClient):
         return obj
 
 
+class TransientThenPendingThenReadyK8sClient(FakeK8sClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.get_calls = 0
+        self.objects[build_public_snapshot_name(SNAPSHOT_ID)] = _snapshot_cr(phase="Pending")
+
+    def get_custom_object(self, **kwargs):
+        self.get_calls += 1
+        if self.get_calls == 1:
+            raise ApiException(status=500, reason="temporary apiserver error")
+        snapshot = deepcopy(self.objects[kwargs["name"]])
+        if self.get_calls >= 4:
+            snapshot["status"] = {
+                "phase": "Succeed",
+                "containers": [
+                    {"containerName": "sandbox", "imageUri": "registry/sandbox:snap"},
+                ],
+            }
+        return snapshot
+
+
 class ReadyOnCreateK8sClient(FakeK8sClient):
     def create_custom_object(self, **kwargs):
         stored = super().create_custom_object(**kwargs)
@@ -293,6 +314,33 @@ def test_create_snapshot_retries_transient_inspect_error_until_controller_ready(
 
     assert status.state == SnapshotState.READY
     assert status.image == "registry/sandbox:snap"
+
+
+def test_create_snapshot_uses_one_deadline_for_observation_and_completion(monkeypatch) -> None:
+    k8s_client = TransientThenPendingThenReadyK8sClient()
+    ticks = iter([0.0, 9.0, 10.0])
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "opensandbox_server.services.k8s.snapshot_runtime.time.monotonic",
+        lambda: next(ticks),
+    )
+    monkeypatch.setattr(
+        "opensandbox_server.services.k8s.snapshot_runtime.time.sleep",
+        sleep_calls.append,
+    )
+    runtime = KubernetesSnapshotRuntime(
+        k8s_client,
+        namespace="default",
+        wait_timeout_seconds=10,
+        poll_interval_seconds=1,
+    )
+
+    status = runtime.create_snapshot(SNAPSHOT_ID, SANDBOX_ID)
+
+    assert status.state == SnapshotState.FAILED
+    assert status.reason == "snapshot_runtime_timeout"
+    assert k8s_client.get_calls == 3
+    assert sleep_calls == [1]
 
 
 def test_delete_snapshot_deletes_cr_and_ignores_missing_cr() -> None:

--- a/server/tests/test_snapshot_migration.py
+++ b/server/tests/test_snapshot_migration.py
@@ -201,6 +201,64 @@ def test_migrate_skips_records_already_in_postgresql(tmp_path, postgresql_dsn: s
     assert len(stored) == 2
 
 
+def test_migrate_backfills_existing_legacy_target_creating_row(
+    tmp_path,
+    postgresql_dsn: str,
+) -> None:
+    now = datetime(2026, 1, 2, 3, 4, 5)
+    sqlite_repo = _create_sqlite_repository(
+        tmp_path,
+        [snapshot_record("snap-existing", "sbx-001", now, SnapshotState.CREATING)],
+    )
+    sqlite_repo.close()
+
+    with psycopg.connect(postgresql_dsn) as conn:
+        conn.execute("DROP TABLE IF EXISTS snapshots")
+        conn.execute(
+            """
+            CREATE TABLE snapshots (
+                id TEXT PRIMARY KEY,
+                source_sandbox_id TEXT NOT NULL,
+                namespace TEXT DEFAULT NULL,
+                name TEXT,
+                description TEXT,
+                restore_config JSONB NOT NULL,
+                state TEXT NOT NULL,
+                reason TEXT,
+                message TEXT,
+                last_transition_at TIMESTAMPTZ,
+                created_at TIMESTAMPTZ NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO snapshots (
+                id, source_sandbox_id, namespace, name, description,
+                restore_config, state, reason, message, last_transition_at,
+                created_at, updated_at
+            ) VALUES (
+                'snap-existing', 'sbx-001', NULL, 'legacy', NULL,
+                '{"image": null}'::jsonb, 'Creating', 'snapshot_accepted', NULL,
+                CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+    result = migrate_sqlite_snapshots_to_postgresql(
+        tmp_path / "opensandbox.db",
+        postgresql_dsn,
+    )
+
+    assert result.migrated == 0
+    assert result.skipped == 1
+    stored = _records_from_postgresql(postgresql_dsn)
+    assert len(stored) == 1
+    assert stored[0].id == "snap-existing"
+    assert stored[0].operation_attempt == 1
+
+
 def test_migrate_dry_run_writes_nothing(tmp_path, postgresql_dsn: str) -> None:
     _truncate_postgresql(postgresql_dsn)
     now = datetime(2026, 1, 2, 3, 4, 5)

--- a/server/tests/test_snapshot_migration.py
+++ b/server/tests/test_snapshot_migration.py
@@ -155,6 +155,13 @@ def test_migrate_preserves_attempt_counters_but_clears_source_lease(
         timedelta(minutes=5),
     )
     assert claim is not None
+    started = sqlite_repo.mark_operation_started(
+        "snap-leased",
+        SnapshotState.CREATING,
+        "old-server",
+        claim.operation_generation,
+    )
+    assert started is not None
     sqlite_repo.close()
 
     migrate_sqlite_snapshots_to_postgresql(
@@ -164,8 +171,8 @@ def test_migrate_preserves_attempt_counters_but_clears_source_lease(
 
     stored = _records_from_postgresql(postgresql_dsn)
     assert len(stored) == 1
-    assert stored[0].operation_generation == claim.operation_generation
-    assert stored[0].operation_attempt == claim.operation_attempt
+    assert stored[0].operation_generation == started.operation_generation
+    assert stored[0].operation_attempt == started.operation_attempt
     assert stored[0].lease_owner is None
     assert stored[0].lease_expires_at is None
 
@@ -309,7 +316,7 @@ def test_migrate_reads_old_sqlite_schema_without_modifying_it(
             "name-snap-legacy",
             "description-snap-legacy",
             json.dumps({"image": "registry.example.com/snapshots/snap-legacy:latest"}),
-            "Ready",
+            "Creating",
             "reason-snap-legacy",
             "message-snap-legacy",
             "2026-01-02T03:04:05",
@@ -338,7 +345,8 @@ def test_migrate_reads_old_sqlite_schema_without_modifying_it(
     legacy = stored[0]
     assert legacy.id == "snap-legacy"
     assert legacy.namespace is None
-    assert legacy.status.state == SnapshotState.READY
+    assert legacy.status.state == SnapshotState.CREATING
+    assert legacy.operation_attempt == 1
     assert legacy.restore_config.image == "registry.example.com/snapshots/snap-legacy:latest"
 
 

--- a/server/tests/test_snapshot_migration.py
+++ b/server/tests/test_snapshot_migration.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import json
 import os
 from pathlib import Path
@@ -131,6 +131,43 @@ def test_migrate_is_idempotent(tmp_path, postgresql_dsn: str) -> None:
     assert second.migrated == 0
     assert second.skipped == 1
     assert len(_records_from_postgresql(postgresql_dsn)) == 1
+
+
+def test_migrate_preserves_attempt_counters_but_clears_source_lease(
+    tmp_path,
+    postgresql_dsn: str,
+) -> None:
+    _truncate_postgresql(postgresql_dsn)
+    sqlite_repo = _create_sqlite_repository(
+        tmp_path,
+        [
+            snapshot_record(
+                "snap-leased",
+                "sbx-001",
+                datetime(2026, 1, 2, 3, 4, 5),
+            )
+        ],
+    )
+    claim = sqlite_repo.claim_operation(
+        "snap-leased",
+        SnapshotState.CREATING,
+        "old-server",
+        timedelta(minutes=5),
+    )
+    assert claim is not None
+    sqlite_repo.close()
+
+    migrate_sqlite_snapshots_to_postgresql(
+        tmp_path / "opensandbox.db",
+        postgresql_dsn,
+    )
+
+    stored = _records_from_postgresql(postgresql_dsn)
+    assert len(stored) == 1
+    assert stored[0].operation_generation == claim.operation_generation
+    assert stored[0].operation_attempt == claim.operation_attempt
+    assert stored[0].lease_owner is None
+    assert stored[0].lease_expires_at is None
 
 
 def test_migrate_skips_records_already_in_postgresql(tmp_path, postgresql_dsn: str) -> None:

--- a/server/tests/test_snapshot_models.py
+++ b/server/tests/test_snapshot_models.py
@@ -38,6 +38,10 @@ def test_snapshot_record_defaults_are_runtime_agnostic() -> None:
     assert record.status.message is None
     assert isinstance(record.created_at, datetime)
     assert isinstance(record.updated_at, datetime)
+    assert record.operation_generation == 0
+    assert record.operation_attempt == 0
+    assert record.lease_owner is None
+    assert record.lease_expires_at is None
 
 
 def test_snapshot_record_supports_ready_restore_config() -> None:

--- a/server/tests/test_snapshot_repository_postgresql.py
+++ b/server/tests/test_snapshot_repository_postgresql.py
@@ -12,16 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 import os
-from threading import Barrier
+from threading import Barrier, Event
+import time
 
 import psycopg
 import pytest
 from pydantic import SecretStr
 
+from opensandbox_server.api.schema import (
+    CreateSandboxRequest,
+    CreateSnapshotRequest,
+    ListSnapshotsRequest,
+    ResourceLimits,
+)
 from opensandbox_server.config import (
     AppConfig,
     PostgreSQLStoreConfig,
@@ -31,6 +38,9 @@ from opensandbox_server.config import (
 from opensandbox_server.repositories.snapshots.factory import create_snapshot_repository
 from opensandbox_server.repositories.snapshots.postgresql import PostgreSQLSnapshotRepository
 from opensandbox_server.services.snapshot_models import SnapshotState
+from opensandbox_server.services.snapshot_restore import resolve_sandbox_image_from_request
+from opensandbox_server.services.snapshot_runtime import SnapshotRuntimeStatus
+from opensandbox_server.services.snapshot_service import PersistedSnapshotService
 from tests.snapshot_repository_contract import (
     SnapshotRepositoryContract,
     snapshot_record,
@@ -55,6 +65,58 @@ def _repository(dsn: str) -> PostgreSQLSnapshotRepository:
         connect_timeout_seconds=5,
         pool_timeout_seconds=5,
     )
+
+
+class _ImmediateExecutor:
+    def submit(self, fn, *args, **kwargs) -> Future:
+        future = Future()
+        try:
+            future.set_result(fn(*args, **kwargs))
+        except Exception as exc:  # noqa: BLE001
+            future.set_exception(exc)
+        return future
+
+    def shutdown(self, wait: bool = True) -> None:
+        return None
+
+
+class _ReadyRuntime:
+    def __init__(self) -> None:
+        self.recover_called = Event()
+        self.delete_called = Event()
+
+    def supports_create_snapshot(self) -> bool:
+        return True
+
+    def create_snapshot_unsupported_message(self) -> str:
+        return ""
+
+    def create_snapshot(self, snapshot_id: str, sandbox_id: str, **kwargs):
+        return SnapshotRuntimeStatus(
+            state=SnapshotState.READY,
+            image=f"registry.example.com/snapshots/{snapshot_id}:ready",
+            reason="snapshot_runtime_ready",
+        )
+
+    def recover_snapshot(self, snapshot_id: str, sandbox_id: str, image=None, **kwargs):
+        self.recover_called.set()
+        return self.create_snapshot(snapshot_id, sandbox_id, **kwargs)
+
+    def get_snapshot_status(self, snapshot_id: str):
+        return None
+
+    def inspect_snapshot(self, snapshot_id: str, image=None, **kwargs):
+        return SnapshotRuntimeStatus(state=SnapshotState.CREATING)
+
+    def delete_snapshot(self, snapshot_id: str, image=None, **kwargs) -> None:
+        self.delete_called.set()
+        return None
+
+
+class _SandboxService:
+    @staticmethod
+    def get_sandbox(sandbox_id: str):
+        return {"id": sandbox_id, "status": {"state": "Running"}}
 
 
 class TestPostgreSQLSnapshotRepositoryContract(SnapshotRepositoryContract):
@@ -87,6 +149,136 @@ def test_postgresql_factory_selects_backend(postgresql_dsn: str) -> None:
         assert isinstance(repo, PostgreSQLSnapshotRepository)
     finally:
         repo.close()
+
+
+@pytest.mark.asyncio
+async def test_two_server_instances_share_snapshot_get_list_and_restore(
+    postgresql_dsn: str,
+    monkeypatch,
+) -> None:
+    first_repo = _repository(postgresql_dsn)
+    second_repo = _repository(postgresql_dsn)
+    first_service = PersistedSnapshotService(
+        first_repo,
+        _SandboxService(),
+        snapshot_runtime=_ReadyRuntime(),
+        snapshot_executor=_ImmediateExecutor(),
+        recover_unfinished_snapshots=False,
+        operation_owner="server-a",
+    )
+    second_service = PersistedSnapshotService(
+        second_repo,
+        _SandboxService(),
+        snapshot_runtime=_ReadyRuntime(),
+        snapshot_executor=_ImmediateExecutor(),
+        recover_unfinished_snapshots=False,
+        operation_owner="server-b",
+    )
+    try:
+        with psycopg.connect(postgresql_dsn) as conn:
+            conn.execute("TRUNCATE TABLE snapshots")
+
+        created = first_service.create_snapshot(
+            "sbx-001",
+            CreateSnapshotRequest(name="shared-snapshot"),
+        )
+
+        fetched = second_service.get_snapshot(created.id)
+        listed = second_service.list_snapshots(ListSnapshotsRequest())
+        assert fetched.status.state == SnapshotState.READY.value
+        assert [item.id for item in listed.items] == [created.id]
+
+        monkeypatch.setattr(
+            "opensandbox_server.services.snapshot_restore.get_snapshot_repository",
+            lambda: second_repo,
+        )
+        request = CreateSandboxRequest(
+            snapshotId=created.id,
+            resourceLimits=ResourceLimits(root={"cpu": "500m"}),
+        )
+        resolved = await resolve_sandbox_image_from_request(request)
+        assert resolved.image is not None
+        assert resolved.image.uri.endswith(f"/{created.id}:ready")
+    finally:
+        first_service.close()
+        second_service.close()
+        first_repo.close()
+        second_repo.close()
+
+
+@pytest.mark.parametrize("state", [SnapshotState.CREATING, SnapshotState.DELETING])
+def test_running_standby_takes_over_expired_operation_lease(
+    postgresql_dsn: str,
+    state: SnapshotState,
+) -> None:
+    first_repo = _repository(postgresql_dsn)
+    second_repo = _repository(postgresql_dsn)
+    runtime = _ReadyRuntime()
+    standby: PersistedSnapshotService | None = None
+    try:
+        with psycopg.connect(postgresql_dsn) as conn:
+            conn.execute("TRUNCATE TABLE snapshots")
+        record = snapshot_record(
+            f"snap-takeover-{state.value.lower()}",
+            "sbx-001",
+            datetime.now(timezone.utc),
+            state,
+        )
+        first_repo.create(record)
+        first_claim = first_repo.claim_operation(
+            record.id,
+            state,
+            "server-a",
+            timedelta(seconds=30),
+        )
+        assert first_claim is not None
+
+        standby = PersistedSnapshotService(
+            second_repo,
+            _SandboxService(),
+            snapshot_runtime=runtime,
+            operation_owner="server-b",
+            operation_lease_seconds=1,
+            lease_renew_interval_seconds=0.2,
+            recovery_interval_seconds=0.02,
+        )
+        with psycopg.connect(postgresql_dsn) as conn:
+            conn.execute(
+                "UPDATE snapshots SET lease_expires_at = CURRENT_TIMESTAMP - INTERVAL '1 second' "
+                "WHERE id = %s",
+                (record.id,),
+            )
+
+        expected_call = (
+            runtime.recover_called
+            if state == SnapshotState.CREATING
+            else runtime.delete_called
+        )
+        assert expected_call.wait(timeout=2)
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            stored = first_repo.get(record.id)
+            if state == SnapshotState.CREATING and stored is not None:
+                if stored.status.state == SnapshotState.READY:
+                    break
+            elif state == SnapshotState.DELETING and stored is None:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail(f"standby did not finish takeover for {state.value}")
+
+        stored = first_repo.get(record.id)
+        if state == SnapshotState.CREATING:
+            assert stored is not None
+            assert stored.status.state == SnapshotState.READY
+            assert stored.operation_generation == first_claim.operation_generation + 1
+        else:
+            assert stored is None
+    finally:
+        if standby is not None:
+            standby.close()
+        first_repo.close()
+        second_repo.close()
 
 
 def test_postgresql_schema_initialization_is_concurrent_safe(
@@ -178,6 +370,235 @@ def test_postgresql_compare_and_swap_has_one_winner(postgresql_dsn: str) -> None
             repo.close()
 
 
+def test_postgresql_operation_claim_has_one_winner(postgresql_dsn: str) -> None:
+    repositories: list[PostgreSQLSnapshotRepository] = []
+    try:
+        first_repo = _repository(postgresql_dsn)
+        repositories.append(first_repo)
+        second_repo = _repository(postgresql_dsn)
+        repositories.append(second_repo)
+        with psycopg.connect(postgresql_dsn) as conn:
+            conn.execute("TRUNCATE TABLE snapshots")
+
+        record = snapshot_record(
+            "snap-claim-race",
+            "sbx-001",
+            datetime.now(timezone.utc),
+        )
+        first_repo.create(record)
+        barrier = Barrier(2)
+
+        def claim(repo, owner: str):
+            barrier.wait(timeout=5)
+            return repo.claim_operation(
+                record.id,
+                SnapshotState.CREATING,
+                owner,
+                timedelta(seconds=30),
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first_future = executor.submit(claim, first_repo, "server-a")
+            second_future = executor.submit(claim, second_repo, "server-b")
+            claims = [first_future.result(), second_future.result()]
+
+        winners = [claim for claim in claims if claim is not None]
+        assert len(winners) == 1
+        assert winners[0].operation_generation == 1
+        assert winners[0].operation_attempt == 1
+        assert winners[0].lease_owner in {"server-a", "server-b"}
+        assert winners[0].lease_expires_at is not None
+    finally:
+        for repo in repositories:
+            repo.close()
+
+
+def test_postgresql_lease_renew_expiry_takeover_and_fencing(
+    postgresql_dsn: str,
+) -> None:
+    first_repo = _repository(postgresql_dsn)
+    second_repo = _repository(postgresql_dsn)
+    try:
+        with psycopg.connect(postgresql_dsn) as conn:
+            conn.execute("TRUNCATE TABLE snapshots")
+
+        record = snapshot_record(
+            "snap-takeover",
+            "sbx-001",
+            datetime.now(timezone.utc),
+        )
+        first_repo.create(record)
+        first_claim = first_repo.claim_operation(
+            record.id,
+            SnapshotState.CREATING,
+            "server-a",
+            timedelta(seconds=30),
+        )
+        assert first_claim is not None
+        assert first_repo.renew_operation(
+            record.id,
+            SnapshotState.CREATING,
+            "server-a",
+            first_claim.operation_generation,
+            timedelta(seconds=30),
+        ) is True
+        assert second_repo.claim_operation(
+            record.id,
+            SnapshotState.CREATING,
+            "server-b",
+            timedelta(seconds=30),
+        ) is None
+
+        with psycopg.connect(postgresql_dsn) as conn:
+            conn.execute(
+                "UPDATE snapshots SET lease_expires_at = CURRENT_TIMESTAMP - INTERVAL '1 second' "
+                "WHERE id = %s",
+                (record.id,),
+            )
+
+        second_claim = second_repo.claim_operation(
+            record.id,
+            SnapshotState.CREATING,
+            "server-b",
+            timedelta(seconds=30),
+        )
+        assert second_claim is not None
+        assert second_claim.operation_generation == first_claim.operation_generation + 1
+        assert second_claim.operation_attempt == first_claim.operation_attempt + 1
+        assert first_repo.renew_operation(
+            record.id,
+            SnapshotState.CREATING,
+            "server-a",
+            first_claim.operation_generation,
+            timedelta(seconds=30),
+        ) is False
+
+        stale_ready = snapshot_record(
+            record.id,
+            record.source_sandbox_id,
+            record.created_at,
+            SnapshotState.READY,
+        )
+        stale_ready.operation_generation = first_claim.operation_generation
+        stale_ready.operation_attempt = first_claim.operation_attempt
+        assert first_repo.update_if_operation_owner(
+            stale_ready,
+            SnapshotState.CREATING,
+            "server-a",
+            first_claim.operation_generation,
+        ) is False
+
+        ready = snapshot_record(
+            record.id,
+            record.source_sandbox_id,
+            record.created_at,
+            SnapshotState.READY,
+        )
+        ready.operation_generation = second_claim.operation_generation
+        ready.operation_attempt = second_claim.operation_attempt
+        assert second_repo.update_if_operation_owner(
+            ready,
+            SnapshotState.CREATING,
+            "server-b",
+            second_claim.operation_generation,
+        ) is True
+        stored = first_repo.get(record.id)
+        assert stored is not None
+        assert stored.status.state == SnapshotState.READY
+        assert stored.lease_owner is None
+        assert stored.lease_expires_at is None
+
+        deleting = snapshot_record(
+            record.id,
+            record.source_sandbox_id,
+            record.created_at,
+            SnapshotState.DELETING,
+        )
+        deleting.operation_generation = stored.operation_generation
+        deleting.operation_attempt = stored.operation_attempt
+        assert second_repo.update_if_state(deleting, SnapshotState.READY) is True
+        first_delete_claim = first_repo.claim_operation(
+            record.id,
+            SnapshotState.DELETING,
+            "server-a",
+            timedelta(seconds=30),
+        )
+        assert first_delete_claim is not None
+        with psycopg.connect(postgresql_dsn) as conn:
+            conn.execute(
+                "UPDATE snapshots SET lease_expires_at = CURRENT_TIMESTAMP - INTERVAL '1 second' "
+                "WHERE id = %s",
+                (record.id,),
+            )
+        second_delete_claim = second_repo.claim_operation(
+            record.id,
+            SnapshotState.DELETING,
+            "server-b",
+            timedelta(seconds=30),
+        )
+        assert second_delete_claim is not None
+        assert first_repo.delete_if_operation_owner(
+            record.id,
+            SnapshotState.DELETING,
+            "server-a",
+            first_delete_claim.operation_generation,
+        ) is False
+        assert second_repo.delete_if_operation_owner(
+            record.id,
+            SnapshotState.DELETING,
+            "server-b",
+            second_delete_claim.operation_generation,
+        ) is True
+        assert first_repo.get(record.id) is None
+    finally:
+        first_repo.close()
+        second_repo.close()
+
+
+def test_postgresql_schema_upgrade_adds_operation_lease_columns(
+    postgresql_dsn: str,
+) -> None:
+    with psycopg.connect(postgresql_dsn) as conn:
+        conn.execute("DROP TABLE IF EXISTS snapshots")
+        conn.execute(
+            """
+            CREATE TABLE snapshots (
+                id TEXT PRIMARY KEY,
+                source_sandbox_id TEXT NOT NULL,
+                namespace TEXT DEFAULT NULL,
+                name TEXT,
+                description TEXT,
+                restore_config JSONB NOT NULL,
+                state TEXT NOT NULL,
+                reason TEXT,
+                message TEXT,
+                last_transition_at TIMESTAMPTZ,
+                created_at TIMESTAMPTZ NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL
+            )
+            """
+        )
+
+    repo = _repository(postgresql_dsn)
+    repo.close()
+
+    with psycopg.connect(postgresql_dsn) as conn:
+        columns = {
+            row[0]: (row[1], row[2])
+            for row in conn.execute(
+                """
+                SELECT column_name, is_nullable, column_default
+                FROM information_schema.columns
+                WHERE table_name = 'snapshots'
+                """
+            ).fetchall()
+        }
+    assert columns["operation_generation"][0] == "NO"
+    assert columns["operation_attempt"][0] == "NO"
+    assert "lease_owner" in columns
+    assert "lease_expires_at" in columns
+
+
 def test_postgresql_close_releases_pool(postgresql_dsn: str) -> None:
     repo = _repository(postgresql_dsn)
 
@@ -204,6 +625,10 @@ def test_postgresql_row_timestamps_are_normalized_to_utc() -> None:
             "last_transition_at": local_time,
             "created_at": local_time,
             "updated_at": local_time,
+            "operation_generation": 0,
+            "lease_owner": None,
+            "lease_expires_at": None,
+            "operation_attempt": 0,
         }
     )
 

--- a/server/tests/test_snapshot_repository_postgresql.py
+++ b/server/tests/test_snapshot_repository_postgresql.py
@@ -405,7 +405,7 @@ def test_postgresql_operation_claim_has_one_winner(postgresql_dsn: str) -> None:
         winners = [claim for claim in claims if claim is not None]
         assert len(winners) == 1
         assert winners[0].operation_generation == 1
-        assert winners[0].operation_attempt == 1
+        assert winners[0].operation_attempt == 0
         assert winners[0].lease_owner in {"server-a", "server-b"}
         assert winners[0].lease_expires_at is not None
     finally:
@@ -435,6 +435,13 @@ def test_postgresql_lease_renew_expiry_takeover_and_fencing(
             timedelta(seconds=30),
         )
         assert first_claim is not None
+        first_started = first_repo.mark_operation_started(
+            record.id,
+            SnapshotState.CREATING,
+            "server-a",
+            first_claim.operation_generation,
+        )
+        assert first_started is not None
         assert first_repo.renew_operation(
             record.id,
             SnapshotState.CREATING,
@@ -464,7 +471,15 @@ def test_postgresql_lease_renew_expiry_takeover_and_fencing(
         )
         assert second_claim is not None
         assert second_claim.operation_generation == first_claim.operation_generation + 1
-        assert second_claim.operation_attempt == first_claim.operation_attempt + 1
+        assert second_claim.operation_attempt == first_started.operation_attempt
+        second_started = second_repo.mark_operation_started(
+            record.id,
+            SnapshotState.CREATING,
+            "server-b",
+            second_claim.operation_generation,
+        )
+        assert second_started is not None
+        assert second_started.operation_attempt == first_started.operation_attempt + 1
         assert first_repo.renew_operation(
             record.id,
             SnapshotState.CREATING,
@@ -480,7 +495,7 @@ def test_postgresql_lease_renew_expiry_takeover_and_fencing(
             SnapshotState.READY,
         )
         stale_ready.operation_generation = first_claim.operation_generation
-        stale_ready.operation_attempt = first_claim.operation_attempt
+        stale_ready.operation_attempt = first_started.operation_attempt
         assert first_repo.update_if_operation_owner(
             stale_ready,
             SnapshotState.CREATING,
@@ -494,13 +509,13 @@ def test_postgresql_lease_renew_expiry_takeover_and_fencing(
             record.created_at,
             SnapshotState.READY,
         )
-        ready.operation_generation = second_claim.operation_generation
-        ready.operation_attempt = second_claim.operation_attempt
+        ready.operation_generation = second_started.operation_generation
+        ready.operation_attempt = second_started.operation_attempt
         assert second_repo.update_if_operation_owner(
             ready,
             SnapshotState.CREATING,
             "server-b",
-            second_claim.operation_generation,
+            second_started.operation_generation,
         ) is True
         stored = first_repo.get(record.id)
         assert stored is not None
@@ -578,6 +593,19 @@ def test_postgresql_schema_upgrade_adds_operation_lease_columns(
             )
             """
         )
+        conn.execute(
+            """
+            INSERT INTO snapshots (
+                id, source_sandbox_id, namespace, name, description,
+                restore_config, state, reason, message, last_transition_at,
+                created_at, updated_at
+            ) VALUES (
+                'legacy-creating', 'sbx-001', NULL, 'legacy', NULL,
+                '{"image": null}'::jsonb, 'Creating', 'snapshot_accepted', NULL,
+                CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
+            """
+        )
 
     repo = _repository(postgresql_dsn)
     repo.close()
@@ -593,10 +621,15 @@ def test_postgresql_schema_upgrade_adds_operation_lease_columns(
                 """
             ).fetchall()
         }
+        legacy_attempt = conn.execute(
+            "SELECT operation_attempt FROM snapshots WHERE id = 'legacy-creating'"
+        ).fetchone()
     assert columns["operation_generation"][0] == "NO"
     assert columns["operation_attempt"][0] == "NO"
     assert "lease_owner" in columns
     assert "lease_expires_at" in columns
+    assert legacy_attempt is not None
+    assert legacy_attempt[0] == 1
 
 
 def test_postgresql_close_releases_pool(postgresql_dsn: str) -> None:

--- a/server/tests/test_snapshot_repository_sqlite.py
+++ b/server/tests/test_snapshot_repository_sqlite.py
@@ -69,6 +69,7 @@ def test_sqlite_snapshot_repository_indexes_name_queries_after_migration(
     repo = SQLiteSnapshotRepository(db_path)
 
     with repo._connect() as conn:
+        columns = {row["name"] for row in conn.execute("PRAGMA table_info(snapshots)")}
         indexes = {row["name"] for row in conn.execute("PRAGMA index_list(snapshots)")}
         name_plan = conn.execute(
             "EXPLAIN QUERY PLAN SELECT COUNT(*) FROM snapshots WHERE name = ?",
@@ -82,6 +83,12 @@ def test_sqlite_snapshot_repository_indexes_name_queries_after_migration(
             ("tenant-a", "cache-key"),
         ).fetchall()
 
+    assert {
+        "operation_generation",
+        "operation_attempt",
+        "lease_owner",
+        "lease_expires_at",
+    } <= columns
     assert "idx_snapshots_name_namespace" in indexes
     assert any("idx_snapshots_name_namespace" in row["detail"] for row in name_plan)
     assert any("idx_snapshots_name_namespace" in row["detail"] for row in tenant_plan)

--- a/server/tests/test_snapshot_repository_sqlite.py
+++ b/server/tests/test_snapshot_repository_sqlite.py
@@ -65,6 +65,27 @@ def test_sqlite_snapshot_repository_indexes_name_queries_after_migration(
             )
             """
         )
+        conn.execute(
+            """
+            INSERT INTO snapshots (
+                id, source_sandbox_id, name, description, restore_config,
+                state, reason, message, last_transition_at, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-creating",
+                "sbx-001",
+                "legacy",
+                None,
+                '{"image": null}',
+                "Creating",
+                "snapshot_accepted",
+                None,
+                "2026-01-02T03:04:05+00:00",
+                "2026-01-02T03:04:05+00:00",
+                "2026-01-02T03:04:05+00:00",
+            ),
+        )
 
     repo = SQLiteSnapshotRepository(db_path)
 
@@ -92,6 +113,9 @@ def test_sqlite_snapshot_repository_indexes_name_queries_after_migration(
     assert "idx_snapshots_name_namespace" in indexes
     assert any("idx_snapshots_name_namespace" in row["detail"] for row in name_plan)
     assert any("idx_snapshots_name_namespace" in row["detail"] for row in tenant_plan)
+    legacy = repo.get("legacy-creating")
+    assert legacy is not None
+    assert legacy.operation_attempt == 1
 
 
 def test_snapshot_repository_factory_defaults_to_sqlite(tmp_path) -> None:

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -1306,6 +1306,31 @@ def test_sqlite_startup_recovers_deleting_backlog_across_page_boundary(tmp_path)
     assert all(repo.get(record.id) is None for record in records)
 
 
+def test_sqlite_startup_recovers_creating_backlog_across_page_boundary(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    records = [
+        _snapshot_record(f"snap-create-page-{index}", SnapshotState.CREATING)
+        for index in range(205)
+    ]
+    for record in records:
+        repo.create(record)
+    runtime = ReadyCreateRuntime()
+
+    PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=ImmediateExecutor(),
+    )
+
+    assert len(runtime.recover_calls) == len(records)
+    assert all(
+        (stored := repo.get(record.id)) is not None
+        and stored.status.state == SnapshotState.READY
+        for record in records
+    )
+
+
 def test_sqlite_startup_continues_creating_backlog_after_slots_free(tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     records = [

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -1034,6 +1034,53 @@ def test_sqlite_failed_delete_schedules_recovery_after_lease_expiry(tmp_path) ->
         service.close()
 
 
+def test_sqlite_failed_delete_claim_schedules_recovery(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    record = _snapshot_record(
+        "snap-delete-claim-retry",
+        SnapshotState.READY,
+        image="opensandbox-snapshots:snap-delete-claim-retry",
+    )
+    repo.create(record)
+    runtime = StubSnapshotRuntime()
+    original_claim = repo.claim_operation
+    claim_attempts = 0
+
+    def fail_first_claim(*args, **kwargs):
+        nonlocal claim_attempts
+        claim_attempts += 1
+        if claim_attempts == 1:
+            raise RuntimeError("transient claim failure")
+        return original_claim(*args, **kwargs)
+
+    repo.claim_operation = fail_first_claim
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        recovery_interval_seconds=0.01,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="transient claim failure"):
+            service.delete_snapshot(record.id)
+
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            if repo.get(record.id) is None:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("SQLite deletion was not recovered after its initial claim failed")
+
+        assert claim_attempts == 2
+        assert runtime.delete_calls == [
+            (record.id, "opensandbox-snapshots:snap-delete-claim-retry"),
+        ]
+    finally:
+        service.close()
+
+
 def test_sqlite_rejected_metadata_delete_is_recovered(tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     record = _snapshot_record(

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -145,6 +145,19 @@ class BlockingRecoveryRuntime(StubSnapshotRuntime):
         )
 
 
+class FailOnceDeleteRuntime(StubSnapshotRuntime):
+    def delete_snapshot(
+        self,
+        snapshot_id: str,
+        image: str | None = None,
+        *,
+        namespace: str | None = None,
+    ) -> None:
+        self.delete_calls.append((snapshot_id, image))
+        if len(self.delete_calls) == 1:
+            raise RuntimeError("transient delete failure")
+
+
 class DistributedSQLiteSnapshotRepository(SQLiteSnapshotRepository):
     @property
     def supports_distributed_leases(self) -> bool:
@@ -689,6 +702,44 @@ def test_snapshot_service_recovers_delete_after_runtime_cleanup_succeeds(tmp_pat
     assert repo.get("snap-delete-crash") is None
 
 
+def test_sqlite_failed_delete_schedules_recovery_after_lease_expiry(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    record = _snapshot_record(
+        "snap-delete-retry",
+        SnapshotState.READY,
+        image="opensandbox-snapshots:snap-delete-retry",
+    )
+    repo.create(record)
+    runtime = FailOnceDeleteRuntime()
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        operation_lease_seconds=0.1,
+        lease_renew_interval_seconds=0.02,
+        recovery_interval_seconds=0.01,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="transient delete failure"):
+            service.delete_snapshot(record.id)
+
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            if repo.get(record.id) is None:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("SQLite deletion was not retried after its lease expired")
+
+        assert runtime.delete_calls == [
+            (record.id, "opensandbox-snapshots:snap-delete-retry"),
+            (record.id, "opensandbox-snapshots:snap-delete-retry"),
+        ]
+    finally:
+        service.close()
+
+
 def test_snapshot_service_stale_worker_does_not_cleanup_runtime_artifact(tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     runtime = StubSnapshotRuntime()
@@ -882,6 +933,31 @@ def test_sqlite_startup_recovers_more_than_distributed_worker_limit(tmp_path) ->
     assert sorted(call[0] for call in runtime.delete_calls) == sorted(
         record.id for record in records
     )
+    assert all(repo.get(record.id) is None for record in records)
+
+
+def test_sqlite_startup_recovers_deleting_backlog_across_page_boundary(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    records = [
+        _snapshot_record(
+            f"snap-delete-page-{index}",
+            SnapshotState.DELETING,
+            image=f"opensandbox-snapshots:snap-delete-page-{index}",
+        )
+        for index in range(205)
+    ]
+    for record in records:
+        repo.create(record)
+    runtime = StubSnapshotRuntime()
+
+    PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=ImmediateExecutor(),
+    )
+
+    assert len(runtime.delete_calls) == len(records)
     assert all(repo.get(record.id) is None for record in records)
 
 

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -1315,6 +1315,20 @@ def test_sqlite_startup_recovers_creating_backlog_across_page_boundary(tmp_path)
     for record in records:
         repo.create(record)
     runtime = ReadyCreateRuntime()
+    listed_pages: list[int] = []
+    original_list = repo.list
+    original_recover = runtime.recover_snapshot
+
+    def record_page(query: SnapshotListQuery):
+        listed_pages.append(query.page)
+        return original_list(query)
+
+    def assert_all_pages_collected(*args, **kwargs):
+        assert listed_pages == [1, 2]
+        return original_recover(*args, **kwargs)
+
+    repo.list = record_page
+    runtime.recover_snapshot = assert_all_pages_collected
 
     PersistedSnapshotService(
         repo,

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -158,6 +158,53 @@ class BlockingRecoveryRuntime(StubSnapshotRuntime):
         )
 
 
+class BlockingDockerLikeCreateRuntime(StubSnapshotRuntime):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = Event()
+        self.release = Event()
+        self.image_ready = False
+        self.recover_calls: list[str] = []
+
+    def create_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        self.calls.append((snapshot_id, sandbox_id))
+        self.started.set()
+        if not self.release.wait(timeout=2):
+            raise TimeoutError("test did not release Docker-like snapshot creation")
+        self.image_ready = True
+        return SnapshotRuntimeStatus(
+            state=SnapshotState.READY,
+            image=f"opensandbox-snapshots:{snapshot_id}",
+            reason="snapshot_runtime_ready",
+        )
+
+    def recover_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        image: str | None = None,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        self.recover_calls.append(snapshot_id)
+        if not self.image_ready:
+            return SnapshotRuntimeStatus(
+                state=SnapshotState.FAILED,
+                reason="snapshot_recovery_missing_image",
+            )
+        return SnapshotRuntimeStatus(
+            state=SnapshotState.READY,
+            image=f"opensandbox-snapshots:{snapshot_id}",
+            reason="snapshot_recovery_ready",
+        )
+
+
 class FailOnceDeleteRuntime(StubSnapshotRuntime):
     def delete_snapshot(
         self,
@@ -683,6 +730,74 @@ def test_queued_never_started_snapshot_uses_create_during_recovery(tmp_path) -> 
     finally:
         if second_heartbeat is not None:
             service._stop_lease_heartbeat(second_heartbeat)
+        service.close()
+
+
+def test_sqlite_recovery_does_not_reclaim_live_local_create(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    runtime = BlockingDockerLikeCreateRuntime()
+    recovery_saw_expired_record = Event()
+    claim_calls = 0
+    original_list_recoverable = repo.list_recoverable_operations
+    original_claim = repo.claim_operation
+
+    def observe_recovery_candidates(states: list[SnapshotState], limit: int):
+        records = original_list_recoverable(states, limit)
+        if states == [SnapshotState.CREATING] and records:
+            recovery_saw_expired_record.set()
+        return records
+
+    def count_claims(*args, **kwargs):
+        nonlocal claim_calls
+        claim_calls += 1
+        return original_claim(*args, **kwargs)
+
+    repo.list_recoverable_operations = observe_recovery_candidates
+    repo.claim_operation = count_claims
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        operation_lease_seconds=0.2,
+        lease_renew_interval_seconds=0.05,
+        recovery_interval_seconds=0.01,
+    )
+
+    try:
+        created = service.create_snapshot(
+            "sbx-001",
+            CreateSnapshotRequest(name="slow-docker-commit"),
+        )
+        assert runtime.started.wait(timeout=2)
+        with repo._connect() as conn:
+            conn.execute(
+                "UPDATE snapshots SET lease_expires_at = ? WHERE id = ?",
+                ("1970-01-01T00:00:00+00:00", created.id),
+            )
+
+        assert recovery_saw_expired_record.wait(timeout=2)
+        active = repo.get(created.id)
+        assert active is not None
+        assert active.status.state == SnapshotState.CREATING
+        assert active.operation_generation == 1
+        assert claim_calls == 1
+        assert runtime.recover_calls == []
+
+        runtime.release.set()
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            stored = repo.get(created.id)
+            if stored is not None and stored.status.state == SnapshotState.READY:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("SQLite did not recover the completed local snapshot")
+
+        assert runtime.calls == [(created.id, "sbx-001")]
+        assert runtime.recover_calls == [created.id]
+        assert claim_calls == 2
+    finally:
+        runtime.release.set()
         service.close()
 
 

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -1301,6 +1301,50 @@ def test_snapshot_service_recovers_deleting_snapshot(tmp_path) -> None:
     assert repo.get("snap-delete") is None
 
 
+def test_sqlite_startup_retries_failed_delete_claim(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    record = _snapshot_record(
+        "snap-delete-startup-claim-retry",
+        SnapshotState.DELETING,
+        image="opensandbox-snapshots:snap-delete-startup-claim-retry",
+    )
+    repo.create(record)
+    runtime = StubSnapshotRuntime()
+    original_claim = repo.claim_operation
+    claim_attempts = 0
+
+    def fail_first_claim(*args, **kwargs):
+        nonlocal claim_attempts
+        claim_attempts += 1
+        if claim_attempts == 1:
+            raise RuntimeError("transient startup claim failure")
+        return original_claim(*args, **kwargs)
+
+    repo.claim_operation = fail_first_claim
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        recovery_interval_seconds=0.01,
+    )
+
+    try:
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            if repo.get(record.id) is None:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("SQLite startup deletion was not retried after its claim failed")
+
+        assert claim_attempts == 2
+        assert runtime.delete_calls == [
+            (record.id, "opensandbox-snapshots:snap-delete-startup-claim-retry"),
+        ]
+    finally:
+        service.close()
+
+
 def test_sqlite_startup_recovers_more_than_distributed_worker_limit(tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     records = [

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -30,6 +30,7 @@ from opensandbox_server.services.snapshot_models import (
     SnapshotStatusRecord,
 )
 from opensandbox_server.services.snapshot_runtime import NoopSnapshotRuntime, SnapshotRuntimeStatus
+from opensandbox_server.services.snapshot_repository import SnapshotListQuery
 from opensandbox_server.services.snapshot_service import PersistedSnapshotService
 
 
@@ -63,6 +64,18 @@ class ImmediateExecutor:
 
     def shutdown(self, wait: bool = True) -> None:
         self.shutdown_called = True
+
+
+class FailOnceSubmitExecutor(ImmediateExecutor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.submit_attempts = 0
+
+    def submit(self, fn, *args, **kwargs) -> Future:
+        self.submit_attempts += 1
+        if self.submit_attempts == 1:
+            raise RuntimeError("simulated executor submission failure")
+        return super().submit(fn, *args, **kwargs)
 
 
 class CapturingExecutor:
@@ -520,6 +533,90 @@ def test_sqlite_terminal_update_exception_is_recovered(tmp_path) -> None:
 
         assert update_attempts == 2
         assert runtime.recover_calls == [created.id]
+    finally:
+        service.close()
+
+
+def test_sqlite_claim_exception_after_create_is_recovered(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    runtime = ReadyCreateRuntime()
+    original_claim = repo.claim_operation
+    claim_attempts = 0
+
+    def fail_first_claim(*args, **kwargs):
+        nonlocal claim_attempts
+        claim_attempts += 1
+        if claim_attempts == 1:
+            raise RuntimeError("simulated SQLite claim contention")
+        return original_claim(*args, **kwargs)
+
+    repo.claim_operation = fail_first_claim
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=ImmediateExecutor(),
+        recovery_interval_seconds=0.01,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="simulated SQLite claim contention"):
+            service.create_snapshot(
+                "sbx-001",
+                CreateSnapshotRequest(name="claim-exception"),
+            )
+
+        deadline = time.monotonic() + 2
+        recovered = None
+        while time.monotonic() < deadline:
+            records = repo.list(SnapshotListQuery(page=1, page_size=10)).items
+            if records and records[0].status.state == SnapshotState.READY:
+                recovered = records[0]
+                break
+            time.sleep(0.01)
+        if recovered is None:
+            pytest.fail("SQLite claim exception left an orphaned Creating row")
+
+        assert claim_attempts == 2
+        assert runtime.recover_calls == [recovered.id]
+    finally:
+        service.close()
+
+
+def test_sqlite_submit_exception_after_claim_is_recovered(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    runtime = ReadyCreateRuntime()
+    executor = FailOnceSubmitExecutor()
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=executor,
+        operation_lease_seconds=0.1,
+        lease_renew_interval_seconds=0.02,
+        recovery_interval_seconds=0.01,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="simulated executor submission failure"):
+            service.create_snapshot(
+                "sbx-001",
+                CreateSnapshotRequest(name="submit-exception"),
+            )
+
+        deadline = time.monotonic() + 2
+        recovered = None
+        while time.monotonic() < deadline:
+            records = repo.list(SnapshotListQuery(page=1, page_size=10)).items
+            if records and records[0].status.state == SnapshotState.READY:
+                recovered = records[0]
+                break
+            time.sleep(0.01)
+        if recovered is None:
+            pytest.fail("SQLite submit exception left an orphaned Creating row")
+
+        assert executor.submit_attempts == 2
+        assert runtime.recover_calls == [recovered.id]
     finally:
         service.close()
 

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -477,6 +477,53 @@ def test_sqlite_rejected_terminal_update_is_recovered(tmp_path) -> None:
         service.close()
 
 
+def test_sqlite_terminal_update_exception_is_recovered(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    runtime = ReadyCreateRuntime()
+    original_update = repo.update_if_operation_owner
+    update_attempts = 0
+
+    def fail_first_terminal_update(*args, **kwargs) -> bool:
+        nonlocal update_attempts
+        update_attempts += 1
+        if update_attempts == 1:
+            with repo._connect() as conn:
+                conn.execute(
+                    "UPDATE snapshots SET lease_expires_at = ? WHERE id = ?",
+                    ("1970-01-01T00:00:00+00:00", args[0].id),
+                )
+            raise RuntimeError("simulated SQLite writer contention")
+        return original_update(*args, **kwargs)
+
+    repo.update_if_operation_owner = fail_first_terminal_update
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=ImmediateExecutor(),
+        recovery_interval_seconds=0.01,
+    )
+
+    try:
+        created = service.create_snapshot(
+            "sbx-001",
+            CreateSnapshotRequest(name="terminal-write-exception"),
+        )
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            stored = repo.get(created.id)
+            if stored is not None and stored.status.state == SnapshotState.READY:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("SQLite terminal update exception was not recovered")
+
+        assert update_attempts == 2
+        assert runtime.recover_calls == [created.id]
+    finally:
+        service.close()
+
+
 def test_recover_unfinished_snapshot_claims_and_reschedules_creating_runtime_status(tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     record = _snapshot_record("snap-in-progress", SnapshotState.CREATING)

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from concurrent.futures import Future
+from datetime import timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -273,7 +274,7 @@ def test_snapshot_service_marks_snapshot_failed_when_worker_returns_none(tmp_pat
     assert stored.status.reason == "snapshot_runtime_missing_result"
 
 
-def test_recover_unfinished_snapshot_reschedules_creating_runtime_status_without_progress(tmp_path) -> None:
+def test_recover_unfinished_snapshot_claims_and_reschedules_creating_runtime_status(tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     record = _snapshot_record("snap-in-progress", SnapshotState.CREATING)
     repo.create(record)
@@ -295,10 +296,111 @@ def test_recover_unfinished_snapshot_reschedules_creating_runtime_status_without
     progressed = service._recover_unfinished_snapshot(record)
 
     stored = repo.get(record.id)
-    assert progressed is False
+    assert progressed is True
     assert stored is not None
     assert stored.status.state == SnapshotState.CREATING
+    assert stored.lease_owner is not None
+    assert stored.operation_generation == 1
     assert len(executor.submitted) == 1
+
+    heartbeat = executor.submitted[0][1][2]
+    service._stop_lease_heartbeat(heartbeat)
+
+
+def test_two_services_share_one_unfinished_operation_owner(tmp_path) -> None:
+    db_path = tmp_path / "snapshots.db"
+    first_repo = SQLiteSnapshotRepository(db_path)
+    second_repo = SQLiteSnapshotRepository(db_path)
+    record = _snapshot_record("snap-shared", SnapshotState.CREATING)
+    first_repo.create(record)
+    first_executor = CapturingExecutor()
+    second_executor = CapturingExecutor()
+    first_service = PersistedSnapshotService(
+        first_repo,
+        StubSandboxService(),
+        snapshot_runtime=StubSnapshotRuntime(),
+        snapshot_executor=first_executor,
+        recover_unfinished_snapshots=False,
+        operation_owner="server-a",
+    )
+    second_service = PersistedSnapshotService(
+        second_repo,
+        StubSandboxService(),
+        snapshot_runtime=StubSnapshotRuntime(),
+        snapshot_executor=second_executor,
+        recover_unfinished_snapshots=False,
+        operation_owner="server-b",
+    )
+
+    assert first_service._recover_unfinished_snapshot(record) is True
+    current = second_repo.get(record.id)
+    assert current is not None
+    assert second_service._recover_unfinished_snapshot(current) is False
+    assert len(first_executor.submitted) == 1
+    assert second_executor.submitted == []
+
+    stored = first_repo.get(record.id)
+    assert stored is not None
+    assert stored.lease_owner == "server-a"
+    assert stored.operation_generation == 1
+    heartbeat = first_executor.submitted[0][1][2]
+    first_service._stop_lease_heartbeat(heartbeat)
+
+
+def test_stale_service_completion_is_rejected_after_takeover(tmp_path) -> None:
+    db_path = tmp_path / "snapshots.db"
+    first_repo = SQLiteSnapshotRepository(db_path)
+    second_repo = SQLiteSnapshotRepository(db_path)
+    record = _snapshot_record("snap-stale", SnapshotState.CREATING)
+    first_repo.create(record)
+    first_claim = first_repo.claim_operation(
+        record.id,
+        SnapshotState.CREATING,
+        "server-a",
+        timedelta(seconds=30),
+    )
+    assert first_claim is not None
+    with first_repo._connect() as conn:
+        conn.execute(
+            "UPDATE snapshots SET lease_expires_at = ? WHERE id = ?",
+            ("1970-01-01T00:00:00+00:00", record.id),
+        )
+    second_claim = second_repo.claim_operation(
+        record.id,
+        SnapshotState.CREATING,
+        "server-b",
+        timedelta(seconds=30),
+    )
+    assert second_claim is not None
+    first_service = PersistedSnapshotService(
+        first_repo,
+        StubSandboxService(),
+        recover_unfinished_snapshots=False,
+        operation_owner="server-a",
+    )
+    second_service = PersistedSnapshotService(
+        second_repo,
+        StubSandboxService(),
+        recover_unfinished_snapshots=False,
+        operation_owner="server-b",
+    )
+    ready_status = SnapshotRuntimeStatus(
+        state=SnapshotState.READY,
+        image="registry/sandbox:snap-stale",
+        reason="snapshot_runtime_ready",
+    )
+
+    first_service._complete_snapshot(first_claim, ready_status)
+    after_stale = second_repo.get(record.id)
+    assert after_stale is not None
+    assert after_stale.status.state == SnapshotState.CREATING
+    assert after_stale.lease_owner == "server-b"
+
+    second_service._complete_snapshot(second_claim, ready_status)
+    completed = first_repo.get(record.id)
+    assert completed is not None
+    assert completed.status.state == SnapshotState.READY
+    assert completed.restore_config.image == "registry/sandbox:snap-stale"
 
 
 def test_snapshot_service_lists_and_deletes_records(tmp_path) -> None:
@@ -456,12 +558,12 @@ def test_snapshot_service_recovers_delete_after_runtime_cleanup_succeeds(tmp_pat
     )
     repo.create(record)
 
-    original_delete = repo.delete
+    original_delete_if_owner = repo.delete_if_operation_owner
 
-    def crash_delete(snapshot_id: str) -> None:
+    def crash_delete(*args, **kwargs) -> bool:
         raise RuntimeError("simulated metadata delete crash")
 
-    repo.delete = crash_delete
+    repo.delete_if_operation_owner = crash_delete
     with pytest.raises(RuntimeError, match="simulated metadata delete crash"):
         service.delete_snapshot("snap-delete-crash")
 
@@ -470,7 +572,20 @@ def test_snapshot_service_recovers_delete_after_runtime_cleanup_succeeds(tmp_pat
     assert stored.status.state == SnapshotState.DELETING
     assert runtime.delete_calls == [("snap-delete-crash", "opensandbox-snapshots:snap-delete-crash")]
 
-    repo.delete = original_delete
+    repo.delete_if_operation_owner = original_delete_if_owner
+    before_expiry_runtime = StubSnapshotRuntime()
+    PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=before_expiry_runtime,
+    )
+    assert before_expiry_runtime.delete_calls == []
+
+    with repo._connect() as conn:
+        conn.execute(
+            "UPDATE snapshots SET lease_expires_at = ? WHERE id = ?",
+            ("1970-01-01T00:00:00+00:00", "snap-delete-crash"),
+        )
     recovery_runtime = StubSnapshotRuntime()
     PersistedSnapshotService(repo, StubSandboxService(), snapshot_runtime=recovery_runtime)
 
@@ -478,7 +593,7 @@ def test_snapshot_service_recovers_delete_after_runtime_cleanup_succeeds(tmp_pat
     assert repo.get("snap-delete-crash") is None
 
 
-def test_snapshot_service_worker_cleans_up_snapshot_deleted_during_creation(tmp_path) -> None:
+def test_snapshot_service_stale_worker_does_not_cleanup_runtime_artifact(tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     runtime = StubSnapshotRuntime()
     service = PersistedSnapshotService(
@@ -505,7 +620,7 @@ def test_snapshot_service_worker_cleans_up_snapshot_deleted_during_creation(tmp_
 
     service._create_snapshot_worker(_snapshot_record(created.id, SnapshotState.CREATING))
 
-    assert runtime.delete_calls == [(created.id, "opensandbox-snapshots:snap-ready")]
+    assert runtime.delete_calls == []
     assert repo.get(created.id) is None
 
 
@@ -599,7 +714,12 @@ def test_snapshot_service_recovers_creating_snapshot_with_existing_artifact(tmp_
         message="Recovered snapshot image after server restart.",
     )
 
-    PersistedSnapshotService(repo, StubSandboxService(), snapshot_runtime=runtime)
+    PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=ImmediateExecutor(),
+    )
 
     recovered = repo.get("snap-ready")
     assert recovered is not None
@@ -612,7 +732,12 @@ def test_snapshot_service_recovers_creating_snapshot_without_artifact(tmp_path) 
     repo.create(_snapshot_record("snap-missing", SnapshotState.CREATING))
     runtime = StubSnapshotRuntime()
 
-    PersistedSnapshotService(repo, StubSandboxService(), snapshot_runtime=runtime)
+    PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=ImmediateExecutor(),
+    )
 
     recovered = repo.get("snap-missing")
     assert recovered is not None

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -883,3 +883,38 @@ def test_sqlite_startup_recovers_more_than_distributed_worker_limit(tmp_path) ->
         record.id for record in records
     )
     assert all(repo.get(record.id) is None for record in records)
+
+
+def test_sqlite_startup_continues_creating_backlog_after_slots_free(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    records = [
+        _snapshot_record(f"snap-create-{index}", SnapshotState.CREATING)
+        for index in range(3)
+    ]
+    for record in records:
+        repo.create(record)
+    runtime = BlockingRecoveryRuntime()
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        recovery_interval_seconds=0.02,
+    )
+
+    try:
+        assert runtime.two_started.wait(timeout=2)
+        assert runtime.three_started.is_set() is False
+        runtime.release.set()
+        assert runtime.three_started.wait(timeout=2)
+
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            stored = [repo.get(record.id) for record in records]
+            if all(item is not None and item.status.state == SnapshotState.READY for item in stored):
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("SQLite startup recovery did not drain the Creating backlog")
+    finally:
+        runtime.release.set()
+        service.close()

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -158,6 +158,41 @@ class FailOnceDeleteRuntime(StubSnapshotRuntime):
             raise RuntimeError("transient delete failure")
 
 
+class CreatingOnceRuntime(StubSnapshotRuntime):
+    def __init__(self) -> None:
+        super().__init__()
+        self.recover_calls: list[str] = []
+
+    def create_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        self.calls.append((snapshot_id, sandbox_id))
+        return SnapshotRuntimeStatus(
+            state=SnapshotState.CREATING,
+            reason="snapshot_runtime_inspect_failed",
+            message="Kubernetes API observation timed out.",
+        )
+
+    def recover_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        image: str | None = None,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        self.recover_calls.append(snapshot_id)
+        return SnapshotRuntimeStatus(
+            state=SnapshotState.READY,
+            image=f"registry/snapshots:{snapshot_id}",
+            reason="snapshot_runtime_ready",
+        )
+
+
 class DistributedSQLiteSnapshotRepository(SQLiteSnapshotRepository):
     @property
     def supports_distributed_leases(self) -> bool:
@@ -325,6 +360,39 @@ def test_snapshot_service_marks_snapshot_failed_when_worker_returns_none(tmp_pat
     assert stored is not None
     assert stored.status.state == SnapshotState.FAILED
     assert stored.status.reason == "snapshot_runtime_missing_result"
+
+
+def test_sqlite_nonterminal_create_is_recovered_after_lease_expiry(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    runtime = CreatingOnceRuntime()
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=ImmediateExecutor(),
+        operation_lease_seconds=0.1,
+        lease_renew_interval_seconds=0.02,
+        recovery_interval_seconds=0.01,
+    )
+
+    try:
+        created = service.create_snapshot(
+            "sbx-001",
+            CreateSnapshotRequest(name="eventually-observed"),
+        )
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            stored = repo.get(created.id)
+            if stored is not None and stored.status.state == SnapshotState.READY:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("SQLite nonterminal creation was not recovered after lease expiry")
+
+        assert runtime.calls == [(created.id, "sbx-001")]
+        assert runtime.recover_calls == [created.id]
+    finally:
+        service.close()
 
 
 def test_recover_unfinished_snapshot_claims_and_reschedules_creating_runtime_status(tmp_path) -> None:

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -241,6 +241,23 @@ class ReadyCreateRuntime(StubSnapshotRuntime):
         )
 
 
+class MissingOnRecoveryRuntime(ReadyCreateRuntime):
+    def recover_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        image: str | None = None,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        self.recover_calls.append(snapshot_id)
+        return SnapshotRuntimeStatus(
+            state=SnapshotState.FAILED,
+            reason="snapshot_recovery_missing_image",
+            message="Snapshot creation never started and no image exists.",
+        )
+
+
 class DistributedSQLiteSnapshotRepository(SQLiteSnapshotRepository):
     @property
     def supports_distributed_leases(self) -> bool:
@@ -578,7 +595,8 @@ def test_sqlite_claim_exception_after_create_is_recovered(tmp_path) -> None:
             pytest.fail("SQLite claim exception left an orphaned Creating row")
 
         assert claim_attempts == 2
-        assert runtime.recover_calls == [recovered.id]
+        assert runtime.calls == [(recovered.id, "sbx-001")]
+        assert runtime.recover_calls == []
     finally:
         service.close()
 
@@ -616,14 +634,62 @@ def test_sqlite_submit_exception_after_claim_is_recovered(tmp_path) -> None:
             pytest.fail("SQLite submit exception left an orphaned Creating row")
 
         assert executor.submit_attempts == 2
-        assert runtime.recover_calls == [recovered.id]
+        assert runtime.calls == [(recovered.id, "sbx-001")]
+        assert runtime.recover_calls == []
     finally:
+        service.close()
+
+
+def test_queued_never_started_snapshot_uses_create_during_recovery(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    runtime = MissingOnRecoveryRuntime()
+    executor = CapturingExecutor()
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=executor,
+        recovery_interval_seconds=60,
+    )
+    second_heartbeat = None
+
+    try:
+        first = service.create_snapshot("sbx-001", CreateSnapshotRequest(name="first"))
+        second = service.create_snapshot("sbx-001", CreateSnapshotRequest(name="second"))
+        queued = service.create_snapshot("sbx-001", CreateSnapshotRequest(name="queued"))
+
+        assert len(executor.submitted) == 2
+        queued_record = repo.get(queued.id)
+        assert queued_record is not None
+        assert queued_record.operation_attempt == 0
+        assert queued_record.lease_owner is None
+
+        first_work = next(item for item in executor.submitted if item[1][0].id == first.id)
+        first_work[0](*first_work[1], **first_work[2])
+        service.recover_unfinished_snapshots()
+
+        assert len(executor.submitted) == 3
+        queued_work = next(item for item in executor.submitted if item[1][0].id == queued.id)
+        queued_work[0](*queued_work[1], **queued_work[2])
+
+        stored = repo.get(queued.id)
+        assert stored is not None
+        assert stored.status.state == SnapshotState.READY
+        assert (queued.id, "sbx-001") in runtime.calls
+        assert queued.id not in runtime.recover_calls
+
+        second_work = next(item for item in executor.submitted if item[1][0].id == second.id)
+        second_heartbeat = second_work[1][2]
+    finally:
+        if second_heartbeat is not None:
+            service._stop_lease_heartbeat(second_heartbeat)
         service.close()
 
 
 def test_recover_unfinished_snapshot_claims_and_reschedules_creating_runtime_status(tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
     record = _snapshot_record("snap-in-progress", SnapshotState.CREATING)
+    record.operation_attempt = 1
     repo.create(record)
     runtime = StubSnapshotRuntime()
     runtime.inspect_status_by_snapshot_id[record.id] = SnapshotRuntimeStatus(
@@ -659,6 +725,7 @@ def test_two_services_share_one_unfinished_operation_owner(tmp_path) -> None:
     first_repo = SQLiteSnapshotRepository(db_path)
     second_repo = SQLiteSnapshotRepository(db_path)
     record = _snapshot_record("snap-shared", SnapshotState.CREATING)
+    record.operation_attempt = 1
     first_repo.create(record)
     first_executor = CapturingExecutor()
     second_executor = CapturingExecutor()
@@ -701,6 +768,7 @@ def test_recovery_claims_only_available_worker_slots(tmp_path) -> None:
         for index in range(3)
     ]
     for record in records:
+        record.operation_attempt = 1
         repo.create(record)
     runtime = BlockingRecoveryRuntime()
     recovery_queries: list[tuple[list[SnapshotState], int]] = []
@@ -1261,7 +1329,9 @@ def test_snapshot_service_returns_501_when_runtime_is_not_supported(tmp_path) ->
 
 def test_snapshot_service_recovers_creating_snapshot_with_existing_artifact(tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
-    repo.create(_snapshot_record("snap-ready", SnapshotState.CREATING))
+    record = _snapshot_record("snap-ready", SnapshotState.CREATING)
+    record.operation_attempt = 1
+    repo.create(record)
     runtime = StubSnapshotRuntime()
     runtime.inspect_status_by_snapshot_id["snap-ready"] = SnapshotRuntimeStatus(
         state=SnapshotState.READY,
@@ -1285,7 +1355,9 @@ def test_snapshot_service_recovers_creating_snapshot_with_existing_artifact(tmp_
 
 def test_snapshot_service_recovers_creating_snapshot_without_artifact(tmp_path) -> None:
     repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
-    repo.create(_snapshot_record("snap-missing", SnapshotState.CREATING))
+    record = _snapshot_record("snap-missing", SnapshotState.CREATING)
+    record.operation_attempt = 1
+    repo.create(record)
     runtime = StubSnapshotRuntime()
 
     PersistedSnapshotService(
@@ -1421,6 +1493,7 @@ def test_sqlite_startup_recovers_creating_backlog_across_page_boundary(tmp_path)
         for index in range(205)
     ]
     for record in records:
+        record.operation_attempt = 1
         repo.create(record)
     runtime = ReadyCreateRuntime()
     recovery_queries: list[tuple[list[SnapshotState], int]] = []
@@ -1461,6 +1534,7 @@ def test_sqlite_startup_continues_creating_backlog_after_slots_free(tmp_path) ->
         for index in range(3)
     ]
     for record in records:
+        record.operation_attempt = 1
         repo.create(record)
     runtime = BlockingRecoveryRuntime()
     service = PersistedSnapshotService(
@@ -1513,6 +1587,14 @@ def test_sqlite_startup_retries_after_previous_owner_lease_expires(
         timedelta(seconds=0.1),
     )
     assert old_claim is not None
+    if state == SnapshotState.CREATING:
+        old_claim = first_repo.mark_operation_started(
+            record.id,
+            state,
+            "stopped-server",
+            old_claim.operation_generation,
+        )
+        assert old_claim is not None
     first_repo.close()
 
     second_repo = SQLiteSnapshotRepository(db_path)

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -14,6 +14,8 @@
 
 from concurrent.futures import Future
 from datetime import timedelta
+from threading import Event, Lock
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -109,6 +111,44 @@ class StubSnapshotRuntime:
                 message="Snapshot creation was interrupted and no snapshot image was found.",
             ),
         )
+
+
+class BlockingRecoveryRuntime(StubSnapshotRuntime):
+    def __init__(self) -> None:
+        super().__init__()
+        self.release = Event()
+        self.two_started = Event()
+        self.three_started = Event()
+        self._started_ids: list[str] = []
+        self._started_lock = Lock()
+
+    def recover_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        image: str | None = None,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        with self._started_lock:
+            self._started_ids.append(snapshot_id)
+            if len(self._started_ids) >= 2:
+                self.two_started.set()
+            if len(self._started_ids) >= 3:
+                self.three_started.set()
+        if not self.release.wait(timeout=2):
+            raise TimeoutError("test did not release snapshot recovery")
+        return SnapshotRuntimeStatus(
+            state=SnapshotState.READY,
+            image=f"registry/snapshots:{snapshot_id}",
+            reason="snapshot_runtime_ready",
+        )
+
+
+class DistributedSQLiteSnapshotRepository(SQLiteSnapshotRepository):
+    @property
+    def supports_distributed_leases(self) -> bool:
+        return True
 
 
 def _snapshot_record(
@@ -345,6 +385,62 @@ def test_two_services_share_one_unfinished_operation_owner(tmp_path) -> None:
     assert stored.operation_generation == 1
     heartbeat = first_executor.submitted[0][1][2]
     first_service._stop_lease_heartbeat(heartbeat)
+
+
+def test_recovery_claims_only_available_worker_slots(tmp_path) -> None:
+    repo = DistributedSQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    records = [
+        _snapshot_record(f"snap-queued-{index}", SnapshotState.CREATING)
+        for index in range(3)
+    ]
+    for record in records:
+        repo.create(record)
+    runtime = BlockingRecoveryRuntime()
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        recover_unfinished_snapshots=False,
+        recovery_interval_seconds=60,
+    )
+
+    try:
+        service.recover_unfinished_snapshots()
+        assert runtime.two_started.wait(timeout=2)
+        stored = [repo.get(record.id) for record in records]
+        assert sum(item is not None and item.lease_owner is not None for item in stored) == 2
+        assert sum(item is not None and item.lease_owner is None for item in stored) == 1
+
+        service.recover_unfinished_snapshots()
+        stored = [repo.get(record.id) for record in records]
+        assert sum(item is not None and item.lease_owner is not None for item in stored) == 2
+        assert runtime.three_started.is_set() is False
+
+        runtime.release.set()
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            if sum(
+                item is not None and item.status.state == SnapshotState.READY
+                for item in (repo.get(record.id) for record in records)
+            ) >= 2:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("initial recovery workers did not complete")
+
+        service.recover_unfinished_snapshots()
+        assert runtime.three_started.wait(timeout=2)
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            final = [repo.get(record.id) for record in records]
+            if all(item is not None and item.status.state == SnapshotState.READY for item in final):
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("queued recovery did not complete after a worker slot became free")
+    finally:
+        runtime.release.set()
+        service.close()
 
 
 def test_stale_service_completion_is_rejected_after_takeover(tmp_path) -> None:

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -760,3 +760,30 @@ def test_snapshot_service_recovers_deleting_snapshot(tmp_path) -> None:
 
     assert runtime.delete_calls == [("snap-delete", "opensandbox-snapshots:snap-delete")]
     assert repo.get("snap-delete") is None
+
+
+def test_sqlite_startup_recovers_more_than_distributed_worker_limit(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    records = [
+        _snapshot_record(
+            f"snap-delete-{index}",
+            SnapshotState.DELETING,
+            image=f"opensandbox-snapshots:snap-delete-{index}",
+        )
+        for index in range(3)
+    ]
+    for record in records:
+        repo.create(record)
+    runtime = StubSnapshotRuntime()
+
+    PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=ImmediateExecutor(),
+    )
+
+    assert sorted(call[0] for call in runtime.delete_calls) == sorted(
+        record.id for record in records
+    )
+    assert all(repo.get(record.id) is None for record in records)

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -1339,3 +1339,64 @@ def test_sqlite_startup_continues_creating_backlog_after_slots_free(tmp_path) ->
     finally:
         runtime.release.set()
         service.close()
+
+
+@pytest.mark.parametrize("state", [SnapshotState.CREATING, SnapshotState.DELETING])
+def test_sqlite_startup_retries_after_previous_owner_lease_expires(
+    tmp_path,
+    state: SnapshotState,
+) -> None:
+    db_path = tmp_path / "snapshots.db"
+    first_repo = SQLiteSnapshotRepository(db_path)
+    record = _snapshot_record(
+        f"snap-stale-startup-{state.value.lower()}",
+        state,
+        image=(
+            f"opensandbox-snapshots:snap-stale-startup-{state.value.lower()}"
+            if state == SnapshotState.DELETING
+            else None
+        ),
+    )
+    first_repo.create(record)
+    old_claim = first_repo.claim_operation(
+        record.id,
+        state,
+        "stopped-server",
+        timedelta(seconds=0.1),
+    )
+    assert old_claim is not None
+    first_repo.close()
+
+    second_repo = SQLiteSnapshotRepository(db_path)
+    runtime = ReadyCreateRuntime() if state == SnapshotState.CREATING else StubSnapshotRuntime()
+    service = PersistedSnapshotService(
+        second_repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=ImmediateExecutor(),
+        operation_owner="replacement-server",
+        operation_lease_seconds=0.2,
+        lease_renew_interval_seconds=0.05,
+        recovery_interval_seconds=0.01,
+    )
+
+    try:
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            stored = second_repo.get(record.id)
+            if state == SnapshotState.CREATING:
+                if stored is not None and stored.status.state == SnapshotState.READY:
+                    break
+            elif stored is None:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail(f"SQLite did not take over stale {state.value} startup lease")
+
+        if state == SnapshotState.CREATING:
+            assert isinstance(runtime, ReadyCreateRuntime)
+            assert runtime.recover_calls == [record.id]
+        else:
+            assert runtime.delete_calls == [(record.id, record.restore_config.image)]
+    finally:
+        service.close()

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -703,6 +703,14 @@ def test_recovery_claims_only_available_worker_slots(tmp_path) -> None:
     for record in records:
         repo.create(record)
     runtime = BlockingRecoveryRuntime()
+    recovery_queries: list[tuple[list[SnapshotState], int]] = []
+    original_list_recoverable = repo.list_recoverable_operations
+
+    def record_recovery_query(states: list[SnapshotState], limit: int):
+        recovery_queries.append((states, limit))
+        return original_list_recoverable(states, limit)
+
+    repo.list_recoverable_operations = record_recovery_query
     service = PersistedSnapshotService(
         repo,
         StubSandboxService(),
@@ -717,11 +725,20 @@ def test_recovery_claims_only_available_worker_slots(tmp_path) -> None:
         stored = [repo.get(record.id) for record in records]
         assert sum(item is not None and item.lease_owner is not None for item in stored) == 2
         assert sum(item is not None and item.lease_owner is None for item in stored) == 1
+        creating_query_count = sum(
+            states == [SnapshotState.CREATING]
+            for states, _limit in recovery_queries
+        )
+        assert creating_query_count == 1
 
         service.recover_unfinished_snapshots()
         stored = [repo.get(record.id) for record in records]
         assert sum(item is not None and item.lease_owner is not None for item in stored) == 2
         assert runtime.three_started.is_set() is False
+        assert sum(
+            states == [SnapshotState.CREATING]
+            for states, _limit in recovery_queries
+        ) == creating_query_count
 
         runtime.release.set()
         deadline = time.monotonic() + 2
@@ -1406,20 +1423,14 @@ def test_sqlite_startup_recovers_creating_backlog_across_page_boundary(tmp_path)
     for record in records:
         repo.create(record)
     runtime = ReadyCreateRuntime()
-    listed_pages: list[int] = []
-    original_list = repo.list
-    original_recover = runtime.recover_snapshot
+    recovery_queries: list[tuple[list[SnapshotState], int]] = []
+    original_list_recoverable = repo.list_recoverable_operations
 
-    def record_page(query: SnapshotListQuery):
-        listed_pages.append(query.page)
-        return original_list(query)
+    def record_recovery_query(states: list[SnapshotState], limit: int):
+        recovery_queries.append((states, limit))
+        return original_list_recoverable(states, limit)
 
-    def assert_all_pages_collected(*args, **kwargs):
-        assert listed_pages == [1, 2]
-        return original_recover(*args, **kwargs)
-
-    repo.list = record_page
-    runtime.recover_snapshot = assert_all_pages_collected
+    repo.list_recoverable_operations = record_recovery_query
 
     PersistedSnapshotService(
         repo,
@@ -1429,6 +1440,13 @@ def test_sqlite_startup_recovers_creating_backlog_across_page_boundary(tmp_path)
     )
 
     assert len(runtime.recover_calls) == len(records)
+    creating_limits = [
+        limit
+        for states, limit in recovery_queries
+        if states == [SnapshotState.CREATING]
+    ]
+    assert creating_limits
+    assert set(creating_limits) == {2}
     assert all(
         (stored := repo.get(record.id)) is not None
         and stored.status.state == SnapshotState.READY

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -93,6 +93,14 @@ class CapturingExecutor:
         self.shutdown_wait = wait
 
 
+class CapturingJoinThread:
+    def __init__(self) -> None:
+        self.join_timeout: float | None | str = "not-called"
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeout = timeout
+
+
 class StubSnapshotRuntime:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
@@ -1419,6 +1427,25 @@ def test_snapshot_service_close_shuts_down_executor(tmp_path) -> None:
 
     assert executor.shutdown_called is True
     assert executor.shutdown_wait is True
+
+
+def test_snapshot_service_close_waits_for_recovery_thread(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    executor = CapturingExecutor()
+    recovery_thread = CapturingJoinThread()
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=StubSnapshotRuntime(),
+        snapshot_executor=executor,
+        recover_unfinished_snapshots=False,
+    )
+    service._recovery_thread = recovery_thread
+
+    service.close()
+
+    assert recovery_thread.join_timeout is None
+    assert executor.shutdown_called is True
 
 
 def test_snapshot_service_propagates_missing_sandbox(tmp_path) -> None:

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -193,6 +193,41 @@ class CreatingOnceRuntime(StubSnapshotRuntime):
         )
 
 
+class ReadyCreateRuntime(StubSnapshotRuntime):
+    def __init__(self) -> None:
+        super().__init__()
+        self.recover_calls: list[str] = []
+
+    def create_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        self.calls.append((snapshot_id, sandbox_id))
+        return SnapshotRuntimeStatus(
+            state=SnapshotState.READY,
+            image=f"registry/snapshots:{snapshot_id}",
+            reason="snapshot_runtime_ready",
+        )
+
+    def recover_snapshot(
+        self,
+        snapshot_id: str,
+        sandbox_id: str,
+        image: str | None = None,
+        *,
+        namespace: str | None = None,
+    ) -> SnapshotRuntimeStatus:
+        self.recover_calls.append(snapshot_id)
+        return SnapshotRuntimeStatus(
+            state=SnapshotState.READY,
+            image=f"registry/snapshots:{snapshot_id}",
+            reason="snapshot_runtime_ready",
+        )
+
+
 class DistributedSQLiteSnapshotRepository(SQLiteSnapshotRepository):
     @property
     def supports_distributed_leases(self) -> bool:
@@ -390,6 +425,53 @@ def test_sqlite_nonterminal_create_is_recovered_after_lease_expiry(tmp_path) -> 
             pytest.fail("SQLite nonterminal creation was not recovered after lease expiry")
 
         assert runtime.calls == [(created.id, "sbx-001")]
+        assert runtime.recover_calls == [created.id]
+    finally:
+        service.close()
+
+
+def test_sqlite_rejected_terminal_update_is_recovered(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    runtime = ReadyCreateRuntime()
+    original_update = repo.update_if_operation_owner
+    update_attempts = 0
+
+    def reject_first_terminal_update(*args, **kwargs) -> bool:
+        nonlocal update_attempts
+        update_attempts += 1
+        if update_attempts == 1:
+            with repo._connect() as conn:
+                conn.execute(
+                    "UPDATE snapshots SET lease_expires_at = ? WHERE id = ?",
+                    ("1970-01-01T00:00:00+00:00", args[0].id),
+                )
+            return False
+        return original_update(*args, **kwargs)
+
+    repo.update_if_operation_owner = reject_first_terminal_update
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=ImmediateExecutor(),
+        recovery_interval_seconds=0.01,
+    )
+
+    try:
+        created = service.create_snapshot(
+            "sbx-001",
+            CreateSnapshotRequest(name="fenced-terminal-retry"),
+        )
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            stored = repo.get(created.id)
+            if stored is not None and stored.status.state == SnapshotState.READY:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("SQLite rejected terminal update was not recovered")
+
+        assert update_attempts == 2
         assert runtime.recover_calls == [created.id]
     finally:
         service.close()
@@ -803,6 +885,57 @@ def test_sqlite_failed_delete_schedules_recovery_after_lease_expiry(tmp_path) ->
         assert runtime.delete_calls == [
             (record.id, "opensandbox-snapshots:snap-delete-retry"),
             (record.id, "opensandbox-snapshots:snap-delete-retry"),
+        ]
+    finally:
+        service.close()
+
+
+def test_sqlite_rejected_metadata_delete_is_recovered(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    record = _snapshot_record(
+        "snap-delete-fenced",
+        SnapshotState.READY,
+        image="opensandbox-snapshots:snap-delete-fenced",
+    )
+    repo.create(record)
+    runtime = StubSnapshotRuntime()
+    original_delete = repo.delete_if_operation_owner
+    delete_attempts = 0
+
+    def reject_first_metadata_delete(*args, **kwargs) -> bool:
+        nonlocal delete_attempts
+        delete_attempts += 1
+        if delete_attempts == 1:
+            with repo._connect() as conn:
+                conn.execute(
+                    "UPDATE snapshots SET lease_expires_at = ? WHERE id = ?",
+                    ("1970-01-01T00:00:00+00:00", args[0]),
+                )
+            return False
+        return original_delete(*args, **kwargs)
+
+    repo.delete_if_operation_owner = reject_first_metadata_delete
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        recovery_interval_seconds=0.01,
+    )
+
+    try:
+        service.delete_snapshot(record.id)
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            if repo.get(record.id) is None:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("SQLite rejected metadata deletion was not recovered")
+
+        assert delete_attempts == 2
+        assert runtime.delete_calls == [
+            (record.id, "opensandbox-snapshots:snap-delete-fenced"),
+            (record.id, "opensandbox-snapshots:snap-delete-fenced"),
         ]
     finally:
         service.close()


### PR DESCRIPTION
# Summary

- Add persistent operation generation, attempt, owner, and expiry fields to the PostgreSQL snapshot repository.
- Claim, renew, complete, and delete operations with short database transactions and owner/generation fencing; runtime work never holds a database transaction open.
- Run periodic recovery so an already-running standby Server can take over `Creating` and `Deleting` work after lease expiry.
- Make Kubernetes snapshot recovery observe the deterministic `SandboxSnapshot` before create, then validate and follow the winner of any create race.
- Fail closed in Helm unless `server.replicaCount > 1` explicitly declares the supported PostgreSQL-plus-Kubernetes topology, and change the safe default from two Server replicas to one.

Fixes #1654.

# Coordination model

Each snapshot operation is claimed before external runtime side effects. The repository atomically increments `operation_generation`, assigns `lease_owner`, and sets `lease_expires_at`; the fenced worker increments `operation_attempt` immediately before runtime side effects begin. Active workers renew their lease while runtime work is in progress. A terminal update or metadata delete succeeds only while the same owner and generation still hold an unexpired lease.

A periodic recovery scan allows another active Server to claim expired work. Within one process, work still executing locally is excluded from takeover even if its database lease has elapsed; after that worker exits, recovery reconciles the result. A stale cross-process worker can still finish an external call, but its database write is fenced out. This provides one current owner, takeover after expiry, observe-before-create runtime recovery, and one fenced terminal database result.

# Runtime boundaries

- PostgreSQL plus the Kubernetes runtime supports multiple active Server replicas for public snapshots.
- Kubernetes uses the stable snapshot ID-derived CR name. Recovery reads that CR first, follows an existing commit, and creates only after the live API confirms absence. A create race still validates the source sandbox.
- SQLite remains single-active and the chart prevents the unsafe default topology.
- Docker snapshot execution remains single-active. PostgreSQL fencing cannot safely fence Docker image or registry side effects across hosts.
- This is not an exactly-once claim across PostgreSQL, Kubernetes, the controller, and the OCI registry.
- No session affinity is added or required for the supported PostgreSQL and Kubernetes topology.

# Schema, migration, and rollback

The PostgreSQL schema upgrade is additive and serialized by the existing schema advisory lock. Existing rows receive zero generation and no owner; legacy unfinished `Creating` rows are conservatively assigned one attempt so recovery observes rather than repeats possible side effects. The SQLite-to-PostgreSQL migration preserves counters when present but clears source owner and expiry before cutover.

Older Server versions ignore the new columns. Before rolling back the Server version, operators must return to one active replica because older versions do not enforce operation ownership. The one-shot migration remains one-way.

# Testing

- [x] Unit tests: local full Server suite, `1681 passed, 26 skipped`.
- [x] Static checks: full Ruff and file-scoped Pyright for every changed Server source file, zero errors.
- [x] Kubernetes runtime tests: existing CR observation, confirmed-missing create, shared-deadline enforcement before create and existing-CR follow-up, create-race winner validation, deterministic name behavior.
- [x] Repository and service tests added for one-winner claim, fenced runtime-start marking, renew, expiry, takeover, queued never-started creation, stale completion and deletion rejection, legacy schema upgrade, two-Server get/list/restore, and already-running standby takeover of both `Creating` and `Deleting`.
- [ ] PostgreSQL 16 integration execution: covered by the existing `postgresql-integration` CI job and pending this PR run because no local PostgreSQL daemon was available.
- [ ] PostgreSQL 17 compatibility is not exercised by this PR and requires separate deployment validation.
- [x] Docs: VitePress build completed successfully.
- [x] Helm: v3.21.3 lint and render passed for the server and umbrella charts; undeclared, unsupported, and TOML-string bypass cases were rejected; the explicitly declared PostgreSQL-plus-Kubernetes render passed; helm-docs 1.14.2 produced no drift.

# Breaking Changes

- [ ] None
- [x] Yes: the Helm default Server replica count changes from 2 to 1, and rendering multiple replicas now requires `server.replicaSafetyMode = "postgresql-kubernetes"` plus matching `[store]` and `[runtime]` settings in `configToml`. SQLite and Docker users remain on the supported single-active topology.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added or updated docs
- [x] Added or updated tests
- [x] Security impact considered
- [x] Backward compatibility and rollback considered