### PR TITLE
fix(server): reject unsupported gVisor snapshots before persistence

### DIFF
--- a/docs/guides/pause-resume.md
+++ b/docs/guides/pause-resume.md
@@ -308,6 +308,18 @@ snapshots are created by the `BatchSandbox` controller and have a controller
 ownerReference to the owning `BatchSandbox`; public snapshots are created by the
 Lifecycle server and do not use that ownerReference.
 
+### Runtime compatibility
+
+The built-in `rootfs-v1` image committer requires a container runtime that
+exposes compatible containerd task pause/resume and writable-snapshot APIs.
+gVisor RuntimeClasses whose handler is `runsc` do not currently satisfy that
+contract. The Lifecycle server rejects public snapshot creation for those
+workloads before it persists a snapshot record or creates a `SandboxSnapshot`
+resource, leaving the running sandbox untouched.
+
+Native gVisor checkpoint/restore requires a dedicated snapshot backend and is
+not provided by the `rootfs-v1` committer.
+
 ### Commit Job
 
 The controller creates a short-lived Kubernetes `Job` for each pause:

--- a/server/opensandbox_server/services/constants.py
+++ b/server/opensandbox_server/services/constants.py
@@ -150,6 +150,8 @@ class SnapshotErrorCodes:
     """Canonical error codes for snapshot service operations."""
 
     INVALID_SOURCE_STATE = "SNAPSHOT::INVALID_SOURCE_STATE"
+    RUNTIME_PREFLIGHT_FAILED = "SNAPSHOT::RUNTIME_PREFLIGHT_FAILED"
+    UNSUPPORTED_RUNTIME = "SNAPSHOT::UNSUPPORTED_RUNTIME"
 
 
 __all__ = [

--- a/server/opensandbox_server/services/docker/snapshot_runtime.py
+++ b/server/opensandbox_server/services/docker/snapshot_runtime.py
@@ -52,6 +52,14 @@ class DockerSnapshotRuntime:
     def create_snapshot_unsupported_message(self) -> str:
         return ""
 
+    def preflight_create_snapshot(
+        self,
+        sandbox_id: str,
+        *,
+        namespace: str | None = None,
+    ) -> None:
+        return None
+
     def create_snapshot(
         self,
         snapshot_id: str,

--- a/server/opensandbox_server/services/k8s/client.py
+++ b/server/opensandbox_server/services/k8s/client.py
@@ -420,6 +420,20 @@ class K8sClient:
         )
         return resp.items
 
+    def read_pod(self, namespace: str, name: str) -> Any | None:
+        """Read a Pod by name, returning None when it no longer exists."""
+        if self._read_limiter:
+            self._read_limiter.acquire()
+        try:
+            return self.get_core_v1_api().read_namespaced_pod(
+                namespace=namespace,
+                name=name,
+            )
+        except ApiException as exc:
+            if exc.status == 404:
+                return None
+            raise
+
     def read_runtime_class(self, name: str) -> Any:
         """Read a RuntimeClass from the cluster."""
         if self._read_limiter:

--- a/server/opensandbox_server/services/k8s/snapshot_runtime.py
+++ b/server/opensandbox_server/services/k8s/snapshot_runtime.py
@@ -19,6 +19,7 @@ Kubernetes-backed public snapshot runtime.
 from __future__ import annotations
 
 from hashlib import sha256
+import json
 import logging
 import time
 from typing import Optional
@@ -27,13 +28,20 @@ from uuid import UUID
 from kubernetes.client import ApiException
 
 from opensandbox_server.services.snapshot_models import SnapshotState
-from opensandbox_server.services.snapshot_runtime import SnapshotRuntimeStatus
+from opensandbox_server.services.snapshot_runtime import (
+    SnapshotRuntimePreflightError,
+    SnapshotRuntimeStatus,
+    SnapshotRuntimeUnsupportedError,
+)
 
 logger = logging.getLogger(__name__)
 
 _GROUP = "sandbox.opensandbox.io"
 _VERSION = "v1alpha1"
 _PLURAL = "sandboxsnapshots"
+_BATCHSANDBOX_PLURAL = "batchsandboxes"
+_POOL_ALLOCATION_ANNOTATION = "sandbox.opensandbox.io/alloc-status"
+_BATCHSANDBOX_NAME_LABEL = "batch-sandbox.sandbox.opensandbox.io/name"
 
 PUBLIC_SNAPSHOT_NAME_PREFIX = "osb-snap-"
 PUBLIC_SNAPSHOT_TAG_PREFIX = "snap-"
@@ -81,6 +89,66 @@ class KubernetesSnapshotRuntime:
 
     def create_snapshot_unsupported_message(self) -> str:
         return ""
+
+    def preflight_create_snapshot(
+        self,
+        sandbox_id: str,
+        *,
+        namespace: str | None = None,
+    ) -> None:
+        ns = namespace if namespace is not None else self._namespace
+        try:
+            workload = self._k8s_client.get_custom_object(
+                group=_GROUP,
+                version=_VERSION,
+                namespace=ns,
+                plural=_BATCHSANDBOX_PLURAL,
+                name=sandbox_id,
+            )
+            if workload is None:
+                raise SnapshotRuntimePreflightError(
+                    f"Cannot verify snapshot runtime for sandbox {sandbox_id}: "
+                    "BatchSandbox was not found."
+                )
+
+            source_pod = self._source_pod(
+                workload,
+                sandbox_id=sandbox_id,
+                namespace=ns,
+            )
+            pod_spec = self._field(source_pod, "spec")
+            runtime_class_name = self._field(
+                pod_spec,
+                "runtimeClassName",
+                "runtime_class_name",
+            )
+            if runtime_class_name is None:
+                return
+            if not isinstance(runtime_class_name, str) or not runtime_class_name:
+                raise SnapshotRuntimePreflightError(
+                    f"Cannot verify snapshot runtime for sandbox {sandbox_id}: "
+                    "source Pod has an invalid RuntimeClass name."
+                )
+
+            runtime_class = self._k8s_client.read_runtime_class(runtime_class_name)
+            handler = self._runtime_class_handler(runtime_class)
+            if not handler:
+                raise SnapshotRuntimePreflightError(
+                    f"Cannot verify snapshot runtime for sandbox {sandbox_id}: "
+                    f"RuntimeClass {runtime_class_name!r} has no handler."
+                )
+        except SnapshotRuntimePreflightError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise SnapshotRuntimePreflightError(
+                f"Cannot verify snapshot runtime for sandbox {sandbox_id}."
+            ) from exc
+
+        if self._is_gvisor_handler(handler):
+            raise SnapshotRuntimeUnsupportedError(
+                f"gVisor RuntimeClass {runtime_class_name!r} (handler {handler!r}) "
+                "does not support the built-in rootfs snapshot committer."
+            )
 
     def create_snapshot(
         self,
@@ -197,6 +265,83 @@ class KubernetesSnapshotRuntime:
                 "sandboxName": sandbox_id,
             },
         }
+
+    def _source_pod(
+        self,
+        workload: dict,
+        *,
+        sandbox_id: str,
+        namespace: str,
+    ):
+        for pod_name in self._allocated_pod_names(workload):
+            pod = self._k8s_client.read_pod(namespace, pod_name)
+            if self._pod_is_running(pod):
+                return pod
+
+        pods = self._k8s_client.list_pods(
+            namespace=namespace,
+            label_selector=f"{_BATCHSANDBOX_NAME_LABEL}={sandbox_id}",
+        )
+        for pod in pods:
+            if self._pod_is_running(pod):
+                return pod
+
+        fallback = self._k8s_client.read_pod(namespace, f"{sandbox_id}-0")
+        if self._pod_is_running(fallback):
+            return fallback
+
+        raise SnapshotRuntimePreflightError(
+            f"Cannot verify snapshot runtime for sandbox {sandbox_id}: "
+            "no running source Pod was found."
+        )
+
+    @staticmethod
+    def _allocated_pod_names(workload: dict) -> list[str]:
+        annotations = (workload.get("metadata") or {}).get("annotations") or {}
+        raw_allocation = annotations.get(_POOL_ALLOCATION_ANNOTATION)
+        if not isinstance(raw_allocation, str):
+            return []
+        try:
+            allocation = json.loads(raw_allocation)
+        except (TypeError, ValueError):
+            return []
+        if not isinstance(allocation, dict):
+            return []
+        pod_names = allocation.get("pods")
+        if not isinstance(pod_names, list):
+            return []
+        return [name for name in pod_names if isinstance(name, str) and name]
+
+    @classmethod
+    def _pod_is_running(cls, pod) -> bool:
+        status = cls._field(pod, "status")
+        return cls._field(status, "phase") == "Running"
+
+    @staticmethod
+    def _field(value, *names: str):
+        if isinstance(value, dict):
+            for name in names:
+                if name in value:
+                    return value[name]
+            return None
+        for name in names:
+            field = getattr(value, name, None)
+            if field is not None:
+                return field
+        return None
+
+    @staticmethod
+    def _runtime_class_handler(runtime_class) -> str | None:
+        if isinstance(runtime_class, dict):
+            handler = runtime_class.get("handler")
+        else:
+            handler = getattr(runtime_class, "handler", None)
+        return handler if isinstance(handler, str) and handler else None
+
+    @staticmethod
+    def _is_gvisor_handler(handler: str) -> bool:
+        normalized = handler.lower()
+        return normalized == "runsc" or normalized.startswith("runsc-")
 
     def _get_snapshot_cr(self, snapshot_name: str, *, namespace: str | None = None) -> Optional[dict]:
         return self._k8s_client.get_custom_object(

--- a/server/opensandbox_server/services/snapshot_runtime.py
+++ b/server/opensandbox_server/services/snapshot_runtime.py
@@ -36,6 +36,14 @@ class SnapshotRuntimeStatus:
     message: Optional[str] = None
 
 
+class SnapshotRuntimePreflightError(RuntimeError):
+    """Snapshot creation cannot safely start for the current source runtime."""
+
+
+class SnapshotRuntimeUnsupportedError(SnapshotRuntimePreflightError):
+    """The source runtime is known to be incompatible with snapshot creation."""
+
+
 class SnapshotRuntime(Protocol):
     def supports_create_snapshot(self) -> bool:
         """
@@ -46,6 +54,14 @@ class SnapshotRuntime(Protocol):
         """
         Human-readable message used when snapshot creation is unsupported.
         """
+
+    def preflight_create_snapshot(
+        self,
+        sandbox_id: str,
+        *,
+        namespace: str | None = None,
+    ) -> None:
+        """Validate source-specific compatibility before persisting a snapshot."""
 
     def create_snapshot(
         self,
@@ -85,6 +101,16 @@ class NoopSnapshotRuntime:
     def create_snapshot_unsupported_message(self) -> str:
         return "Snapshot management is not implemented for this runtime."
 
+    def preflight_create_snapshot(
+        self,
+        sandbox_id: str,
+        *,
+        namespace: str | None = None,
+    ) -> None:
+        raise SnapshotRuntimeUnsupportedError(
+            self.create_snapshot_unsupported_message()
+        )
+
     def create_snapshot(
         self,
         snapshot_id: str,
@@ -110,6 +136,8 @@ class NoopSnapshotRuntime:
 
 __all__ = [
     "SnapshotRuntime",
+    "SnapshotRuntimePreflightError",
     "SnapshotRuntimeStatus",
+    "SnapshotRuntimeUnsupportedError",
     "NoopSnapshotRuntime",
 ]

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -44,7 +44,9 @@ from opensandbox_server.services.constants import SnapshotErrorCodes
 from opensandbox_server.services.snapshot_runtime import (
     NoopSnapshotRuntime,
     SnapshotRuntime,
+    SnapshotRuntimePreflightError,
     SnapshotRuntimeStatus,
+    SnapshotRuntimeUnsupportedError,
 )
 from opensandbox_server.services.snapshot_runtime_factory import create_snapshot_runtime
 from opensandbox_server.services.snapshot_models import (
@@ -128,11 +130,34 @@ class PersistedSnapshotService(SnapshotService):
                 },
             )
 
+        namespace = self._get_tenant_namespace()
+        try:
+            self._snapshot_runtime.preflight_create_snapshot(
+                sandbox_id,
+                namespace=namespace,
+            )
+        except SnapshotRuntimeUnsupportedError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": SnapshotErrorCodes.UNSUPPORTED_RUNTIME,
+                    "message": str(exc),
+                },
+            ) from exc
+        except SnapshotRuntimePreflightError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": SnapshotErrorCodes.RUNTIME_PREFLIGHT_FAILED,
+                    "message": str(exc),
+                },
+            ) from exc
+
         now = datetime.now(timezone.utc)
         record = SnapshotRecord(
             id=str(uuid4()),
             source_sandbox_id=sandbox_id,
-            namespace=self._get_tenant_namespace(),
+            namespace=namespace,
             name=request.name,
             restore_config=self._default_restore_config(),
             status=SnapshotStatusRecord(

--- a/server/tests/k8s/test_k8s_client.py
+++ b/server/tests/k8s/test_k8s_client.py
@@ -575,6 +575,20 @@ class TestK8sClient:
         with pytest.raises(Exception, match="network error"):
             c.list_pods("ns")
 
+    def test_read_pod_returns_pod_and_maps_not_found_to_none(self, k8s_runtime_config):
+        c = self._make_client(k8s_runtime_config)
+        pod = MagicMock()
+        c._core_v1_api.read_namespaced_pod.return_value = pod
+
+        assert c.read_pod("ns", "sandbox-0") is pod
+        c._core_v1_api.read_namespaced_pod.assert_called_once_with(
+            namespace="ns",
+            name="sandbox-0",
+        )
+
+        c._core_v1_api.read_namespaced_pod.side_effect = ApiException(status=404)
+        assert c.read_pod("ns", "missing") is None
+
     def test_read_runtime_class_delegates_to_api(self, k8s_runtime_config):
         """read_runtime_class forwards to NodeV1Api.read_runtime_class."""
         c = self._make_client(k8s_runtime_config)
@@ -641,6 +655,13 @@ class TestK8sClient:
         mock_limiter = MagicMock()
         c._read_limiter = mock_limiter
         c.list_pods("ns")
+        mock_limiter.acquire.assert_called_once()
+
+    def test_read_limiter_called_on_read_pod(self, k8s_runtime_config):
+        c = self._make_client(k8s_runtime_config)
+        mock_limiter = MagicMock()
+        c._read_limiter = mock_limiter
+        c.read_pod("ns", "sandbox-0")
         mock_limiter.acquire.assert_called_once()
 
     def test_read_limiter_called_on_read_runtime_class(self, k8s_runtime_config):

--- a/server/tests/test_k8s_snapshot_runtime.py
+++ b/server/tests/test_k8s_snapshot_runtime.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 
+import pytest
 from kubernetes.client import ApiException
 
 from opensandbox_server.services.k8s.snapshot_runtime import (
@@ -24,6 +25,7 @@ from opensandbox_server.services.k8s.snapshot_runtime import (
     build_public_snapshot_tag,
 )
 from opensandbox_server.services.snapshot_models import SnapshotState
+from opensandbox_server.services.snapshot_runtime import SnapshotRuntimeUnsupportedError
 
 
 SNAPSHOT_ID = "11111111-2222-4333-8444-555555555555"
@@ -34,6 +36,9 @@ SANDBOX_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
 class FakeK8sClient:
     def __init__(self) -> None:
         self.objects: dict[str, dict] = {}
+        self.workloads: dict[str, dict] = {}
+        self.pods: dict[str, dict] = {}
+        self.runtime_classes: dict[str, dict] = {}
         self.created: list[dict] = []
         self.deleted: list[str] = []
 
@@ -47,8 +52,25 @@ class FakeK8sClient:
         return stored
 
     def get_custom_object(self, *, group: str, version: str, namespace: str, plural: str, name: str):
-        obj = self.objects.get(name)
+        objects = {
+            "batchsandboxes": self.workloads,
+            "sandboxsnapshots": self.objects,
+        }[plural]
+        obj = objects.get(name)
         return deepcopy(obj) if obj is not None else None
+
+    def read_pod(self, namespace: str, name: str):
+        pod = self.pods.get(name)
+        return deepcopy(pod) if pod is not None else None
+
+    def list_pods(self, namespace: str, label_selector: str = ""):
+        return [deepcopy(pod) for pod in self.pods.values()]
+
+    def read_runtime_class(self, name: str):
+        runtime_class = self.runtime_classes.get(name)
+        if runtime_class is None:
+            raise ApiException(status=404, reason="Not Found")
+        return deepcopy(runtime_class)
 
     def delete_custom_object(self, *, group: str, version: str, namespace: str, plural: str, name: str, **kwargs):
         self.deleted.append(name)
@@ -122,6 +144,66 @@ def _snapshot_cr(*, phase: str, containers: list[dict] | None = None, sandbox_id
 def test_public_snapshot_name_and_tag_are_derived_from_snapshot_id() -> None:
     assert build_public_snapshot_name(SNAPSHOT_ID) == f"osb-snap-{SNAPSHOT_HEX}"
     assert build_public_snapshot_tag(SNAPSHOT_ID) == f"snap-{SNAPSHOT_HEX}"
+
+
+def test_preflight_rejects_gvisor_runtimeclass_before_snapshot_cr_creation() -> None:
+    k8s_client = FakeK8sClient()
+    k8s_client.workloads[SANDBOX_ID] = {
+        "spec": {"template": {"spec": {"runtimeClassName": "sandboxed"}}},
+    }
+    k8s_client.pods[f"{SANDBOX_ID}-0"] = {
+        "spec": {"runtimeClassName": "sandboxed"},
+        "status": {"phase": "Running"},
+    }
+    k8s_client.runtime_classes["sandboxed"] = {"handler": "runsc"}
+    runtime = KubernetesSnapshotRuntime(k8s_client, namespace="default")
+
+    with pytest.raises(SnapshotRuntimeUnsupportedError, match="gVisor"):
+        runtime.preflight_create_snapshot(SANDBOX_ID)
+
+    assert k8s_client.created == []
+
+
+def test_preflight_allows_non_gvisor_runtimeclass() -> None:
+    k8s_client = FakeK8sClient()
+    k8s_client.workloads[SANDBOX_ID] = {
+        "spec": {"template": {"spec": {"runtimeClassName": "native"}}},
+    }
+    k8s_client.pods[f"{SANDBOX_ID}-0"] = {
+        "spec": {"runtimeClassName": "native"},
+        "status": {"phase": "Running"},
+    }
+    k8s_client.runtime_classes["native"] = {"handler": "runc"}
+    runtime = KubernetesSnapshotRuntime(k8s_client, namespace="default")
+
+    runtime.preflight_create_snapshot(SANDBOX_ID)
+
+    assert k8s_client.created == []
+
+
+def test_preflight_uses_allocated_pool_pod_runtimeclass() -> None:
+    k8s_client = FakeK8sClient()
+    k8s_client.workloads[SANDBOX_ID] = {
+        "metadata": {
+            "annotations": {
+                "sandbox.opensandbox.io/alloc-status": (
+                    '{"pods":["pool-pod-1"],"poolRef":"gvisor-pool"}'
+                ),
+            },
+        },
+        "spec": {"poolRef": "gvisor-pool"},
+    }
+    k8s_client.pods["pool-pod-1"] = {
+        "spec": {"runtimeClassName": "sandboxed"},
+        "status": {"phase": "Running"},
+    }
+    k8s_client.runtime_classes["sandboxed"] = {"handler": "runsc"}
+    runtime = KubernetesSnapshotRuntime(k8s_client, namespace="default")
+
+    with pytest.raises(SnapshotRuntimeUnsupportedError, match="gVisor"):
+        runtime.preflight_create_snapshot(SANDBOX_ID)
+
+    assert k8s_client.created == []
 
 
 def test_create_snapshot_creates_cr_and_maps_succeed_to_ready() -> None:

--- a/server/tests/test_routes_snapshots.py
+++ b/server/tests/test_routes_snapshots.py
@@ -226,6 +226,14 @@ def test_snapshot_routes_can_use_persisted_service(
             return ""
 
         @staticmethod
+        def preflight_create_snapshot(
+            sandbox_id: str,
+            *,
+            namespace: str | None = None,
+        ) -> None:
+            return None
+
+        @staticmethod
         def create_snapshot(snapshot_id: str, sandbox_id: str):
             return None
 

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -26,7 +26,11 @@ from opensandbox_server.services.snapshot_models import (
     SnapshotState,
     SnapshotStatusRecord,
 )
-from opensandbox_server.services.snapshot_runtime import NoopSnapshotRuntime, SnapshotRuntimeStatus
+from opensandbox_server.services.snapshot_runtime import (
+    NoopSnapshotRuntime,
+    SnapshotRuntimeStatus,
+    SnapshotRuntimeUnsupportedError,
+)
 from opensandbox_server.services.snapshot_service import PersistedSnapshotService
 
 
@@ -88,6 +92,9 @@ class StubSnapshotRuntime:
 
     def create_snapshot_unsupported_message(self) -> str:
         return ""
+
+    def preflight_create_snapshot(self, sandbox_id: str, *, namespace: str | None = None) -> None:
+        return None
 
     def create_snapshot(self, snapshot_id: str, sandbox_id: str, *, namespace: str | None = None):
         self.calls.append((snapshot_id, sandbox_id))
@@ -166,6 +173,33 @@ def test_snapshot_service_rejects_create_when_source_sandbox_not_running(tmp_pat
     assert exc_info.value.status_code == 409
     assert exc_info.value.detail["code"] == "SNAPSHOT::INVALID_SOURCE_STATE"
     assert runtime.calls == []
+
+
+def test_snapshot_service_rejects_unsupported_runtime_before_persisting(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    runtime = StubSnapshotRuntime()
+    executor = CapturingExecutor()
+
+    def reject_preflight(sandbox_id: str, *, namespace: str | None = None) -> None:
+        raise SnapshotRuntimeUnsupportedError(
+            "gVisor RuntimeClass handler 'runsc' does not support rootfs snapshots."
+        )
+
+    runtime.preflight_create_snapshot = reject_preflight
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=executor,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.create_snapshot("sbx-001", CreateSnapshotRequest(name="checkpoint"))
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "SNAPSHOT::UNSUPPORTED_RUNTIME"
+    assert service.list_snapshots(ListSnapshotsRequest()).pagination.total_items == 0
+    assert executor.submitted == []
 
 
 def test_snapshot_service_rejects_create_when_source_sandbox_state_missing(tmp_path) -> None:


### PR DESCRIPTION
# Summary

- add a source-specific snapshot preflight before the Server persists a public snapshot record;
- resolve the actual running source Pod for direct and pooled `BatchSandbox` workloads, then inspect its effective `RuntimeClass` handler;
- reject `runsc`/gVisor workloads with `409 SNAPSHOT::UNSUPPORTED_RUNTIME` before creating snapshot metadata, a `SandboxSnapshot`, or a commit Job;
- fail closed with `SNAPSHOT::RUNTIME_PREFLIGHT_FAILED` when the source runtime cannot be verified;
- keep Docker and non-gVisor Kubernetes snapshot behavior unchanged, and document the compatibility boundary.

The current `rootfs-v1` committer uses containerd task pause/resume plus writable-snapshot image creation. gVisor has its own `runsc checkpoint`/`restore` state format, so native gVisor support requires a separate backend rather than routing it through the rootfs committer. That follow-up should define checkpoint artifact packaging, `runsc` version and CPU compatibility, restore-time OCI/Pod reconstruction, registry or object-store lifecycle, and dedicated RuntimeClass e2e coverage.

Closes #1719.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [ ] e2e / manual verification

Commands run:

```text
cd server
uv run pytest -q
uv run ruff check

cd ../docs
corepack pnpm@9.15.0 install --frozen-lockfile
corepack pnpm@9.15.0 docs:build

git diff --check
```

Results:

- Server: 1657 passed, 16 skipped
- Ruff: passed
- VitePress: built successfully
- Kind/gVisor e2e was not run because this environment does not provide a configured gVisor cluster. The focused tests cover direct and pooled source-Pod resolution, `runsc` rejection before CR creation, non-gVisor pass-through, API persistence ordering, and Kubernetes client reads.
- The repository-wide `pyright` command currently reports pre-existing baseline errors; focused changed files report the same existing Protocol/pagination/nullable-namespace issues and no new preflight-specific diagnostic.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

The only behavior change is fail-closed rejection for Kubernetes snapshots whose effective RuntimeClass handler is `runsc`, replacing a late destructive commit-Job failure with an early `409` response.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
