### PR TITLE
fix(python-sdk): reject negative timeout in run_command

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/execution_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/execution_converter.py
@@ -22,11 +22,13 @@ similar to the Kotlin SDK ExecutionConverter.
 This converter is designed to work with openapi-python-client generated models.
 """
 
+from datetime import timedelta
 from typing import Any
 
 from opensandbox.api.execd.models.run_command_request import (
     RunCommandRequest as ApiRunCommandRequest,
 )
+from opensandbox.exceptions import InvalidArgumentException
 from opensandbox.models.execd import RunCommandOpts
 
 
@@ -59,6 +61,8 @@ class ExecutionConverter:
 
         timeout_milliseconds = UNSET
         if opts.timeout is not None:
+            if opts.timeout < timedelta(0):
+                raise InvalidArgumentException("timeout must be positive")
             timeout_milliseconds = int(opts.timeout.total_seconds() * 1000)
 
         uid = UNSET

--- a/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
@@ -209,6 +209,20 @@ async def test_run_command_rejects_blank_command() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "timeout",
+    [timedelta(milliseconds=-1), timedelta(microseconds=-1), timedelta(microseconds=-999)],
+)
+async def test_run_command_rejects_negative_timeout(timeout: timedelta) -> None:
+    cfg = ConnectionConfig(protocol="http")
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+    adapter = CommandsAdapter(cfg, endpoint)
+
+    with pytest.raises(InvalidArgumentException):
+        await adapter.run("pwd", opts=RunCommandOpts(timeout=timeout))
+
+
+@pytest.mark.asyncio
 async def test_run_command_non_200_raises_api_exception() -> None:
     transport = _SseTransport()
     cfg = ConnectionConfig(protocol="http", transport=transport)

--- a/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
@@ -22,7 +22,7 @@ import httpx
 import pytest
 
 from opensandbox.config.connection_sync import ConnectionConfigSync
-from opensandbox.exceptions import SandboxConnectionException
+from opensandbox.exceptions import InvalidArgumentException, SandboxConnectionException
 from opensandbox.models.execd import RunCommandOpts
 from opensandbox.models.sandboxes import SandboxEndpoint
 from opensandbox.sync.adapters.command_adapter import CommandsAdapterSync
@@ -120,6 +120,19 @@ class _SseTransport(httpx.BaseTransport):
             content=sse,
             request=request,
         )
+
+
+@pytest.mark.parametrize(
+    "timeout",
+    [timedelta(milliseconds=-1), timedelta(microseconds=-1), timedelta(microseconds=-999)],
+)
+def test_sync_run_command_rejects_negative_timeout(timeout: timedelta) -> None:
+    cfg = ConnectionConfigSync(protocol="http")
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+    adapter = CommandsAdapterSync(cfg, endpoint)
+
+    with pytest.raises(InvalidArgumentException):
+        adapter.run("pwd", opts=RunCommandOpts(timeout=timeout))
 
 
 def test_sync_run_command_streaming_happy_path_updates_execution() -> None:


### PR DESCRIPTION
# Summary

`RunCommandOpts.timeout` (used by `CommandsAdapter.run` / `Sandbox.run`) had no negative-timeout validation, unlike `run_in_session`'s `_resolve_run_in_session_timeout`. Negative `timedelta` values were silently converted to millisecond integers and sent to the server:

- `int(...)` truncates toward zero, so `timedelta(microseconds=-1)` became `0` ms and was sent as if no/zero timeout.
- Whole-millisecond negative durations such as `timedelta(milliseconds=-1)` were converted to `-1` ms and sent as-is.

This is the sibling of #1726 (which covers `run_in_session`) for the `run_command` path.

`ExecutionConverter.to_api_run_command_request` in `sdks/sandbox/python/src/opensandbox/adapters/converter/execution_converter.py` is shared by both the async `CommandsAdapter.run()` and the sync `CommandsAdapterSync.run()` (both call `_build_run_command_request_body`, which calls this converter), so a single check there covers both adapters without duplicating the validation per-adapter the way `_resolve_run_in_session_timeout` currently is.

Fix: reject `opts.timeout < timedelta(0)` with `InvalidArgumentException("timeout must be positive")` before converting to milliseconds, matching the pattern `_resolve_run_in_session_timeout` uses.

Fixes #1732

# Testing

- [ ] Not run (explain why)
- [x] Unit tests: `uv run pytest tests/test_command_service_adapter_streaming.py tests/test_sync_command_service_adapter_streaming.py -v` (24 passed, including 6 new parametrized regression cases covering `timedelta(milliseconds=-1)`, `timedelta(microseconds=-1)`, `timedelta(microseconds=-999)` for both adapters). Full suite: `uv run pytest tests/` (536 passed).
- [ ] Integration tests
- [x] e2e / manual verification: N/A, covered by unit tests above
- `uv run ruff check`: all checks passed.
- `uv run pyright`: 0 errors, 0 warnings.

Note: `uv run ruff format --check` currently flags ~60 pre-existing files (including two I touched) for reformatting under my locally pinned `ruff==0.14.8` — this reproduces on unmodified `main` and isn't part of the documented `ruff check`/`pyright` gate in `CONTRIBUTING.md`/`sdks/AGENTS.md`, so I left unrelated formatting untouched per the "surgical changes" guardrail rather than reformatting 60 unrelated files in this PR.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed): not needed; restores existing negative-timeout validation, matching `run_in_session`'s existing (documented) behavior.
- [x] Added/updated tests (if needed)
- [x] Security impact considered: invalid negative values are rejected client-side before an execution request is sent.
- [x] Backward compatibility considered: valid timeout conversion (`None`, zero, positive) is unchanged.

---

One heads-up: GitHub Actions isn't enabled on my fork yet (a one-time manual step outside the PR itself), so CI may not have run on this PR initially — I'll push a retrigger once it's enabled.