### PR TITLE
fix(python-sdk): reject negative sub-millisecond session timeouts

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
@@ -63,9 +63,9 @@ def _resolve_run_in_session_timeout(timeout: timedelta | None) -> int | None:
     if timeout is None:
         return None
     if isinstance(timeout, timedelta):
-        timeout_ms = int(timeout.total_seconds() * 1000)
-        if timeout_ms < 0:
+        if timeout < timedelta(0):
             raise InvalidArgumentException("timeout must be positive")
+        timeout_ms = int(timeout.total_seconds() * 1000)
         return timeout_ms
     raise InvalidArgumentException("timeout must be a datetime.timedelta or None")
 

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
@@ -58,9 +58,9 @@ def _resolve_run_in_session_timeout(timeout: timedelta | None) -> int | None:
     if timeout is None:
         return None
     if isinstance(timeout, timedelta):
-        timeout_ms = int(timeout.total_seconds() * 1000)
-        if timeout_ms < 0:
+        if timeout < timedelta(0):
             raise InvalidArgumentException("timeout must be positive")
+        timeout_ms = int(timeout.total_seconds() * 1000)
         return timeout_ms
     raise InvalidArgumentException("timeout must be a datetime.timedelta or None")
 

--- a/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
@@ -263,6 +263,22 @@ async def test_run_in_session_non_zero_exit_updates_exit_code() -> None:
     assert execution.exit_code == 7
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "timeout",
+    [timedelta(milliseconds=-1), timedelta(microseconds=-1), timedelta(microseconds=-999)],
+)
+async def test_run_in_session_rejects_negative_timeout(timeout: timedelta) -> None:
+    transport = _SseTransport()
+    cfg = ConnectionConfig(protocol="http", transport=transport)
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+    adapter = CommandsAdapter(cfg, endpoint)
+
+    with pytest.raises(InvalidArgumentException):
+        await adapter.run_in_session("sess-1", "pwd", timeout=timeout)
+    assert transport.last_request is None
+
+
 class _EarlyCloseAfterCompleteStream(httpx.AsyncByteStream):
     """Yields SSE bytes then simulates the connection closing before the
     chunked terminator arrives (regression case for #1528)."""

--- a/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
@@ -22,7 +22,7 @@ import httpx
 import pytest
 
 from opensandbox.config.connection_sync import ConnectionConfigSync
-from opensandbox.exceptions import SandboxConnectionException
+from opensandbox.exceptions import InvalidArgumentException, SandboxConnectionException
 from opensandbox.models.execd import RunCommandOpts
 from opensandbox.models.sandboxes import SandboxEndpoint
 from opensandbox.sync.adapters.command_adapter import CommandsAdapterSync
@@ -31,7 +31,11 @@ _UNICODE_SEPARATORS = "before\u0085middle\u2028middle\u2029after"
 
 
 class _SseTransport(httpx.BaseTransport):
+    def __init__(self) -> None:
+        self.last_request: httpx.Request | None = None
+
     def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.last_request = request
         body = request.content.decode("utf-8") if isinstance(request.content, (bytes, bytearray)) else ""
         payload = json.loads(body) if body else {}
 
@@ -205,6 +209,21 @@ def test_sync_run_in_session_non_zero_exit_updates_exit_code() -> None:
     assert execution.error.value == "7"
     assert execution.complete is None
     assert execution.exit_code == 7
+
+
+@pytest.mark.parametrize(
+    "timeout",
+    [timedelta(milliseconds=-1), timedelta(microseconds=-1), timedelta(microseconds=-999)],
+)
+def test_sync_run_in_session_rejects_negative_timeout(timeout: timedelta) -> None:
+    transport = _SseTransport()
+    cfg = ConnectionConfigSync(protocol="http", transport=transport)
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+    adapter = CommandsAdapterSync(cfg, endpoint)
+
+    with pytest.raises(InvalidArgumentException):
+        adapter.run_in_session("sess-1", "pwd", timeout=timeout)
+    assert transport.last_request is None
 
 
 class _EarlyCloseAfterCompleteStream(httpx.SyncByteStream):


### PR DESCRIPTION
# Summary
- Reject negative session timeouts before converting Python `timedelta` values to integer milliseconds in both async and sync adapters.
- Previously, values such as `timedelta(microseconds=-1)` and `-999` were truncated to zero and accepted. `None`, zero, and positive-value conversion remain unchanged.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests: `uv run pytest tests/test_command_service_adapter_streaming.py tests/test_sync_command_service_adapter_streaming.py -q` (24 passed; new regression cases fail before the fix).
- [ ] Integration tests
- [x] e2e / manual verification: checked unchanged conversion for `None`, zero, positive sub-millisecond, millisecond, and fractional-second values in both adapters; no live sandbox was started.
- `uv run ruff check` passed.
- `uv run pyright` passed (0 errors).
- `git diff --check` passed.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed): not needed; restores existing negative-timeout validation.
- [x] Added/updated tests (if needed)
- [x] Security impact considered: invalid negative values are rejected before an execution request is sent.
- [x] Backward compatibility considered: valid timeout conversion is unchanged.
