### PR TITLE
fix(python-sdk): bound readiness polling sleeps

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -447,11 +447,11 @@ class Sandbox:
             f"Waiting for sandbox {self.id} to pass health check (timeout: {timeout.total_seconds()}s)"
         )
 
-        deadline = time.time() + timeout.total_seconds()
+        deadline = time.monotonic() + timeout.total_seconds()
         attempt = 0
         last_exception: Exception | None = None
 
-        while time.time() < deadline:
+        while time.monotonic() < deadline:
             attempt += 1
             logger.debug(f"Health check attempt #{attempt} for sandbox {self.id}")
 
@@ -472,7 +472,10 @@ class Sandbox:
                 )
 
             if not is_healthy:
-                await asyncio.sleep(polling_interval.total_seconds())
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                await asyncio.sleep(min(polling_interval.total_seconds(), remaining))
 
         error_detail = (
             f"Last error: {last_exception}"

--- a/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
@@ -442,11 +442,11 @@ class SandboxSync:
             f"Waiting for sandbox {self.id} to pass health check (timeout: {timeout.total_seconds()}s)"
         )
 
-        deadline = time.time() + timeout.total_seconds()
+        deadline = time.monotonic() + timeout.total_seconds()
         attempt = 0
         last_exception: Exception | None = None
 
-        while time.time() < deadline:
+        while time.monotonic() < deadline:
             attempt += 1
             logger.debug(f"Health check attempt #{attempt} for sandbox {self.id}")
             try:
@@ -459,7 +459,10 @@ class SandboxSync:
             except Exception as e:
                 last_exception = e
 
-            time.sleep(polling_interval.total_seconds())
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(polling_interval.total_seconds(), remaining))
 
         error_detail = (
             f"Last error: {last_exception}"

--- a/sdks/sandbox/python/tests/test_sandbox_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_business_logic.py
@@ -166,6 +166,41 @@ async def test_check_ready_succeeds_after_retries_without_real_sleep(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_check_ready_limits_final_sleep_to_remaining_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = [0.0]
+    sleep_calls: list[float] = []
+
+    def _monotonic() -> float:
+        return clock[0]
+
+    async def _sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    async def _always_false(_: Sandbox) -> bool:
+        return False
+
+    monkeypatch.setattr("opensandbox.sandbox.time.time", _monotonic)
+    monkeypatch.setattr("opensandbox.sandbox.time.monotonic", _monotonic)
+    monkeypatch.setattr("opensandbox.sandbox.asyncio.sleep", _sleep)
+    sbx = _make_sandbox(
+        health_service=_HealthServiceStub(),
+        sandbox_service=_SandboxServiceStub(),
+        custom_health_check=_always_false,
+    )
+
+    with pytest.raises(SandboxReadyTimeoutException):
+        await sbx.check_ready(
+            timeout=timedelta(milliseconds=10),
+            polling_interval=timedelta(milliseconds=200),
+        )
+
+    assert sleep_calls == [0.01]
+
+
+@pytest.mark.asyncio
 async def test_check_ready_timeout_raises() -> None:
     async def _always_false(_: Sandbox) -> bool:
         return False

--- a/sdks/sandbox/python/tests/test_sandbox_sync_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_sync_business_logic.py
@@ -90,6 +90,83 @@ class _DiagnosticsServiceStub:
         )
 
 
+def test_sync_check_ready_limits_final_sleep_to_remaining_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = [0.0]
+    sleep_calls: list[float] = []
+
+    def _monotonic() -> float:
+        return clock[0]
+
+    def _sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr("opensandbox.sync.sandbox.time.time", _monotonic)
+    monkeypatch.setattr("opensandbox.sync.sandbox.time.monotonic", _monotonic)
+    monkeypatch.setattr("opensandbox.sync.sandbox.time.sleep", _sleep)
+    sbx = SandboxSync(
+        sandbox_id=str(uuid4()),
+        sandbox_service=_Noop(),
+        filesystem_service=_Noop(),
+        command_service=_Noop(),
+        health_service=_Noop(),
+        metrics_service=_Noop(),
+        egress_service=_EgressServiceStub(),
+        diagnostics_service=_DiagnosticsServiceStub(),
+        connection_config=ConnectionConfigSync(),
+        custom_health_check=lambda _: False,
+    )
+
+    with pytest.raises(SandboxReadyTimeoutException):
+        sbx.check_ready(
+            timeout=timedelta(milliseconds=10),
+            polling_interval=timedelta(milliseconds=200),
+        )
+
+    assert sleep_calls == [0.01]
+
+
+def test_sync_check_ready_succeeds_after_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = [0.0]
+    sleep_calls: list[float] = []
+    calls = {"n": 0}
+
+    def _monotonic() -> float:
+        return clock[0]
+
+    def _sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        clock[0] += seconds
+
+    def _healthy_after_two_failures(_: SandboxSync) -> bool:
+        calls["n"] += 1
+        return calls["n"] >= 3
+
+    monkeypatch.setattr("opensandbox.sync.sandbox.time.monotonic", _monotonic)
+    monkeypatch.setattr("opensandbox.sync.sandbox.time.sleep", _sleep)
+    sbx = SandboxSync(
+        sandbox_id=str(uuid4()),
+        sandbox_service=_Noop(),
+        filesystem_service=_Noop(),
+        command_service=_Noop(),
+        health_service=_Noop(),
+        metrics_service=_Noop(),
+        egress_service=_EgressServiceStub(),
+        diagnostics_service=_DiagnosticsServiceStub(),
+        connection_config=ConnectionConfigSync(),
+        custom_health_check=_healthy_after_two_failures,
+    )
+
+    sbx.check_ready(timeout=timedelta(seconds=1), polling_interval=timedelta(seconds=0.01))
+
+    assert calls["n"] == 3
+    assert sleep_calls == [0.01, 0.01]
+
+
 def test_sync_check_ready_timeout_message_omits_network_configuration_hints() -> None:
     def _always_false(_: SandboxSync) -> bool:
         return False


### PR DESCRIPTION
# Summary

`Sandbox.check_ready()` and `SandboxSync.check_ready()` sleep for the full polling interval after an unsuccessful health check, even when the readiness timeout has almost expired. A 10 ms timeout with a 200 ms polling interval therefore takes about 200 ms to fail.

This change uses monotonic deadlines, recalculates the remaining budget after each unsuccessful check, and limits the next delay to that budget. It preserves the health-check call, success path, timeout exception and message, and public signatures. An in-flight custom health check is still not cancelled; only the polling delay is bounded.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests: both sandbox business-logic files, 35 passed
- [ ] Integration tests
- [x] e2e / manual verification: async and sync reproduction improved from about 203 ms to 15–16 ms
- Full non-Redis Python SDK suite: 516 passed; the two optional Redis tests were excluded because Redis is unavailable
- Changed-file Ruff, source-file Pyright, `uv build --offline`, and `git diff --check`

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed): existing behavior description remains accurate
- [x] Added/updated tests (if needed)
- [x] Security impact considered: no security boundary changes
- [x] Backward compatibility considered: retry and timeout behavior remain compatible
