### PR TITLE
fix(code-interpreter): destroy sandbox when example fails

### DIFF
--- a/docs/examples/code-interpreter.md
+++ b/docs/examples/code-interpreter.md
@@ -38,7 +38,7 @@ uv pip install opensandbox opensandbox-code-interpreter
 uv run python examples/code-interpreter/main.py
 ```
 
-The script creates a Sandbox + CodeInterpreter, runs a Python code snippet and prints stdout/result, then terminates the remote instance.
+The script creates a Sandbox + CodeInterpreter, runs a Python code snippet and prints stdout/result, then terminates the remote instance. Cleanup is attempted in a `finally` block even if interpreter setup or code execution raises an exception.
 
 ## Environment variables
 

--- a/examples/code-interpreter/main.py
+++ b/examples/code-interpreter/main.py
@@ -41,7 +41,7 @@ async def main() -> None:
         entrypoint=["/opt/code-interpreter/code-interpreter.sh"]
     )
 
-    async with sandbox:
+    try:
         interpreter = await CodeInterpreter.create(sandbox=sandbox)
 
         # Python example: show runtime info and return a simple calculation.
@@ -106,7 +106,8 @@ async def main() -> None:
         if ts_exec.error:
             print(f"[TypeScript error] {ts_exec.error.name}: {ts_exec.error.value}")
 
-        await sandbox.kill()
+    finally:
+        await sandbox.destroy()
 
 
 if __name__ == "__main__":

--- a/examples/code-interpreter/test_main.py
+++ b/examples/code-interpreter/test_main.py
@@ -1,0 +1,77 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+class MainCleanupTest(unittest.TestCase):
+    def test_main_destroys_sandbox_when_interpreter_creation_fails(self) -> None:
+        destroyed = False
+
+        class FakeSandbox:
+            @classmethod
+            async def create(cls, *args, **kwargs):
+                return cls()
+
+            async def destroy(self):
+                nonlocal destroyed
+                destroyed = True
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+        class FakeCodeInterpreter:
+            @classmethod
+            async def create(cls, **kwargs):
+                raise RuntimeError("interpreter unavailable")
+
+        code_interpreter = types.ModuleType("code_interpreter")
+        code_interpreter.CodeInterpreter = FakeCodeInterpreter
+        code_interpreter.SupportedLanguage = object()
+        opensandbox = types.ModuleType("opensandbox")
+        opensandbox.Sandbox = FakeSandbox
+        config = types.ModuleType("opensandbox.config")
+        config.ConnectionConfig = lambda **kwargs: kwargs
+        with patch.dict(
+            sys.modules,
+            {
+                "code_interpreter": code_interpreter,
+                "opensandbox": opensandbox,
+                "opensandbox.config": config,
+            },
+        ):
+            spec = importlib.util.spec_from_file_location(
+                "code_interpreter_example",
+                Path(__file__).with_name("main.py"),
+            )
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+
+            with self.assertRaisesRegex(RuntimeError, "interpreter unavailable"):
+                asyncio.run(module.main())
+
+        self.assertTrue(destroyed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary
- Ensure the code-interpreter example attempts remote sandbox and local client cleanup when interpreter initialization or an example operation raises.
- Previously, `async with sandbox` only closed local clients, and an exception skipped the trailing `kill()`, leaving the remote sandbox alive until another cleanup path or expiration.
- Use the existing `Sandbox.destroy()` method in `finally`, add a standard-library fault-injection regression, and clarify cleanup behavior in the example documentation.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests: `python3 -m unittest discover -s examples/code-interpreter -p 'test_*.py' -v` passed; the same test against the original main raises the expected interpreter error and fails the cleanup assertion.
- [ ] Integration tests
- [ ] e2e / manual verification
- `ruff check examples/code-interpreter/test_main.py` and `git diff --check` passed.
- In `docs/`, `npx --yes pnpm@9.15.0 install --frozen-lockfile` and `npx --yes pnpm@9.15.0 docs:build` passed. Used the package-manager version pinned by the repository; lockfile unchanged.
- No live server or sandbox was started. The regression mocks interpreter initialization failure and checks that the example requests cleanup; backend deletion behavior is unchanged.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered: reduces remote resource retention after example failures.
- [x] Backward compatibility considered: uses the existing SDK destroy behavior without changing its API.
