### PR TITLE
fix(server): relay client websocket closes with a legal code

### DIFF
--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -31,7 +31,7 @@ from fastapi.responses import StreamingResponse
 from starlette.types import Receive, Scope, Send
 from starlette.websockets import WebSocketDisconnect
 from websockets.asyncio.client import ClientConnection
-from websockets.frames import EXTERNAL_CLOSE_CODES
+from websockets.frames import EXTERNAL_CLOSE_CODES, CloseCode
 from websockets.typing import Origin
 
 from opensandbox_server.api import lifecycle
@@ -431,6 +431,24 @@ def _client_websocket_close_code(code: int | None) -> int:
     return status.WS_1011_INTERNAL_ERROR
 
 
+def _backend_websocket_close_code(code: int | None) -> int:
+    """Map non-transmittable disconnect codes to a legal backend close code.
+
+    ASGI reports ``1005`` when the client closed without a status code and
+    ``1006`` when the connection dropped without a Close frame. RFC 6455 7.4.1
+    reserves both for local use, so relaying either to the backend is rejected
+    when the Close frame is serialized.
+    """
+    if code is None:
+        return status.WS_1000_NORMAL_CLOSURE
+    if code in EXTERNAL_CLOSE_CODES or 3000 <= code < 5000:
+        return code
+    if code == CloseCode.NO_STATUS_RCVD:
+        # The client did send a Close frame, it just carried no status code.
+        return status.WS_1000_NORMAL_CLOSURE
+    return status.WS_1001_GOING_AWAY
+
+
 async def _relay_client_messages(
     websocket: WebSocket,
     backend: ClientConnection,
@@ -446,12 +464,15 @@ async def _relay_client_messages(
                     await backend.send(message["bytes"])
             elif message["type"] == "websocket.disconnect":
                 await backend.close(
-                    code=message.get("code", status.WS_1000_NORMAL_CLOSURE),
+                    code=_backend_websocket_close_code(message.get("code")),
                     reason=message.get("reason") or "",
                 )
                 return
     except WebSocketDisconnect as exc:
-        await backend.close(code=exc.code, reason=getattr(exc, "reason", "") or "")
+        await backend.close(
+            code=_backend_websocket_close_code(exc.code),
+            reason=getattr(exc, "reason", "") or "",
+        )
     finally:
         cancel_scope.cancel()
 

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -168,6 +168,35 @@ class _ClosingBackendWebSocket:
         raise self._close_exception
 
 
+class _DisconnectingClientWebSocket:
+    """Client side that delivers one frame and then an ASGI ``websocket.disconnect``."""
+
+    def __init__(self, disconnect_code: int | None, reason: str = "") -> None:
+        message: dict[str, Any] = {"type": "websocket.disconnect", "reason": reason}
+        if disconnect_code is not None:
+            message["code"] = disconnect_code
+        self._messages: list[dict[str, Any]] = [
+            {"type": "websocket.receive", "text": "client-text"},
+            message,
+        ]
+
+    async def receive(self) -> dict[str, Any]:
+        return self._messages.pop(0)
+
+
+class _RecordingBackendWebSocket:
+    def __init__(self) -> None:
+        self.sent: list[str | bytes] = []
+        self.close_calls: list[tuple[int, str]] = []
+
+    async def send(self, payload: str | bytes) -> None:
+        self.sent.append(payload)
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        Close(code, reason).serialize()
+        self.close_calls.append((code, reason))
+
+
 class _RecordingClientWebSocket:
     def __init__(self) -> None:
         self.text_messages: list[str] = []
@@ -247,6 +276,66 @@ def test_client_websocket_close_code_maps_only_transmittable_codes(
     expected_code: int,
 ) -> None:
     assert proxy_api._client_websocket_close_code(backend_code) == expected_code
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("disconnect_code", "expected_code"),
+    [
+        (1000, 1000),
+        (1001, 1001),
+        (4001, 4001),
+        (None, 1000),
+        (1005, 1000),
+        (1006, 1001),
+    ],
+)
+async def test_relay_client_messages_maps_non_transmittable_disconnect_code(
+    disconnect_code: int | None,
+    expected_code: int,
+) -> None:
+    websocket = _DisconnectingClientWebSocket(disconnect_code)
+    backend = _RecordingBackendWebSocket()
+    cancelled: list[bool] = []
+    cancel_scope = SimpleNamespace(cancel=lambda: cancelled.append(True))
+
+    await asyncio.wait_for(
+        proxy_api._relay_client_messages(
+            cast(Any, websocket),
+            cast(Any, backend),
+            cast(Any, cancel_scope),
+        ),
+        timeout=0.5,
+    )
+
+    assert backend.sent == ["client-text"]
+    assert backend.close_calls == [(expected_code, "")]
+    assert cancelled == [True]
+
+
+@pytest.mark.parametrize(
+    ("client_code", "expected_code"),
+    [
+        (None, 1000),
+        (999, 1001),
+        (1000, 1000),
+        (1004, 1001),
+        (1005, 1000),
+        (1006, 1001),
+        (1011, 1011),
+        (1015, 1001),
+        (2999, 1001),
+        (3000, 3000),
+        (4001, 4001),
+        (4999, 4999),
+        (5000, 1001),
+    ],
+)
+def test_backend_websocket_close_code_maps_only_transmittable_codes(
+    client_code: int | None,
+    expected_code: int,
+) -> None:
+    assert proxy_api._backend_websocket_close_code(client_code) == expected_code
 
 
 def test_proxy_openapi_operation_ids_are_unique(client: TestClient) -> None:


### PR DESCRIPTION
# Summary

- Translate the ASGI `websocket.disconnect` code into a transmittable WebSocket close code before relaying it to the sandbox backend.
- Keep normal, application-defined and other externally valid codes exactly as the client sent them.
- Add regression tests for both the new boundary helper and the client relay loop.

## Problem

When a browser calls `ws.close()` with no status code, the Close frame it sends carries an empty payload. Uvicorn reports that to the app as `{"type": "websocket.disconnect", "code": 1005}`, and it reports a dropped connection as `1006`. RFC 6455 7.4.1 reserves both codes for local use and forbids them on the wire.

`_relay_client_messages()` in `server/opensandbox_server/api/proxy.py` passed that code straight into `backend.close()`. Serializing it fails, so `websockets` raises `ProtocolError: invalid status code`. The exception escaped the relay task, tore down the proxy task group, and came out the other side as an `Unexpected websocket proxy failure` traceback plus a `1011` close to a client that had already gone. The backend never learned why its peer disappeared, and the most common way a browser closes a WebSocket logged an error every time.

## Root cause

Two call sites relayed the raw code: the `websocket.disconnect` branch (`proxy.py:448`, `code=message.get("code", ...)`) and the `WebSocketDisconnect` handler (`proxy.py:454`, `code=exc.code`).

The mirrored direction was already fixed. `_relay_backend_messages()` runs every backend code through `_client_websocket_close_code()` before closing the client. The client-to-backend direction had no equivalent.

## Change

Add `_backend_websocket_close_code()` next to the existing helper and route both close paths through it.

- Codes in `EXTERNAL_CLOSE_CODES` and application codes `3000-4999` pass through unchanged.
- `1005` maps to `1000`: the client did send a Close frame, it just carried no status.
- Everything else reserved or out of range, including `1006` and `1015`, maps to `1001`, because from the backend's point of view the peer went away without a clean close.
- A missing code still maps to `1000`, as before.

## Testing

`_RecordingBackendWebSocket.close()` in the new tests calls `Close(code, reason).serialize()`, the same trick the existing backend-to-client test uses, so an illegal relayed code fails deterministically instead of silently passing.

- `uv run pytest tests/test_routes_proxy.py -q` gives `115 passed`. On `main` the two new relay cases fail with `websockets.exceptions.ProtocolError: invalid status code`.
- `uv run pytest -q --cov=opensandbox_server --cov-report=term --cov-fail-under=80` gives `1670 passed, 16 skipped`, total coverage `82.57%`.
- `uv run ruff check` gives `All checks passed!`.
- `uv run pyright opensandbox_server/api/proxy.py tests/test_routes_proxy.py` gives `0 errors, 0 warnings, 0 informations`.
- `./scripts/verify-license.sh` gives `License headers verified.`, and `git diff --check` is clean.
- Manual check against a real peer: I ran `_relay_client_messages()` against a live `websockets` server and fed it each disconnect code. Before the change, `1005`, `1006`, `1015` and `999` all raised `ProtocolError` and the server saw no Close frame. After it, the server observes `1000`, `1001`, `1001` and `1001`, while `1000`, `1001` and `4001` arrive unchanged.

`uv run ruff format --check` reports drift on both files, but it reports the same drift on `main`; the reformatting it wants is in unrelated lines, so this change leaves that baseline alone. CI runs `ruff check`, not `ruff format`.

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

No HTTP API, OpenAPI, SDK, config or Kubernetes change. Close codes that were already legal on the wire are relayed exactly as before; only the codes that could never be sent change.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (not needed; protocol-correctness fix with no user-visible API or config change)
- [x] Added/updated tests
- [x] Security impact considered: no new inputs, no new headers, no change to authentication or to what is forwarded
- [x] Backward compatibility considered
