### PR TITLE
fix(javascript): bound readiness polling sleeps

### DIFF
--- a/sdks/sandbox/javascript/src/sandbox.ts
+++ b/sdks/sandbox/javascript/src/sandbox.ts
@@ -803,11 +803,7 @@ export class Sandbox {
     // Wait until execd becomes reachable and passes health check.
     while (true) {
       throwIfAborted(opts.signal);
-      if (Date.now() > deadline) {
-        throw new SandboxReadyTimeoutException({
-          message: buildTimeoutMessage(),
-        });
-      }
+      if (Date.now() > deadline) break;
       attempt++;
       try {
         if (opts.healthCheck) {
@@ -829,7 +825,14 @@ export class Sandbox {
         const message = err instanceof Error ? err.message : String(err);
         errorDetail = `Last health check error: ${message}`;
       }
-      await sleep(opts.pollingIntervalMillis, opts.signal);
+      // Clamp the sleep to the remaining budget so the final failed check
+      // does not overshoot the timeout by a full polling interval.
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await sleep(Math.min(opts.pollingIntervalMillis, remaining), opts.signal);
     }
+    throw new SandboxReadyTimeoutException({
+      message: buildTimeoutMessage(),
+    });
   }
 }

--- a/sdks/sandbox/javascript/src/sandbox.ts
+++ b/sdks/sandbox/javascript/src/sandbox.ts
@@ -803,7 +803,7 @@ export class Sandbox {
     // Wait until execd becomes reachable and passes health check.
     while (true) {
       throwIfAborted(opts.signal);
-      if (Date.now() > deadline) break;
+      if (Date.now() >= deadline) break;
       attempt++;
       try {
         if (opts.healthCheck) {

--- a/sdks/sandbox/javascript/tests/sandbox.create.test.mjs
+++ b/sdks/sandbox/javascript/tests/sandbox.create.test.mjs
@@ -597,6 +597,39 @@ test("Sandbox.create readiness timeout omits network configuration hints", async
   );
 });
 
+test("Sandbox.create readiness timeout does not overshoot by a polling interval", async () => {
+  const { adapterFactory } = createAdapterFactory();
+  adapterFactory.createExecdStack = () => ({
+    commands: {},
+    files: {},
+    health: {
+      async ping() {
+        return false;
+      },
+    },
+    metrics: {},
+  });
+
+  const connectionConfig = new ConnectionConfig({
+    domain: "http://127.0.0.1:8080",
+    disableMetrics: true,
+  });
+
+  const started = Date.now();
+  await assert.rejects(
+    Sandbox.create({
+      adapterFactory,
+      connectionConfig,
+      image: "python:3.12",
+      readyTimeoutSeconds: 0.02,
+      healthCheckPollingInterval: 2000,
+    }),
+    /Sandbox health check timed out after 0\.02s/
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(elapsed < 500, `expected timeout in ~20ms, took ${elapsed}ms`);
+});
+
 test("Sandbox.create metrics synchronous throw does not change create error", async () => {
   // Regression test: previously, payload/URL/headers construction and
   // `connectionConfig.fetch(...)` ran outside any try/catch in the reporter.


### PR DESCRIPTION
# Summary
- JavaScript part of #1739. `waitUntilReady` slept a full `pollingIntervalMillis` after every failed health check even when less time remained in the timeout budget, so with `readyTimeoutSeconds=0.02` / `healthCheckPollingInterval=2000` a never-ready sandbox took ~2s to reject with `SandboxReadyTimeoutException` instead of ~20ms.
- After an unsuccessful check, sleep `min(pollingIntervalMillis, deadline - now)` and exit the loop once the budget is exhausted (same approach as the Python fix in #1734). The two exit points now share one `throw`, so the timeout message, attempt count, and abort behavior are unchanged.

Go SDK: #1744. Kotlin / C# are left for separate PRs.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Added `Sandbox.create readiness timeout does not overshoot by a polling interval` in `tests/sandbox.create.test.mjs` (ping always returns false, timeout 20ms, interval 2s). Before the fix: `expected timeout in ~20ms, took 2003ms`; after: passes in ~22ms. `pnpm run lint`, `pnpm run typecheck`, and `pnpm run test` (129/129) pass in `sdks/sandbox/javascript`.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
