### PR TITLE
docs: mark this fork as patch-only (opened on the wrong repository)

### DIFF
--- a/OBJECTIVE_FORK.md
+++ b/OBJECTIVE_FORK.md
@@ -1,0 +1,10 @@
+# Objective patch branch
+
+This branch is **committer-skip-sidecar** on `DotModus/OpenSandbox`.
+
+- Base tag: `k8s/image-committer/v0.1.1`
+- Concern: Skip or tolerate egress sidecar commit in image-committer. Restore uses the sandbox image only.
+- Inventory: `objective_infrastructure` `docs/opensandbox/maintenance/evidence/fork-inventory.md`
+
+Do not merge upstream `main`. Do not add unrelated OpenSandbox work.
+Product source for this patch is not landed yet (Phase 3 hygiene only).


### PR DESCRIPTION
Opened against the wrong repository by mistake and closed immediately. This change was never intended for upstream; it is a note in a downstream fork.

No upstream review is needed. Apologies for the noise.