### PR TITLE
fix(helm): default server to one active replica

### DIFF
--- a/.github/workflows/helm-release-test.yml
+++ b/.github/workflows/helm-release-test.yml
@@ -84,6 +84,21 @@ jobs:
           printf '%s  %s\n' "$package_sha256" "$package_name" >dist/SHA256SUMS
           echo "package_name=$package_name" >>"$GITHUB_OUTPUT"
 
+      - name: Verify single-active Server defaults
+        env:
+          PACKAGE_NAME: ${{ steps.package.outputs.package_name }}
+        run: |
+          set -euo pipefail
+
+          helm template opensandbox-server kubernetes/charts/opensandbox-server \
+            --show-only templates/server.yaml >/tmp/opensandbox-server-rendered.yaml
+          grep -qx '  replicas: 1' /tmp/opensandbox-server-rendered.yaml
+
+          helm template opensandbox "dist/$PACKAGE_NAME" \
+            --show-only charts/opensandbox-server/templates/server.yaml \
+            >/tmp/opensandbox-umbrella-server-rendered.yaml
+          grep -qx '  replicas: 1' /tmp/opensandbox-umbrella-server-rendered.yaml
+
       - name: Run exact-package Kind smoke
         env:
           PACKAGE_NAME: ${{ steps.package.outputs.package_name }}

--- a/.github/workflows/helm-release-test.yml
+++ b/.github/workflows/helm-release-test.yml
@@ -93,11 +93,13 @@ jobs:
           helm template opensandbox-server kubernetes/charts/opensandbox-server \
             --show-only templates/server.yaml >/tmp/opensandbox-server-rendered.yaml
           grep -qx '  replicas: 1' /tmp/opensandbox-server-rendered.yaml
+          grep -qx '    type: Recreate' /tmp/opensandbox-server-rendered.yaml
 
           helm template opensandbox "dist/$PACKAGE_NAME" \
             --show-only charts/opensandbox-server/templates/server.yaml \
             >/tmp/opensandbox-umbrella-server-rendered.yaml
           grep -qx '  replicas: 1' /tmp/opensandbox-umbrella-server-rendered.yaml
+          grep -qx '    type: Recreate' /tmp/opensandbox-umbrella-server-rendered.yaml
 
       - name: Run exact-package Kind smoke
         env:

--- a/docs/kubernetes/deployment.md
+++ b/docs/kubernetes/deployment.md
@@ -56,7 +56,7 @@ Reference the Secret from a values file:
 ```yaml
 # values-server.yaml
 server:
-  replicaCount: 2
+  replicaCount: 1
   env:
     - name: OPENSANDBOX_SERVER_API_KEY
       valueFrom:
@@ -68,6 +68,13 @@ server:
 Use an external secret manager instead of creating the Secret manually in production environments.
 
 The chart installs the server into `opensandbox-system`, while the default `configToml` creates sandbox and pool resources in `opensandbox`. If you change `[kubernetes].namespace` in `configToml`, create that namespace instead of `opensandbox` before submitting workloads.
+
+::: warning Single-active Server default
+The chart defaults to `server.replicaCount: 1`. Keep one active Lifecycle
+Server. Multi-replica Server HA is not supported yet, including with a shared
+PostgreSQL database. PostgreSQL-backed Kubernetes HA will be delivered in a
+separate change.
+:::
 
 ### Use PostgreSQL for server persistence
 
@@ -107,8 +114,8 @@ configToml: |
 ```
 
 ::: warning
-Snapshot recovery is not coordinated across server replicas. Keep
-`server.replicaCount: 1` when replicas use the same PostgreSQL database.
+PostgreSQL provides shared persistence, but recovery is not coordinated across
+server replicas. Keep `server.replicaCount: 1` when using PostgreSQL.
 :::
 
 ### Install and verify
@@ -152,7 +159,7 @@ curl --fail http://127.0.0.1:8080/health
 |-------|---------|-------|
 | `server.image.repository` | Server image registry and repository | Override for a private mirror or custom build. |
 | `server.image.tag` | Server image version | The release install command pins it to `APP_VERSION`. |
-| `server.replicaCount` | Number of server Pods | Defaults to `2`. |
+| `server.replicaCount` | Number of server Pods | Defaults to `1`; multi-replica Server HA is not supported yet. |
 | `server.env` | Additional container environment variables | Use it with `secretKeyRef` for `OPENSANDBOX_SERVER_API_KEY`. |
 | `configToml` | Complete server configuration | Mounted at `/etc/opensandbox/config.toml`; overriding it replaces the complete default TOML, including the workload namespace. |
 | `server.gateway.enabled` | Deploy the ingress gateway with the server | Defaults to `false`. |

--- a/docs/kubernetes/deployment.md
+++ b/docs/kubernetes/deployment.md
@@ -73,7 +73,9 @@ The chart installs the server into `opensandbox-system`, while the default `conf
 The chart defaults to `server.replicaCount: 1`. Keep one active Lifecycle
 Server. Multi-replica Server HA is not supported yet, including with a shared
 PostgreSQL database. PostgreSQL-backed Kubernetes HA will be delivered in a
-separate change.
+separate change. The Server Deployment uses the `Recreate` strategy so an
+upgrade stops the active Server before starting its replacement; expect a brief
+API interruption during upgrades.
 :::
 
 ### Use PostgreSQL for server persistence

--- a/kubernetes/charts/opensandbox-server/README.md
+++ b/kubernetes/charts/opensandbox-server/README.md
@@ -2,6 +2,11 @@
 
 OpenSandbox Lifecycle API server: provides sandbox create/delete and other lifecycle APIs, typically used with BatchSandbox/Pool on Kubernetes.
 
+> **Single-active default**: The chart deploys one active Lifecycle Server by
+> default. Multi-replica Server HA is not supported yet, including with a shared
+> PostgreSQL database. PostgreSQL-backed Kubernetes HA will be delivered in a
+> separate change.
+
 ## Prerequisites
 
 - Kubernetes 1.21.1+
@@ -154,7 +159,7 @@ The following table lists the configurable parameters of the chart and their def
 | server.podLabels | object | `{}` | Extra labels for the server pod. |
 | server.podSecurityContext | object | `{}` | Pod-level security context for the server pod. |
 | server.priorityClassName | string | `""` | Priority class name for the server pod. |
-| server.replicaCount | int | `2` | Number of server replicas |
+| server.replicaCount | int | `1` | Number of server replicas. Keep one active server; multi-replica HA is not supported yet. |
 | server.resources | object | `{"limits":{"cpu":"2","memory":"8Gi"},"requests":{"cpu":"1","memory":"4Gi"}}` | Resource requests and limits |
 | server.service.nodePort | string | `""` | Node port to bind when type is not ClusterIP. Empty lets Kubernetes allocate one from the cluster node-port range. |
 | server.service.type | string | `"ClusterIP"` | Service type for the server. Set to NodePort or LoadBalancer to reach the server from outside the cluster. |

--- a/kubernetes/charts/opensandbox-server/README.md
+++ b/kubernetes/charts/opensandbox-server/README.md
@@ -5,7 +5,9 @@ OpenSandbox Lifecycle API server: provides sandbox create/delete and other lifec
 > **Single-active default**: The chart deploys one active Lifecycle Server by
 > default. Multi-replica Server HA is not supported yet, including with a shared
 > PostgreSQL database. PostgreSQL-backed Kubernetes HA will be delivered in a
-> separate change.
+> separate change. The Server Deployment uses the `Recreate` strategy so an
+> upgrade stops the active Server before starting its replacement; expect a
+> brief API interruption during upgrades.
 
 ## Prerequisites
 

--- a/kubernetes/charts/opensandbox-server/README.md.gotmpl
+++ b/kubernetes/charts/opensandbox-server/README.md.gotmpl
@@ -5,7 +5,9 @@ OpenSandbox Lifecycle API server: provides sandbox create/delete and other lifec
 > **Single-active default**: The chart deploys one active Lifecycle Server by
 > default. Multi-replica Server HA is not supported yet, including with a shared
 > PostgreSQL database. PostgreSQL-backed Kubernetes HA will be delivered in a
-> separate change.
+> separate change. The Server Deployment uses the `Recreate` strategy so an
+> upgrade stops the active Server before starting its replacement; expect a
+> brief API interruption during upgrades.
 
 ## Prerequisites
 

--- a/kubernetes/charts/opensandbox-server/README.md.gotmpl
+++ b/kubernetes/charts/opensandbox-server/README.md.gotmpl
@@ -2,6 +2,11 @@
 
 OpenSandbox Lifecycle API server: provides sandbox create/delete and other lifecycle APIs, typically used with BatchSandbox/Pool on Kubernetes.
 
+> **Single-active default**: The chart deploys one active Lifecycle Server by
+> default. Multi-replica Server HA is not supported yet, including with a shared
+> PostgreSQL database. PostgreSQL-backed Kubernetes HA will be delivered in a
+> separate change.
+
 ## Prerequisites
 
 - Kubernetes 1.21.1+

--- a/kubernetes/charts/opensandbox-server/templates/server.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/server.yaml
@@ -81,6 +81,8 @@ metadata:
     {{- include "opensandbox-server.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.server.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "opensandbox-server.selectorLabels" . | nindent 6 }}

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -29,8 +29,8 @@ server:
     # -- Server image tag. Defaults to the chart appVersion when empty.
     tag: "v0.2.2"
 
-  # -- Number of server replicas
-  replicaCount: 2
+  # -- Number of server replicas. Keep one active server; multi-replica HA is not supported yet.
+  replicaCount: 1
 
   # -- Resource requests and limits
   resources:

--- a/kubernetes/charts/opensandbox/README.md
+++ b/kubernetes/charts/opensandbox/README.md
@@ -5,7 +5,9 @@ This Helm chart bundles both the **OpenSandbox Controller** and **OpenSandbox Se
 > **Single-active Server default**: The chart deploys one active Lifecycle
 > Server by default. Multi-replica Server HA is not supported yet, including
 > with a shared PostgreSQL database. PostgreSQL-backed Kubernetes HA will be
-> delivered in a separate change.
+> delivered in a separate change. The Server Deployment uses the `Recreate`
+> strategy so an upgrade stops the active Server before starting its
+> replacement; expect a brief API interruption during upgrades.
 
 ## Prerequisites
 

--- a/kubernetes/charts/opensandbox/README.md
+++ b/kubernetes/charts/opensandbox/README.md
@@ -2,6 +2,11 @@
 
 This Helm chart bundles both the **OpenSandbox Controller** and **OpenSandbox Server** into a single deployment for simplified installation.
 
+> **Single-active Server default**: The chart deploys one active Lifecycle
+> Server by default. Multi-replica Server HA is not supported yet, including
+> with a shared PostgreSQL database. PostgreSQL-backed Kubernetes HA will be
+> delivered in a separate change.
+
 ## Prerequisites
 
 - Kubernetes 1.21.1+
@@ -72,7 +77,7 @@ The following table lists the configurable parameters of the chart and their def
 | opensandbox-controller.controller.snapshot.resumePullSecret | string | `""` | Secret name injected into resumed sandboxes for pulling snapshot images. |
 | opensandbox-controller.controller.snapshot.snapshotPushSecret | string | `""` | Secret name used by commit Jobs to push snapshot images. |
 | opensandbox-node-agent.enabled | bool | `false` | Whether the node agent is enabled. |
-| opensandbox-server.server.replicaCount | int | `2` | Number of server replicas. |
+| opensandbox-server.server.replicaCount | int | `1` | Number of server replicas. Keep one active server; multi-replica HA is not supported yet. |
 
 ### Override Sub-chart Values
 
@@ -104,7 +109,7 @@ opensandbox-controller:
 
 opensandbox-server:
   server:
-    replicaCount: 2
+    replicaCount: 1
     gateway:
       enabled: true
       host: gateway.example.com

--- a/kubernetes/charts/opensandbox/README.md.gotmpl
+++ b/kubernetes/charts/opensandbox/README.md.gotmpl
@@ -2,6 +2,11 @@
 
 This Helm chart bundles both the **OpenSandbox Controller** and **OpenSandbox Server** into a single deployment for simplified installation.
 
+> **Single-active Server default**: The chart deploys one active Lifecycle
+> Server by default. Multi-replica Server HA is not supported yet, including
+> with a shared PostgreSQL database. PostgreSQL-backed Kubernetes HA will be
+> delivered in a separate change.
+
 ## Prerequisites
 
 - Kubernetes 1.21.1+
@@ -86,7 +91,7 @@ opensandbox-controller:
 
 opensandbox-server:
   server:
-    replicaCount: 2
+    replicaCount: 1
     gateway:
       enabled: true
       host: gateway.example.com

--- a/kubernetes/charts/opensandbox/README.md.gotmpl
+++ b/kubernetes/charts/opensandbox/README.md.gotmpl
@@ -5,7 +5,9 @@ This Helm chart bundles both the **OpenSandbox Controller** and **OpenSandbox Se
 > **Single-active Server default**: The chart deploys one active Lifecycle
 > Server by default. Multi-replica Server HA is not supported yet, including
 > with a shared PostgreSQL database. PostgreSQL-backed Kubernetes HA will be
-> delivered in a separate change.
+> delivered in a separate change. The Server Deployment uses the `Recreate`
+> strategy so an upgrade stops the active Server before starting its
+> replacement; expect a brief API interruption during upgrades.
 
 ## Prerequisites
 

--- a/kubernetes/charts/opensandbox/values.yaml
+++ b/kubernetes/charts/opensandbox/values.yaml
@@ -32,8 +32,8 @@ opensandbox-server:
   # Default values are inherited from the sub-chart.
   # Override specific server settings here if needed.
   server:
-    # -- Number of server replicas.
-    replicaCount: 2
+    # -- Number of server replicas. Keep one active server; multi-replica HA is not supported yet.
+    replicaCount: 1
 
 # Optional node-level sandbox log collection. Configure the target in the
 # sub-chart values before enabling it.


### PR DESCRIPTION
## Summary

- default the `opensandbox-server` chart to one active Lifecycle Server and use `Recreate` upgrades to avoid old/new Pod overlap
- keep the umbrella chart, generated chart READMEs, and Kubernetes deployment guide aligned with that default
- assert the single-active replica and rollout strategy for both the source subchart and the packaged umbrella chart in the Helm release smoke workflow

## Why

The charts currently default to two Server replicas, while snapshot recovery is not coordinated across replicas, including when they share PostgreSQL. A single active Server is the currently supported deployment boundary, so the safe default should match it. The Server Deployment also uses `Recreate` because the default RollingUpdate strategy can briefly run an old Pod and a surge Pod together even when the desired replica count is one. This means upgrades have a brief API interruption instead of overlapping active Servers.

PostgreSQL-backed Kubernetes multi-replica HA will be handled in a separate PR. This change does not add a lease, recovery, persistence, runtime, or fail-closed protocol, and it does not claim to complete the HA work in #1654.

## Validation

- red baseline assertions: both Server chart defaults reported `actual=2` when `1` was required
- `make helm-lint`
- `make helm-docs` followed by an idempotency check and `make helm-docs-check`
- `helm template` for the Server subchart and umbrella chart: default Server Deployment renders `replicas: 1` and `strategy.type: Recreate`
- packaged umbrella chart verification and render: Server Deployment renders `replicas: 1` and `strategy.type: Recreate`
- explicit `replicaCount=2` overrides still render for both charts
- `pnpm docs:build`
- `actionlint v1.7.7 .github/workflows/helm-release-test.yml`

Related to #1654.
