### PR TITLE
fix(server): skip missing IPv6 sysctl in K8s init

### DIFF
--- a/server/opensandbox_server/services/k8s/egress_helper.py
+++ b/server/opensandbox_server/services/k8s/egress_helper.py
@@ -20,6 +20,7 @@ Public entry points: ``prep_execd_init_for_egress``, ``build_security_context_fo
 """
 
 import json
+import shlex
 from typing import Any, Dict, List, Optional
 
 from opensandbox_server.services.constants import (
@@ -34,19 +35,26 @@ from opensandbox_server.services.constants import (
 )
 from opensandbox_server.services.k8s.workload_provider import EgressWorkloadSettings
 
+_IPV6_DISABLE_PATH = "/proc/sys/net/ipv6/conf/all/disable_ipv6"
+
 
 def prep_execd_init_for_egress(exec_install_script: str) -> tuple[str, Dict[str, Any]]:
     """
     Prepare execd init when ``egress.disable_ipv6`` is true: disable IPv6 in the Pod netns, then install.
 
-    Writes ``/proc/sys/.../disable_ipv6`` (no ``sysctl`` binary required). The returned
-    security context dict must be applied to the execd init container (typically via
-    ``build_security_context_from_dict`` in ``security_context``).
+    Writes ``/proc/sys/.../disable_ipv6`` when that path exists (no ``sysctl`` binary
+    required). A missing path is valid for an IPv4-only Pod netns, while a write failure
+    remains fatal. The returned security context dict must be applied to the execd init
+    container (typically via ``build_security_context_from_dict`` in ``security_context``).
 
     Returns:
         ``(prefixed_shell_script, {"privileged": True})``
     """
-    script = f"set -e; echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6 && {exec_install_script}"
+    ipv6_disable_path = shlex.quote(_IPV6_DISABLE_PATH)
+    script = (
+        f"set -e; if [ -e {ipv6_disable_path} ]; then "
+        f"echo 1 > {ipv6_disable_path}; fi; {exec_install_script}"
+    )
     return script, {"privileged": True}
 
 

--- a/server/opensandbox_server/services/k8s/windows_profile.py
+++ b/server/opensandbox_server/services/k8s/windows_profile.py
@@ -19,6 +19,7 @@ import re
 from typing import Any, Dict, List, Optional
 
 from opensandbox_server.api.schema import PlatformSpec
+from opensandbox_server.services.k8s.egress_helper import prep_execd_init_for_egress
 from opensandbox_server.services.k8s.provider_common import DEFAULT_ENTRYPOINT
 from opensandbox_server.services.windows_common import (
     inject_windows_resource_limits_env,
@@ -87,8 +88,9 @@ def apply_windows_profile_overrides(
         "chmod 0644 /oem/install.bat /oem/execd.exe"
     )
     if disable_ipv6_for_egress:
-        init_container["args"] = [f"set -e; echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6 && {init_script}"]
-        init_container["securityContext"] = {"privileged": True}
+        init_script, security_context = prep_execd_init_for_egress(init_script)
+        init_container["args"] = [init_script]
+        init_container["securityContext"] = security_context
     else:
         init_container["args"] = [init_script]
         init_container.pop("securityContext", None)

--- a/server/tests/k8s/test_egress_helper.py
+++ b/server/tests/k8s/test_egress_helper.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import json
+import shutil
+import subprocess
 from typing import Optional
 
 import pytest
@@ -33,6 +35,7 @@ from opensandbox_server.services.constants import (
     OPENSANDBOX_RUNTIME_VOLUME_NAME,
 )
 from opensandbox_server.services.helpers import split_egress_env
+from opensandbox_server.services.k8s import egress_helper
 from opensandbox_server.services.k8s.workload_provider import EgressWorkloadSettings
 from opensandbox_server.services.k8s.egress_helper import (
     apply_egress_to_spec,
@@ -558,12 +561,57 @@ class TestApplyEgressToSpec:
 
 
 class TestPrepExecdInitForEgress:
-    def test_returns_privileged_security_dict_and_prefixed_script(self):
-        base = "cp ./execd /opt/opensandbox/execd"
-        script, sc = prep_execd_init_for_egress(base)
-        assert sc == {"privileged": True}
-        assert "/proc/sys/net/ipv6/conf/all/disable_ipv6" in script
-        assert script.endswith(base)
+    @staticmethod
+    def _run_script(tmp_path, monkeypatch, ipv6_disable_path):
+        install_marker = tmp_path / "execd-installed"
+        monkeypatch.setattr(
+            egress_helper,
+            "_IPV6_DISABLE_PATH",
+            ipv6_disable_path.relative_to(tmp_path).as_posix(),
+            raising=False,
+        )
+        install_script = "printf installed > execd-installed"
+        script, security_context = prep_execd_init_for_egress(install_script)
+        shell = shutil.which("sh")
+        assert shell is not None
+        result = subprocess.run(
+            [shell, "-c", script],
+            capture_output=True,
+            check=False,
+            text=True,
+            cwd=tmp_path,
+        )
+        return result, install_marker, security_context
+
+    def test_missing_ipv6_path_still_runs_execd_install(self, tmp_path, monkeypatch):
+        ipv6_disable_path = tmp_path / "missing" / "disable_ipv6"
+
+        result, install_marker, security_context = self._run_script(
+            tmp_path, monkeypatch, ipv6_disable_path
+        )
+
+        assert result.returncode == 0
+        assert install_marker.read_text() == "installed"
+        assert security_context == {"privileged": True}
+
+    def test_existing_ipv6_path_is_disabled_before_execd_install(self, tmp_path, monkeypatch):
+        ipv6_disable_path = tmp_path / "disable_ipv6"
+        ipv6_disable_path.write_text("0")
+
+        result, install_marker, _ = self._run_script(tmp_path, monkeypatch, ipv6_disable_path)
+
+        assert result.returncode == 0
+        assert ipv6_disable_path.read_text() == "1\n"
+        assert install_marker.read_text() == "installed"
+
+    def test_existing_ipv6_path_write_failure_stops_execd_install(self, tmp_path, monkeypatch):
+        ipv6_disable_path = tmp_path / "disable_ipv6"
+        ipv6_disable_path.mkdir()
+
+        result, install_marker, _ = self._run_script(tmp_path, monkeypatch, ipv6_disable_path)
+
+        assert result.returncode != 0
+        assert not install_marker.exists()
 
 
 class TestSplitEgressEnv:
@@ -657,6 +705,7 @@ class TestSplitEgressEnv:
 
     def test_allows_all_permitted_vars(self):
         from opensandbox_server.services.constants import ALLOWED_EGRESS_ENV_VARS
+
         env = {key: "val" for key in ALLOWED_EGRESS_ENV_VARS}
         sandbox_env, egress_env = split_egress_env(env)
         assert set(egress_env.keys()) == ALLOWED_EGRESS_ENV_VARS

--- a/server/tests/k8s/test_k8s_windows_profile.py
+++ b/server/tests/k8s/test_k8s_windows_profile.py
@@ -14,8 +14,12 @@
 
 """Unit tests for K8s windows_profile module."""
 
+import shutil
+import subprocess
+
 import pytest
 
+from opensandbox_server.services.k8s import egress_helper
 from opensandbox_server.services.k8s.windows_profile import (
     _memory_with_qemu_overhead,
     apply_windows_profile_overrides,
@@ -133,6 +137,44 @@ class TestApplyWindowsProfileOverrides:
             ],
             "volumes": [{"name": "opensandbox-bin", "emptyDir": {}}],
         }
+
+    def test_missing_ipv6_path_still_runs_windows_install(
+        self, tmp_path, monkeypatch
+    ):
+        ipv6_disable_path = tmp_path / "missing" / "disable_ipv6"
+        monkeypatch.setattr(
+            egress_helper,
+            "_IPV6_DISABLE_PATH",
+            ipv6_disable_path.relative_to(tmp_path).as_posix(),
+        )
+        pod_spec = self._make_pod_spec()
+        apply_windows_profile_overrides(
+            pod_spec=pod_spec,
+            entrypoint=[],
+            env={},
+            resource_limits={},
+            disable_ipv6_for_egress=True,
+        )
+
+        script = pod_spec["initContainers"][0]["args"][0]
+        shell = shutil.which("sh")
+        assert shell is not None
+        command_stubs = 'cp() { printf "%s\\n" "$*" >> cp.log; }; chmod() { :; }; '
+        result = subprocess.run(
+            [shell, "-c", command_stubs + script],
+            capture_output=True,
+            check=False,
+            text=True,
+            cwd=tmp_path,
+        )
+
+        assert result.returncode == 0
+        assert (tmp_path / "cp.log").read_text().splitlines() == [
+            "./install.bat /oem/install.bat",
+            "./execd.exe /oem/execd.exe",
+        ]
+        security_context = pod_spec["initContainers"][0]["securityContext"]
+        assert security_context == {"privileged": True}
 
     def test_custom_entrypoint_sets_command(self):
         pod_spec = self._make_pod_spec()


### PR DESCRIPTION
# Summary

- guard the Kubernetes egress IPv6 sysctl write with an explicit path-existence check
- continue execd installation when an IPv4-only Pod network namespace does not expose the IPv6 sysctl path
- keep the init container fail-closed when the path exists but the write fails
- reuse the guarded init construction for Windows Profile BatchSandboxes

Related to #570.

# Root cause

When a Kubernetes sandbox request includes `networkPolicy` and `egress.disable_ipv6` is enabled, the privileged `execd-installer` prepends an unconditional write to `/proc/sys/net/ipv6/conf/all/disable_ipv6`. IPv4-only Pod network namespaces may omit that path, so `set -e` exits before execd and bootstrap files are installed.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Commands run:

- `uv run pytest -q tests/k8s/test_egress_helper.py` — 47 passed
- `uv run pytest -q tests/k8s/test_k8s_windows_profile.py` — 26 passed
- `uv run pytest -q tests/k8s` — 631 passed
- `uv run pytest --cov=opensandbox_server --cov-fail-under=80` — 1654 passed, 16 skipped, 82.57% coverage
- `uv run ruff check`
- `uv run ruff format --check opensandbox_server/services/k8s/egress_helper.py tests/k8s/test_egress_helper.py`
- `./scripts/verify-license.sh`
- `git diff --check`

The regression tests execute the generated shell script and cover all three branches: missing path continues installation, an existing path is written with `1`, and a write failure prevents installation.

# Compatibility boundary

- Kubernetes init-script generation, including the Windows Profile override
- no Docker runtime changes
- no gVisor or Kata selection changes
- no `NetworkPolicy`, config-default, CRD, SDK, or lifecycle contract changes
- BatchSandbox init-failure propagation and ready-timeout behavior remain out of scope

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (not needed; no public contract changes)
- [x] Added/updated tests
- [x] Security impact considered
- [x] Backward compatibility considered