### PR TITLE
fix(kubernetes): propagate terminal Pod failures

### DIFF
--- a/docs/kubernetes/index.md
+++ b/docs/kubernetes/index.md
@@ -528,12 +528,12 @@ For a BatchSandbox with multiple replicas, `Succeed` also does not mean that eve
 
 | `status.phase` | Meaning |
 |---|---|
-| `Pending` | The controller has not observed a Running and Ready sandbox Pod yet. |
+| `Pending` | The controller has not observed a Running and Ready sandbox Pod yet. Scheduling waits and retryable image-pull states remain Pending. |
 | `Succeed` | At least one sandbox Pod is Running and Ready; the sandbox is available. |
 | `Pausing` | A pause operation is in progress. |
 | `Paused` | The sandbox is paused and its runtime resources have been released. |
 | `Resuming` | The controller is restoring runtime resources after a pause. |
-| `Failed` | The controller detected a sandbox runtime failure. Inspect conditions and Pod events for details. |
+| `Failed` | The controller detected a terminal sandbox runtime failure. A Pod in Kubernetes phase `Failed` is terminal; inspect conditions and Pod events for details. |
 
 The controller records active conditions with `status: "True"`:
 
@@ -542,7 +542,9 @@ The controller records active conditions with `status: "True"`:
 | `Ready` | The phase is `Succeed`; reason `PodsReady` means the sandbox is running. |
 | `Progressing` | The sandbox is being created, paused, or resumed. |
 | `Paused` | The sandbox is fully paused. |
-| `PauseFailed`, `ResumeFailed`, `PodFailed` | The corresponding operation or runtime failed; inspect `reason` and `message`. |
+| `PauseFailed`, `ResumeFailed`, `PodFailed` | The corresponding operation or runtime failed; inspect `reason` and `message`. A terminal init-container or container exit is summarized on `PodFailed`. |
+
+`status.taskFailed` remains the number of failed optional tasks. Pod or init-container failures are reported through `status.phase` and `PodFailed`; they do not overwrite task counters. During synchronous sandbox creation, the Server converts a terminal `Failed` phase into `KUBERNETES::POD_FAILED` immediately instead of waiting for the Pod readiness timeout.
 
 Treat a condition as satisfied only when the matching entry exists with `status: "True"`. Check `status.observedGeneration` against `metadata.generation` before acting on status after a spec update.
 

--- a/kubernetes/internal/controller/batchsandbox_controller.go
+++ b/kubernetes/internal/controller/batchsandbox_controller.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -820,7 +821,50 @@ func (r *BatchSandboxReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurren
 		For(&sandboxv1alpha1.BatchSandbox{}).
 		Named("batchsandbox").
 		Owns(&corev1.Pod{}).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.findBatchSandboxesForPooledPod)).
 		Owns(&sandboxv1alpha1.SandboxSnapshot{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
+}
+
+func (r *BatchSandboxReconciler) findBatchSandboxesForPooledPod(ctx context.Context, obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod.Labels[LabelPoolName] == "" {
+		return nil
+	}
+
+	batchSandboxes := &sandboxv1alpha1.BatchSandboxList{}
+	if err := r.List(ctx, batchSandboxes, &client.ListOptions{
+		Namespace:     pod.Namespace,
+		FieldSelector: fields.SelectorFromSet(fields.Set{fieldindex.IndexNameForPoolRef: pod.Labels[LabelPoolName]}),
+	}); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to find BatchSandbox for pooled Pod", "pod", pod.Name)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, 1)
+	for i := range batchSandboxes.Items {
+		batchSandbox := &batchSandboxes.Items[i]
+		allocation, err := parseSandboxAllocation(batchSandbox)
+		if err != nil {
+			logf.FromContext(ctx).Error(err, "Failed to parse BatchSandbox allocation", "batchSandbox", batchSandbox.Name)
+			continue
+		}
+		if !slices.Contains(allocation.Pods, pod.Name) {
+			continue
+		}
+		released, err := parseSandboxReleased(batchSandbox)
+		if err != nil {
+			logf.FromContext(ctx).Error(err, "Failed to parse BatchSandbox release", "batchSandbox", batchSandbox.Name)
+			continue
+		}
+		if slices.Contains(released.Pods, pod.Name) {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: batchSandbox.Namespace,
+			Name:      batchSandbox.Name,
+		}})
+	}
+	return requests
 }

--- a/kubernetes/internal/controller/batchsandbox_controller.go
+++ b/kubernetes/internal/controller/batchsandbox_controller.go
@@ -217,7 +217,9 @@ func (r *BatchSandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Normal mode owns pod lifecycle except while a sandbox is fully paused. In Paused, the
 	// snapshot-backed runtime is quiesced and pods must stay absent until resume rewrites the
 	// template images and transitions back through Resuming.
-	if !poolStrategy.IsPooledMode() && batchSbx.Status.Phase != sandboxv1alpha1.BatchSandboxPhasePaused {
+	if !poolStrategy.IsPooledMode() &&
+		batchSbx.Status.Phase != sandboxv1alpha1.BatchSandboxPhasePaused &&
+		!hasTerminalPodFailureCondition(batchSbx.Status.Conditions) {
 		err := r.scaleBatchSandbox(ctx, batchSbx, batchSbx.Spec.Template, pods)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to scale batch sandbox %w", err)

--- a/kubernetes/internal/controller/batchsandbox_controller_test.go
+++ b/kubernetes/internal/controller/batchsandbox_controller_test.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	sandboxv1alpha1 "github.com/alibaba/OpenSandbox/sandbox-k8s/apis/sandbox/v1alpha1"
 	"github.com/alibaba/OpenSandbox/sandbox-k8s/internal/controller/strategy"
@@ -702,6 +703,63 @@ func TestBatchSandboxReconciler_scheduleTasks(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFindBatchSandboxesForPooledPod(t *testing.T) {
+	allocated := &sandboxv1alpha1.BatchSandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allocated",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnoAllocStatusKey: `{"pods":["pool-pod"]}`,
+			},
+		},
+		Spec: sandboxv1alpha1.BatchSandboxSpec{PoolRef: "shared-pool"},
+	}
+	released := &sandboxv1alpha1.BatchSandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "released",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnoAllocStatusKey:  `{"pods":["pool-pod"]}`,
+				AnnoAllocReleaseKey: `{"pods":["pool-pod"]}`,
+			},
+		},
+		Spec: sandboxv1alpha1.BatchSandboxSpec{PoolRef: "shared-pool"},
+	}
+	other := &sandboxv1alpha1.BatchSandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnoAllocStatusKey: `{"pods":["other-pod"]}`,
+			},
+		},
+		Spec: sandboxv1alpha1.BatchSandboxSpec{PoolRef: "shared-pool"},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testscheme).
+		WithIndex(&sandboxv1alpha1.BatchSandbox{}, fieldindex.IndexNameForPoolRef, fieldindex.PoolRefIndexFunc).
+		WithObjects(allocated, released, other).
+		Build()
+	reconciler := &BatchSandboxReconciler{Client: fakeClient}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "pool-pod",
+		Namespace: "default",
+		Labels:    map[string]string{LabelPoolName: "shared-pool"},
+	}}
+
+	requests := reconciler.findBatchSandboxesForPooledPod(context.Background(), pod)
+
+	want := []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "default", Name: "allocated"}}}
+	if !reflect.DeepEqual(requests, want) {
+		t.Fatalf("findBatchSandboxesForPooledPod() = %v, want %v", requests, want)
+	}
+
+	pod.Labels[LabelPoolName] = "unrelated-pool"
+	if requests := reconciler.findBatchSandboxesForPooledPod(context.Background(), pod); len(requests) != 0 {
+		t.Fatalf("findBatchSandboxesForPooledPod() for unrelated pool = %v, want none", requests)
 	}
 }
 

--- a/kubernetes/internal/controller/batchsandbox_pause_resume_test.go
+++ b/kubernetes/internal/controller/batchsandbox_pause_resume_test.go
@@ -1810,6 +1810,170 @@ func TestBuildRuntimeView_AggregatesPodFailuresInSteadyState(t *testing.T) {
 	assert.Equal(t, "3/4 observed pods failed; primary reason=ErrImagePull; sample pod=err-image-0", podFailed.Message)
 }
 
+func TestBuildRuntimeView_MarksTerminalInitContainerFailure(t *testing.T) {
+	bs := &sandboxv1alpha1.BatchSandbox{
+		Status: sandboxv1alpha1.BatchSandboxStatus{
+			Phase:      sandboxv1alpha1.BatchSandboxPhasePending,
+			TaskFailed: 2,
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-0", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name: "bootstrap-execd",
+				State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					ExitCode: 1,
+					Reason:   "Error",
+					Message:  "install failed",
+				}},
+			}},
+		},
+	}
+
+	view := buildRuntimeView(bs, []*corev1.Pod{pod})
+
+	assert.Equal(t, sandboxv1alpha1.BatchSandboxPhaseFailed, view.status.Phase)
+	assert.Equal(t, int32(2), view.status.TaskFailed, "pod failures must not overwrite the failed-task count")
+	for i := range view.status.Conditions {
+		condition := view.status.Conditions[i]
+		if condition.Type != sandboxv1alpha1.BatchSandboxConditionPodFailed {
+			continue
+		}
+		assert.Equal(t, sandboxv1alpha1.ConditionTrue, condition.Status)
+		assert.Equal(t, "InitContainerFailed", condition.Reason)
+		assert.Equal(
+			t,
+			"1/1 observed pods failed; primary reason=InitContainerFailed; sample pod=sandbox-0; sample detail=Pod sandbox-0 init container bootstrap-execd exited with code 1 (Error): install failed",
+			condition.Message,
+		)
+		return
+	}
+	t.Fatal("expected PodFailed condition")
+}
+
+func TestBuildRuntimeView_InitialRetryablePodStatesRemainPending(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+	}{
+		{
+			name: "ordinary pending",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pending-0"},
+				Status:     corev1.PodStatus{Phase: corev1.PodPending},
+			},
+		},
+		{
+			name: "waiting for scheduling",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "unscheduled-0"},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonUnschedulable,
+						Message: "insufficient cpu",
+					}},
+				},
+			},
+		},
+		{
+			name: "retryable image pull",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "image-pull-0"},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "ImagePullBackOff",
+							Message: "back-off pulling image",
+						}},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bs := &sandboxv1alpha1.BatchSandbox{
+				Status: sandboxv1alpha1.BatchSandboxStatus{Phase: sandboxv1alpha1.BatchSandboxPhasePending},
+			}
+
+			view := buildRuntimeView(bs, []*corev1.Pod{tt.pod})
+
+			assert.Equal(t, sandboxv1alpha1.BatchSandboxPhasePending, view.status.Phase)
+			for _, condition := range view.status.Conditions {
+				assert.NotEqual(t, sandboxv1alpha1.BatchSandboxConditionPodFailed, condition.Type)
+			}
+		})
+	}
+}
+
+func TestReconcile_DoesNotReplacePodAfterTerminalPodFailure(t *testing.T) {
+	previousExpectations := BatchSandboxScaleExpectations
+	BatchSandboxScaleExpectations = expectations.NewScaleExpectations()
+	t.Cleanup(func() { BatchSandboxScaleExpectations = previousExpectations })
+
+	bs := &sandboxv1alpha1.BatchSandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "terminal-failure", Namespace: "default", UID: "terminal-failure-uid"},
+		Spec: sandboxv1alpha1.BatchSandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			Template: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "main", Image: "example.invalid/sandbox:test"}},
+			}},
+		},
+		Status: sandboxv1alpha1.BatchSandboxStatus{
+			Phase: sandboxv1alpha1.BatchSandboxPhaseFailed,
+			Conditions: []sandboxv1alpha1.BatchSandboxCondition{{
+				Type:   sandboxv1alpha1.BatchSandboxConditionPodFailed,
+				Status: sandboxv1alpha1.ConditionTrue,
+				Reason: "InitContainerFailed",
+			}},
+		},
+	}
+	reconciler := newTestReconciler(bs)
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: bs.Namespace, Name: bs.Name},
+	})
+	require.NoError(t, err)
+
+	pod := &corev1.Pod{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Namespace: bs.Namespace, Name: bs.Name + "-0"}, pod)
+	assert.True(t, apierrors.IsNotFound(err), "a recorded terminal Pod failure must not be hidden by an automatic replacement")
+}
+
+func TestReconcile_ReplacesMissingPodWithoutTerminalFailure(t *testing.T) {
+	previousExpectations := BatchSandboxScaleExpectations
+	BatchSandboxScaleExpectations = expectations.NewScaleExpectations()
+	t.Cleanup(func() { BatchSandboxScaleExpectations = previousExpectations })
+
+	bs := &sandboxv1alpha1.BatchSandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "retryable-pending", Namespace: "default", UID: "retryable-pending-uid"},
+		Spec: sandboxv1alpha1.BatchSandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			Template: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "main", Image: "example.invalid/sandbox:test"}},
+			}},
+		},
+		Status: sandboxv1alpha1.BatchSandboxStatus{Phase: sandboxv1alpha1.BatchSandboxPhasePending},
+	}
+	reconciler := newTestReconciler(bs)
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: bs.Namespace, Name: bs.Name},
+	})
+	require.NoError(t, err)
+
+	pod := &corev1.Pod{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Namespace: bs.Namespace, Name: bs.Name + "-0"}, pod)
+	require.NoError(t, err, "ordinary expected-state reconciliation must still replace a missing Pod")
+}
+
 func TestBuildRuntimeView_AggregatesResumeFailures(t *testing.T) {
 	bs := &sandboxv1alpha1.BatchSandbox{
 		ObjectMeta: metav1.ObjectMeta{

--- a/kubernetes/internal/controller/batchsandbox_status.go
+++ b/kubernetes/internal/controller/batchsandbox_status.go
@@ -38,6 +38,12 @@ type runtimeView struct {
 	resumeCompleted bool
 }
 
+const (
+	terminalPodFailedReason           = "PodFailed"
+	terminalContainerFailedReason     = "ContainerFailed"
+	terminalInitContainerFailedReason = "InitContainerFailed"
+)
+
 func setConditionInStatus(
 	status *sandboxv1alpha1.BatchSandboxStatus,
 	conditionType sandboxv1alpha1.BatchSandboxConditionType,
@@ -108,6 +114,9 @@ func applyBatchSandboxPhaseConditions(status *sandboxv1alpha1.BatchSandboxStatus
 }
 
 func getPodFailureReasonAndMessage(pod *corev1.Pod) (string, string, bool) {
+	if reason, message, failed := getTerminalPodFailureReasonAndMessage(pod); failed {
+		return reason, message, true
+	}
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.State.Waiting == nil {
 			continue
@@ -120,21 +129,82 @@ func getPodFailureReasonAndMessage(pod *corev1.Pod) (string, string, bool) {
 	return "", "", false
 }
 
+func getTerminalPodFailureReasonAndMessage(pod *corev1.Pod) (string, string, bool) {
+	if pod.Status.Phase != corev1.PodFailed {
+		return "", "", false
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		if reason, message, failed := terminatedContainerFailure(pod, &pod.Status.InitContainerStatuses[i], true); failed {
+			return reason, message, true
+		}
+	}
+	for i := range pod.Status.ContainerStatuses {
+		if reason, message, failed := terminatedContainerFailure(pod, &pod.Status.ContainerStatuses[i], false); failed {
+			return reason, message, true
+		}
+	}
+
+	message := fmt.Sprintf("Pod %s entered Failed phase", pod.Name)
+	if pod.Status.Reason != "" {
+		message += fmt.Sprintf(" (%s)", pod.Status.Reason)
+	}
+	if pod.Status.Message != "" {
+		message += ": " + pod.Status.Message
+	}
+	return terminalPodFailedReason, message, true
+}
+
+func terminatedContainerFailure(pod *corev1.Pod, status *corev1.ContainerStatus, initContainer bool) (string, string, bool) {
+	terminated := status.State.Terminated
+	if terminated == nil || terminated.ExitCode == 0 {
+		return "", "", false
+	}
+
+	reason := terminalContainerFailedReason
+	kind := "container"
+	if initContainer {
+		reason = terminalInitContainerFailedReason
+		kind = "init container"
+	}
+	message := fmt.Sprintf("Pod %s %s %s exited with code %d", pod.Name, kind, status.Name, terminated.ExitCode)
+	if terminated.Reason != "" {
+		message += fmt.Sprintf(" (%s)", terminated.Reason)
+	}
+	if terminated.Message != "" {
+		message += ": " + terminated.Message
+	}
+	return reason, message, true
+}
+
 type podFailureSummary struct {
 	observed      int
 	failed        int
 	primaryReason string
 	samplePod     string
+	sampleDetail  string
 }
 
 func summarizePodFailures(pods []*corev1.Pod) (podFailureSummary, bool) {
+	return summarizePodFailuresWith(pods, getPodFailureReasonAndMessage, false)
+}
+
+func summarizeTerminalPodFailures(pods []*corev1.Pod) (podFailureSummary, bool) {
+	return summarizePodFailuresWith(pods, getTerminalPodFailureReasonAndMessage, true)
+}
+
+func summarizePodFailuresWith(
+	pods []*corev1.Pod,
+	detectFailure func(*corev1.Pod) (string, string, bool),
+	includeSampleDetail bool,
+) (podFailureSummary, bool) {
 	summary := podFailureSummary{observed: len(pods)}
 	reasonCounts := make(map[string]int)
 	firstPodByReason := make(map[string]string)
+	firstDetailByReason := make(map[string]string)
 	primaryCount := 0
 
 	for _, pod := range pods {
-		reason, _, failed := getPodFailureReasonAndMessage(pod)
+		reason, message, failed := detectFailure(pod)
 		if !failed {
 			continue
 		}
@@ -142,12 +212,16 @@ func summarizePodFailures(pods []*corev1.Pod) (podFailureSummary, bool) {
 		summary.failed++
 		if _, exists := firstPodByReason[reason]; !exists {
 			firstPodByReason[reason] = pod.Name
+			firstDetailByReason[reason] = message
 		}
 		reasonCounts[reason]++
 		if reasonCounts[reason] > primaryCount {
 			primaryCount = reasonCounts[reason]
 			summary.primaryReason = reason
 			summary.samplePod = firstPodByReason[reason]
+			if includeSampleDetail {
+				summary.sampleDetail = firstDetailByReason[reason]
+			}
 		}
 	}
 
@@ -159,7 +233,11 @@ func (s podFailureSummary) message(duringResume bool) string {
 	if duringResume {
 		scope = "observed pods failed during resume"
 	}
-	return fmt.Sprintf("%d/%d %s; primary reason=%s; sample pod=%s", s.failed, s.observed, scope, s.primaryReason, s.samplePod)
+	message := fmt.Sprintf("%d/%d %s; primary reason=%s; sample pod=%s", s.failed, s.observed, scope, s.primaryReason, s.samplePod)
+	if s.sampleDetail != "" {
+		message += "; sample detail=" + s.sampleDetail
+	}
+	return message
 }
 
 func buildRuntimeView(batchSbx *sandboxv1alpha1.BatchSandbox, pods []*corev1.Pod) runtimeView {
@@ -221,7 +299,11 @@ func applyResumingRuntimePhase(status *sandboxv1alpha1.BatchSandboxStatus, pods 
 }
 
 func applySteadyRuntimePhase(batchSbx *sandboxv1alpha1.BatchSandbox, status *sandboxv1alpha1.BatchSandboxStatus, pods []*corev1.Pod) {
-	if summary, hasFailures := summarizePodFailures(pods); hasFailures {
+	summary, hasFailures := summarizePodFailures(pods)
+	if batchSbx.Status.Phase == "" || batchSbx.Status.Phase == sandboxv1alpha1.BatchSandboxPhasePending {
+		summary, hasFailures = summarizeTerminalPodFailures(pods)
+	}
+	if hasFailures {
 		if batchSbx.Status.Phase != sandboxv1alpha1.BatchSandboxPhaseFailed {
 			setConditionInStatus(status, sandboxv1alpha1.BatchSandboxConditionPodFailed, sandboxv1alpha1.ConditionTrue, summary.primaryReason, summary.message(false))
 			// Under informer lag a resume-in-progress failure can be observed while the
@@ -244,6 +326,19 @@ func applySteadyRuntimePhase(batchSbx *sandboxv1alpha1.BatchSandbox, status *san
 		return
 	}
 	status.Phase = sandboxv1alpha1.BatchSandboxPhasePending
+}
+
+func hasTerminalPodFailureCondition(conditions []sandboxv1alpha1.BatchSandboxCondition) bool {
+	for _, condition := range conditions {
+		if condition.Type != sandboxv1alpha1.BatchSandboxConditionPodFailed || condition.Status != sandboxv1alpha1.ConditionTrue {
+			continue
+		}
+		switch condition.Reason {
+		case terminalPodFailedReason, terminalContainerFailedReason, terminalInitContainerFailedReason:
+			return true
+		}
+	}
+	return false
 }
 
 // isInitialUnallocatedSandbox returns true when the sandbox has just been created

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -313,6 +313,17 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                             ),
                         },
                     )
+                if current_state == "Failed":
+                    raise HTTPException(
+                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                        detail={
+                            "code": SandboxErrorCodes.K8S_POD_FAILED,
+                            "message": (
+                                f"Sandbox {sandbox_id} failed: "
+                                f"{current_message or current_reason or 'no failure details'}"
+                            ),
+                        },
+                    )
 
                 now = time.time()
                 pool_capacity_exhausted = _is_pool_capacity_exhausted_status(

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -15,6 +15,7 @@
 import pytest
 from types import SimpleNamespace
 from datetime import datetime, timedelta, timezone
+from typing import cast
 from unittest.mock import MagicMock, patch
 from fastapi import HTTPException
 
@@ -935,6 +936,47 @@ class TestWaitForSandboxReady:
         result = await k8s_service._wait_for_sandbox_ready("test-sandbox-id", timeout_seconds=10)
         
         assert result == mock_workload
+
+    @pytest.mark.asyncio
+    async def test_wait_fails_immediately_for_terminal_pod(self, k8s_service, mock_workload):
+        clock = SimpleNamespace(now=0.0)
+
+        async def advance_clock(seconds: float) -> None:
+            clock.now += seconds
+
+        k8s_service.workload_provider.get_workload.return_value = mock_workload
+        k8s_service.workload_provider.get_status.return_value = {
+            "state": "Failed",
+            "reason": "FAILED",
+            "message": (
+                "1/1 observed pods failed; primary reason=InitContainerFailed; "
+                "sample pod=sandbox-0"
+            ),
+            "last_transition_at": datetime.now(timezone.utc),
+        }
+
+        with (
+            patch(
+                "opensandbox_server.services.k8s.kubernetes_service.time.time",
+                side_effect=lambda: clock.now,
+            ),
+            patch(
+                "opensandbox_server.services.k8s.kubernetes_service.asyncio.sleep",
+                new=advance_clock,
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await k8s_service._wait_for_sandbox_ready(
+                "test-sandbox-id",
+                timeout_seconds=600,
+                poll_interval_seconds=1,
+            )
+
+        assert exc_info.value.status_code == 500
+        detail = cast(dict[str, str], exc_info.value.detail)
+        assert detail["code"] == SandboxErrorCodes.K8S_POD_FAILED
+        assert "InitContainerFailed" in detail["message"]
+        assert k8s_service.workload_provider.get_status.call_count == 1
     
     @pytest.mark.asyncio
     async def test_wait_timeout_raises_exception(self, k8s_service, mock_workload):


### PR DESCRIPTION
# Summary

- propagate a Kubernetes Pod in terminal `Failed` phase into `BatchSandbox.status.phase=Failed` with a stable `PodFailed` reason/message, including the failing init-container or container exit code
- keep initial scheduling waits and retryable image-pull states in `Pending`, and preserve `status.taskFailed` as the failed optional-task count
- stop standalone Pod replacement only after a terminal Pod failure has been recorded, while retaining normal expected-state replacement for other missing Pods
- make synchronous Server creation fail immediately with the existing `KUBERNETES::POD_FAILED` error instead of waiting for `KUBERNETES::POD_READY_TIMEOUT`

## Root cause and state-machine boundary

The Controller's failure detector only inspected `containerStatuses[*].state.waiting` for selected reasons. It did not inspect `pod.status.phase=Failed` or terminated init-container statuses. A Pod whose init container exited non-zero with `restartPolicy: Never` therefore left its owning BatchSandbox in `Pending` (`ready=0`) even though Kubernetes had already made the Pod terminal.

The Server already mapped `BatchSandbox.status.phase=Failed` to public state `Failed`, but its synchronous readiness loop only returned on Running/Allocated and special-cased platform scheduling failures. Generic terminal failures continued polling until the full readiness timeout.

This change uses Kubernetes Pod phase as the terminal boundary:

- `PodFailed`: terminal; surface `InitContainerFailed`, `ContainerFailed`, or `PodFailed` details and retain the failed state.
- ordinary Pending, scheduler waits, `ErrImagePull`, and `ImagePullBackOff` during initial provisioning: retryable; remain Pending.
- missing Pods without a recorded terminal failure: continue to reconcile toward `spec.replicas`.
- missing Pods after a recorded terminal failure: do not recreate and hide the original error; delete/recreate the BatchSandbox to retry.

`status.taskFailed` is intentionally not overloaded: it remains the number of failed optional tasks, while Pod failures use `status.phase` and the `PodFailed` condition.

## Minimal reproduction

Create a standalone BatchSandbox with one replica, `restartPolicy: Never`, and an init container that exits `1`. Before this change, the Pod reaches `phase: Failed` while the BatchSandbox remains `Pending`, and Server creation ends only at the readiness timeout. After this change, the BatchSandbox reports `Failed` with the init-container exit details and the Server returns `KUBERNETES::POD_FAILED` on the first failed-status observation.

## Why this is not a DELETE 204 leak

This PR does not change deletion, finalizers, owner references, or garbage collection. In the observed sequence, an unauthenticated DELETE was rejected; a subsequent authenticated DELETE returned 204, and follow-up reads found the Sandbox and owned Kubernetes resources gone. The defect addressed here is the pre-delete failure-status path and the replacement race while the owner CR still exists, not resource leakage after a successful DELETE.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Local verification:

- `cd kubernetes && make test`
- `cd kubernetes && make lint`
- `cd kubernetes && make build && make task-executor-build`
- focused Controller regression tests, first confirmed red, then green
- `cd server && uv run ruff check`
- `cd server && uv run pytest -q` (`1652 passed, 16 skipped`)
- `cd docs && corepack pnpm docs:build`
- `./scripts/verify-license.sh`
- `git diff --check`

The repository's Kubernetes E2E matrix is left to CI because it requires the supported Kind matrix and Docker environment.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

No CRD, API, annotation, label, config, Pool, Snapshot, Pause/Resume, or RuntimeClass contract changes. The observable correction is that terminal Pod failures now return the existing failure state/code promptly instead of a later readiness timeout.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
