### PR TITLE
docs(contributing): correct config path after entering server directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ cd server
 uv sync
 
 # Copy example configuration from the source tree
-cp server/opensandbox_server/examples/example.config.toml ~/.sandbox.toml
+cp opensandbox_server/examples/example.config.toml ~/.sandbox.toml
 
 # Edit configuration for development
 # Set [log] level = "DEBUG" and [server] api_key


### PR DESCRIPTION
# Summary
- Fix the configuration copy command in the server development quick setup.
- After the preceding `cd server`, the old source path incorrectly resolved to `server/server/opensandbox_server/examples/example.config.toml`. Remove the redundant `server/` prefix.

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification: from `server/`, confirmed the old source path is absent and the corrected path exists; copied the source to a temporary file and verified byte equality.
- `git diff --check` passed. No user configuration was overwritten and no server or Docker runtime was started.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed): no automated test needed for this command-path correction; manually verified above.
- [x] Security impact considered: no runtime or configuration behavior changes.
- [x] Backward compatibility considered
