### PR TITLE
fix(mcp): constrain SDK to MCP 1.x

### DIFF
--- a/sdks/mcp/sandbox/python/pyproject.toml
+++ b/sdks/mcp/sandbox/python/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "mcp[cli]",
+    "mcp[cli]<2",
     "opensandbox>=0.1.10,<0.2.0",
     "starlette>=1.3.1",
     "python-multipart>=0.0.31",

--- a/sdks/mcp/sandbox/python/tests/test_package_metadata.py
+++ b/sdks/mcp/sandbox/python/tests/test_package_metadata.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from importlib.metadata import metadata
+
+
+def test_published_metadata_keeps_mcp_v1_upper_bound() -> None:
+    """Prevent releases from installing the incompatible MCP 2 API."""
+    requirements = metadata("opensandbox-mcp").get_all("Requires-Dist") or []
+    normalized = {requirement.replace(" ", "") for requirement in requirements}
+
+    assert "mcp[cli]<2" in normalized

--- a/sdks/mcp/sandbox/python/uv.lock
+++ b/sdks/mcp/sandbox/python/uv.lock
@@ -554,7 +554,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=50.0.0" },
-    { name = "mcp", extras = ["cli"] },
+    { name = "mcp", extras = ["cli"], specifier = "<2" },
     { name = "opensandbox", editable = "../../../sandbox/python" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },


### PR DESCRIPTION
# Summary
- constrain `opensandbox-mcp` to MCP 1.x while its server still imports the MCP 1.x `FastMCP` API
- synchronize the package lock metadata without upgrading unrelated dependencies
- add a regression that verifies the installed distribution keeps `Requires-Dist: mcp[cli]<2`

Refs #1718.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests: `uv run --frozen pytest tests/ -v`
- [ ] Integration tests
- [x] e2e / manual verification: built the wheel, inspected its `Requires-Dist`, installed it in an isolated environment, and verified MCP 1.x `FastMCP` imports successfully

Additional checks:
- `uv lock --check`
- `uv run --frozen ruff check`
- `uv run --frozen pyright`
- `uv build --no-sources`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (not needed; this corrects dependency metadata)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
