### PR TITLE
fix(kubernetes): fail sandbox when main container terminates without restart

### DIFF
--- a/docs/kubernetes/index.md
+++ b/docs/kubernetes/index.md
@@ -533,7 +533,7 @@ For a BatchSandbox with multiple replicas, `Succeed` also does not mean that eve
 | `Pausing` | A pause operation is in progress. |
 | `Paused` | The sandbox is paused and its runtime resources have been released. |
 | `Resuming` | The controller is restoring runtime resources after a pause. |
-| `Failed` | The controller detected a terminal sandbox runtime failure. A Pod in Kubernetes phase `Failed` is terminal; inspect conditions and Pod events for details. |
+| `Failed` | The controller detected a terminal sandbox runtime failure. A Pod in Kubernetes phase `Failed` is terminal; inspect conditions and Pod events for details. A Pod still in phase `Running` is also treated as terminal when its restart policy is `Never` and its main container (the first container in the Pod spec) has exited with a non-zero code — for example when a sidecar keeps the Pod running after the sandbox main process crashed. |
 
 The controller records active conditions with `status: "True"`:
 

--- a/kubernetes/internal/controller/batchsandbox_pause_resume_test.go
+++ b/kubernetes/internal/controller/batchsandbox_pause_resume_test.go
@@ -1853,6 +1853,119 @@ func TestBuildRuntimeView_MarksTerminalInitContainerFailure(t *testing.T) {
 	t.Fatal("expected PodFailed condition")
 }
 
+func TestBuildRuntimeView_MarksTerminatedMainContainerFailureWhilePodRunning(t *testing.T) {
+	// restartPolicy=Never multi-container pod: the main container (containers[0],
+	// by server convention the "sandbox" container) exits non-zero while an egress
+	// sidecar keeps the pod Running forever. The sandbox must fail instead of
+	// regressing to Pending (the pod phase will never become Failed).
+	bs := &sandboxv1alpha1.BatchSandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-bs", Namespace: "default"},
+		Status:     sandboxv1alpha1.BatchSandboxStatus{Phase: sandboxv1alpha1.BatchSandboxPhaseSucceed},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbx-0", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{Name: "sandbox"},
+				{Name: "egress"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "sandbox",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 1,
+						Reason:   "Error",
+						Message:  "main process crashed",
+					}},
+				},
+				{
+					Name:  "egress",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+			},
+		},
+	}
+
+	view := buildRuntimeView(bs, []*corev1.Pod{pod})
+
+	assert.Equal(t, sandboxv1alpha1.BatchSandboxPhaseFailed, view.status.Phase)
+	for i := range view.status.Conditions {
+		condition := view.status.Conditions[i]
+		if condition.Type != sandboxv1alpha1.BatchSandboxConditionPodFailed {
+			continue
+		}
+		assert.Equal(t, sandboxv1alpha1.ConditionTrue, condition.Status)
+		assert.Equal(t, "ContainerFailed", condition.Reason)
+		assert.Equal(
+			t,
+			"1/1 observed pods failed; primary reason=ContainerFailed; sample pod=sbx-0",
+			condition.Message,
+		)
+		return
+	}
+	t.Fatal("expected PodFailed condition")
+}
+
+func TestBuildRuntimeView_TerminatedMainContainerWithRestartablePolicyIsNotTerminal(t *testing.T) {
+	// With the default (Always) restart policy the kubelet restarts a terminated
+	// main container; a transient termination must not brick the sandbox in the
+	// sticky Failed phase. Same pod as above but restart policy left unset.
+	tests := []struct {
+		name          string
+		restartPolicy corev1.RestartPolicy
+	}{
+		{name: "unset defaults to Always", restartPolicy: ""},
+		{name: "Always", restartPolicy: corev1.RestartPolicyAlways},
+		{name: "OnFailure restarts on non-zero exit", restartPolicy: corev1.RestartPolicyOnFailure},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bs := &sandboxv1alpha1.BatchSandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-bs", Namespace: "default"},
+				Status:     sandboxv1alpha1.BatchSandboxStatus{Phase: sandboxv1alpha1.BatchSandboxPhaseSucceed},
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "sbx-0", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					RestartPolicy: tt.restartPolicy,
+					Containers: []corev1.Container{
+						{Name: "sandbox"},
+						{Name: "egress"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "sandbox",
+							State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+								Reason:   "Error",
+							}},
+						},
+						{
+							Name:  "egress",
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			}
+
+			view := buildRuntimeView(bs, []*corev1.Pod{pod})
+
+			assert.NotEqual(t, sandboxv1alpha1.BatchSandboxPhaseFailed, view.status.Phase,
+				"restartable policies must not treat the termination as terminal")
+			for i := range view.status.Conditions {
+				assert.NotEqual(t, sandboxv1alpha1.BatchSandboxConditionPodFailed, view.status.Conditions[i].Type)
+			}
+		})
+	}
+}
+
 func TestBuildRuntimeView_InitialRetryablePodStatesRemainPending(t *testing.T) {
 	tests := []struct {
 		name string

--- a/kubernetes/internal/controller/batchsandbox_pause_resume_test.go
+++ b/kubernetes/internal/controller/batchsandbox_pause_resume_test.go
@@ -1966,6 +1966,56 @@ func TestBuildRuntimeView_TerminatedMainContainerWithRestartablePolicyIsNotTermi
 	}
 }
 
+func TestBuildRuntimeView_TerminatingPodIsNotMainContainerTerminalFailure(t *testing.T) {
+	// Deletion, eviction, or node drain signal-kills the main container while the
+	// pod still exists (deletionTimestamp set, sidecar winding down). The signal
+	// exit must not record a sticky terminal failure that would block the
+	// replacement of the deleted pod.
+	now := metav1.Now()
+	bs := &sandboxv1alpha1.BatchSandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-bs", Namespace: "default"},
+		Status:     sandboxv1alpha1.BatchSandboxStatus{Phase: sandboxv1alpha1.BatchSandboxPhaseSucceed},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sbx-0",
+			Namespace:         "default",
+			DeletionTimestamp: &now,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{Name: "sandbox"},
+				{Name: "egress"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "sandbox",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 137,
+						Reason:   "Error",
+					}},
+				},
+				{
+					Name:  "egress",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+			},
+		},
+	}
+
+	view := buildRuntimeView(bs, []*corev1.Pod{pod})
+
+	assert.NotEqual(t, sandboxv1alpha1.BatchSandboxPhaseFailed, view.status.Phase,
+		"terminating pods must not turn into a sticky terminal failure")
+	for i := range view.status.Conditions {
+		assert.NotEqual(t, sandboxv1alpha1.BatchSandboxConditionPodFailed, view.status.Conditions[i].Type)
+	}
+}
+
 func TestBuildRuntimeView_InitialRetryablePodStatesRemainPending(t *testing.T) {
 	tests := []struct {
 		name string

--- a/kubernetes/internal/controller/batchsandbox_status.go
+++ b/kubernetes/internal/controller/batchsandbox_status.go
@@ -167,9 +167,14 @@ func getTerminalPodFailureReasonAndMessage(pod *corev1.Pod) (string, string, boo
 // terminatedMainContainerFailure reports whether the sandbox's main container
 // terminated with a non-zero exit code under a restart policy that will not
 // restart it (Never). RestartPolicyAlways and RestartPolicyOnFailure pods are
-// excluded because the kubelet restarts the container instead.
+// excluded because the kubelet restarts the container instead. Pods that are
+// already terminating are excluded too: deletion, eviction, or node drain may
+// signal-kill the main container, and the resulting non-zero exit must not turn
+// into a sticky terminal failure that blocks replacement of the deleted pod.
 func terminatedMainContainerFailure(pod *corev1.Pod) (string, string, bool) {
-	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever || len(pod.Spec.Containers) == 0 {
+	if pod.DeletionTimestamp != nil ||
+		pod.Spec.RestartPolicy != corev1.RestartPolicyNever ||
+		len(pod.Spec.Containers) == 0 {
 		return "", "", false
 	}
 	mainName := pod.Spec.Containers[0].Name

--- a/kubernetes/internal/controller/batchsandbox_status.go
+++ b/kubernetes/internal/controller/batchsandbox_status.go
@@ -130,28 +130,57 @@ func getPodFailureReasonAndMessage(pod *corev1.Pod) (string, string, bool) {
 }
 
 func getTerminalPodFailureReasonAndMessage(pod *corev1.Pod) (string, string, bool) {
-	if pod.Status.Phase != corev1.PodFailed {
-		return "", "", false
-	}
-	for i := range pod.Status.InitContainerStatuses {
-		if reason, message, failed := terminatedContainerFailure(pod, &pod.Status.InitContainerStatuses[i], true); failed {
-			return reason, message, true
+	if pod.Status.Phase == corev1.PodFailed {
+		for i := range pod.Status.InitContainerStatuses {
+			if reason, message, failed := terminatedContainerFailure(pod, &pod.Status.InitContainerStatuses[i], true); failed {
+				return reason, message, true
+			}
 		}
-	}
-	for i := range pod.Status.ContainerStatuses {
-		if reason, message, failed := terminatedContainerFailure(pod, &pod.Status.ContainerStatuses[i], false); failed {
-			return reason, message, true
+		for i := range pod.Status.ContainerStatuses {
+			if reason, message, failed := terminatedContainerFailure(pod, &pod.Status.ContainerStatuses[i], false); failed {
+				return reason, message, true
+			}
 		}
+
+		message := fmt.Sprintf("Pod %s entered Failed phase", pod.Name)
+		if pod.Status.Reason != "" {
+			message += fmt.Sprintf(" (%s)", pod.Status.Reason)
+		}
+		if pod.Status.Message != "" {
+			message += ": " + pod.Status.Message
+		}
+		return terminalPodFailedReason, message, true
 	}
 
-	message := fmt.Sprintf("Pod %s entered Failed phase", pod.Name)
-	if pod.Status.Reason != "" {
-		message += fmt.Sprintf(" (%s)", pod.Status.Reason)
+	// A Running pod can be terminal even before Kubernetes flips its phase: when
+	// the restart policy is Never and the main container (the first regular
+	// container, matching the server-side convention) has already terminated with
+	// a non-zero exit code, no restart will bring the sandbox runtime back.
+	// This matters for multi-container pods (for example an egress sidecar keeps
+	// the pod Running) that would otherwise never reach the PodFailed phase.
+	if reason, message, failed := terminatedMainContainerFailure(pod); failed {
+		return reason, message, true
 	}
-	if pod.Status.Message != "" {
-		message += ": " + pod.Status.Message
+	return "", "", false
+}
+
+// terminatedMainContainerFailure reports whether the sandbox's main container
+// terminated with a non-zero exit code under a restart policy that will not
+// restart it (Never). RestartPolicyAlways and RestartPolicyOnFailure pods are
+// excluded because the kubelet restarts the container instead.
+func terminatedMainContainerFailure(pod *corev1.Pod) (string, string, bool) {
+	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever || len(pod.Spec.Containers) == 0 {
+		return "", "", false
 	}
-	return terminalPodFailedReason, message, true
+	mainName := pod.Spec.Containers[0].Name
+	for i := range pod.Status.ContainerStatuses {
+		status := &pod.Status.ContainerStatuses[i]
+		if status.Name != mainName {
+			continue
+		}
+		return terminatedContainerFailure(pod, status, false)
+	}
+	return "", "", false
 }
 
 func terminatedContainerFailure(pod *corev1.Pod, status *corev1.ContainerStatus, initContainer bool) (string, string, bool) {


### PR DESCRIPTION
## Problem

When a BatchSandbox pod's main container exits with a non-zero code while the pod stays in Kubernetes phase `Running` (e.g. an egress sidecar keeps the pod alive under `restartPolicy: Never`, so the pod can never reach phase `Failed`), the controller does not detect a terminal failure. With `status.Ready` at 0 and no failure classified, `applySteadyRuntimePhase` regresses the sandbox phase from `Succeed` back to `Pending` instead of `Failed`.

## Fix

`getTerminalPodFailureReasonAndMessage` now treats a non-zero termination of the sandbox's main container — the first regular container (`spec.containers[0]`, the server-side convention: main `sandbox` container with `execd-installer` as an init container and `egress` appended last) — as terminal when `restartPolicy: Never` will not restart it, even while the pod is still `Running`.

`Always`/`OnFailure` pods are excluded: the kubelet restarts the container there, and a transient termination must not brick the sandbox in the sticky `Failed` phase. The existing `PodFailed` condition reason `ContainerFailed` is reused, so the terminal-failure condition gate and server-side phase mapping are unaffected.

## Verification

- New unit tests: Running pod + terminated main container under `Never` → `Failed`; same pod under `""`/`Always`/`OnFailure` → not terminal.
- Existing terminal-failure / pause-resume unit tests pass.
- Docs updated (`docs/kubernetes/index.md` `Failed` phase row).