### PR TITLE
fix(sdk/go): bound readiness polling sleeps

### DIFF
--- a/sdks/sandbox/go/sandbox.go
+++ b/sdks/sandbox/go/sandbox.go
@@ -369,10 +369,16 @@ func (s *Sandbox) WaitUntilReady(ctx context.Context, opts ReadyOptions) error {
 			return nil
 		}
 
+		// Clamp the sleep to the remaining budget so the final failed check
+		// does not overshoot the timeout by a full polling interval.
+		wait := interval
+		if remaining := time.Until(deadline); remaining < wait {
+			wait = remaining
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(interval):
+		case <-time.After(wait):
 		}
 	}
 

--- a/sdks/sandbox/go/sandbox_wait_running_test.go
+++ b/sdks/sandbox/go/sandbox_wait_running_test.go
@@ -97,3 +97,22 @@ func TestWaitUntilReady_RespectsContextCancellationDuringBackoff(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.LessOrEqual(t, elapsed, 500*time.Millisecond, "WaitUntilReady should stop quickly on ctx cancel")
 }
+
+func TestWaitUntilReady_TimeoutDoesNotOvershootByPollingInterval(t *testing.T) {
+	sb := &Sandbox{id: "sbx-ready-timeout"}
+
+	start := time.Now()
+	err := sb.WaitUntilReady(context.Background(), ReadyOptions{
+		Timeout:         20 * time.Millisecond,
+		PollingInterval: 2 * time.Second,
+		HealthCheck: func(context.Context, *Sandbox) (bool, error) {
+			return false, nil
+		},
+	})
+	elapsed := time.Since(start)
+
+	var timeoutErr *SandboxReadyTimeoutError
+	require.ErrorAs(t, err, &timeoutErr)
+	require.Equal(t, "20ms", timeoutErr.Elapsed)
+	require.LessOrEqual(t, elapsed, 500*time.Millisecond, "final sleep must be clamped to the remaining timeout budget")
+}


### PR DESCRIPTION
# Summary
- Go part of #1739. `WaitUntilReady` slept a full `PollingInterval` after every failed health check even when less time remained in the timeout budget, so with `Timeout=20ms` / `PollingInterval=2s` a never-ready sandbox took ~2s to return `SandboxReadyTimeoutError` instead of ~20ms.
- Clamp the sleep to `time.Until(deadline)` (same approach as the Python fix in #1734). The Go deadline comparison was already monotonic-safe since `time.Now()` carries a monotonic reading, so only the sleep needed bounding. Public signature, success path, and the `SandboxReadyTimeoutError` fields (`Elapsed` still reports the configured timeout) are unchanged.
- go.mod targets Go 1.20, so the clamp is written without the builtin `min`.

Kotlin / JS / C# loops from the issue are left for separate PRs.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Added `TestWaitUntilReady_TimeoutDoesNotOvershootByPollingInterval` (timeout 20ms, interval 2s, health check always false). Before the fix it fails with `expected 2.00014075s <= 500ms`; after the fix it completes in 0.02s. `go vet ./...` and `go test -race ./...` pass in `sdks/sandbox/go`.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
