### PR TITLE
perf(execd): avoid rereading unfinished command output

### DIFF
--- a/components/execd/pkg/runtime/command_common.go
+++ b/components/execd/pkg/runtime/command_common.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sync"
 	"time"
 
 	"github.com/alibaba/opensandbox/internal/safego"
@@ -40,20 +39,17 @@ var legacyCommandOutputPattern = regexp.MustCompile(`^[0-9a-f]{32}\.(stdout|stde
 
 // tailStdPipe streams appended log data until the process finishes.
 func (c *Controller) tailStdPipe(file string, onExecute func(text string), done <-chan struct{}) {
-	lastPos := int64(0)
+	var tail commandOutputTail
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
-	mutex := &sync.Mutex{}
-	var lastWasCR bool
 	for {
 		select {
 		case <-done:
-			c.readFromPos(mutex, file, lastPos, onExecute, true, &lastWasCR)
+			tail.read(file, onExecute, true)
 			return
 		case <-ticker.C:
-			newPos := c.readFromPos(mutex, file, lastPos, onExecute, false, &lastWasCR)
-			lastPos = newPos
+			tail.read(file, onExecute, false)
 		}
 	}
 }
@@ -243,75 +239,56 @@ func (c *Controller) StartCommandOutputJanitor(ctx context.Context) error {
 	return nil
 }
 
-// readFromPos streams new content from a file starting at startPos.
-// lastWasCR persists CRLF detection across calls so a \r\n pair split between
-// two polls does not surface a spurious blank line for the trailing \n.
-func (c *Controller) readFromPos(mutex *sync.Mutex, filepath string, startPos int64, onExecute func(string), flushIncomplete bool, lastWasCR *bool) int64 {
-	if !mutex.TryLock() {
-		return -1
-	}
-	defer mutex.Unlock()
+// commandOutputTail retains an unfinished line while reading only appended bytes.
+// Each stdout/stderr tail goroutine owns its own state.
+type commandOutputTail struct {
+	offset    int64
+	pending   bytes.Buffer
+	lastWasCR bool
+}
 
-	file, err := os.Open(filepath)
+func (t *commandOutputTail) read(path string, onExecute func(string), flushIncomplete bool) {
+	file, err := os.Open(path)
 	if err != nil {
-		return startPos
+		return
 	}
 	defer file.Close()
 
-	_, _ = file.Seek(startPos, 0) //nolint:errcheck
+	if _, err := file.Seek(t.offset, io.SeekStart); err != nil {
+		return
+	}
 
 	reader := bufio.NewReader(file)
-	var buffer bytes.Buffer
-	var currentPos int64 = startPos
-	cr := false
-	if lastWasCR != nil {
-		cr = *lastWasCR
-	}
-	defer func() {
-		if lastWasCR != nil {
-			*lastWasCR = cr
-		}
-	}()
-
 	for {
 		b, err := reader.ReadByte()
 		if err != nil {
-			if err == io.EOF {
-				// If buffer has content but no newline, flush if needed, otherwise wait for next read
-				if flushIncomplete && buffer.Len() > 0 {
-					onExecute(buffer.String())
-					buffer.Reset()
-				}
+			if err == io.EOF && flushIncomplete && t.pending.Len() > 0 {
+				onExecute(t.pending.String())
+				t.pending.Reset()
 			}
 			break
 		}
-		currentPos++
+		t.offset++
 
-		// Check if it's a line terminator (\n or \r)
 		if b == '\n' || b == '\r' {
 			switch {
-			case buffer.Len() > 0:
-				// Flush the line content without the terminator
-				onExecute(buffer.String())
-				buffer.Reset()
-			case b == '\n' && cr:
-				// Second half of a \r\n pair; already emitted on \r
+			case t.pending.Len() > 0:
+				onExecute(t.pending.String())
+				t.pending.Reset()
+			case b == '\n' && t.lastWasCR:
+				// The preceding CR already emitted this line.
 			default:
-				// Standalone blank line; surface it so callers see the gap
 				onExecute("\n")
 			}
-			cr = (b == '\r')
+			t.lastWasCR = b == '\r'
 			continue
 		}
 
-		cr = false
-		buffer.WriteByte(b)
+		t.lastWasCR = false
+		t.pending.WriteByte(b)
 	}
-
-	endPos, _ := file.Seek(0, 1)
-	// If the last read position doesn't end with a newline, return buffer start position and wait for next flush
-	if !flushIncomplete && buffer.Len() > 0 {
-		return currentPos - int64(buffer.Len())
+	// Reuse storage within a poll, but release completed long lines between polls.
+	if t.pending.Len() == 0 {
+		t.pending = bytes.Buffer{}
 	}
-	return endPos
 }

--- a/components/execd/pkg/runtime/command_common.go
+++ b/components/execd/pkg/runtime/command_common.go
@@ -290,5 +290,8 @@ func (t *commandOutputTail) read(path string, onExecute func(string), flushIncom
 	// Reuse storage within a poll, but release completed long lines between polls.
 	if t.pending.Len() == 0 {
 		t.pending = bytes.Buffer{}
+	} else if t.pending.Cap() > 4096 && t.pending.Len() < t.pending.Cap()/2 {
+		// Keep a short trailing fragment without retaining a completed long line's storage.
+		t.pending = *bytes.NewBuffer(bytes.Clone(t.pending.Bytes()))
 	}
 }

--- a/components/execd/pkg/runtime/command_tail_bench_test.go
+++ b/components/execd/pkg/runtime/command_tail_bench_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// One operation is an idle poll after a 1 MiB unterminated line was primed.
+func BenchmarkCommandOutputIdlePollAfterStatic1MiB(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "stdout.log")
+	content := bytes.Repeat([]byte{'x'}, 1<<20)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		b.Fatal(err)
+	}
+
+	var tail commandOutputTail
+	tail.read(path, func(string) {
+		b.Fatal("unterminated output emitted without a flush")
+	}, false)
+	if tail.offset != int64(len(content)) {
+		b.Fatalf("prime position = %d, want %d", tail.offset, len(content))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tail.read(path, func(string) {
+			b.Fatal("unterminated output emitted without a flush")
+		}, false)
+	}
+	b.StopTimer()
+	if tail.offset != int64(len(content)) {
+		b.Fatalf("final position = %d, want %d", tail.offset, len(content))
+	}
+}
+
+// One operation is 16 polls after 64 KiB appends, followed by a terminating
+// newline and one final poll. File writes are excluded from ns/op.
+func BenchmarkCommandOutputGrowing1MiBLine(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "stdout.log")
+	file, err := os.Create(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer file.Close()
+
+	const (
+		appendCount = 16
+		appendSize  = 64 << 10
+	)
+	chunk := bytes.Repeat([]byte{'x'}, appendSize)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		if err := file.Truncate(0); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := file.Seek(0, 0); err != nil {
+			b.Fatal(err)
+		}
+		var tail commandOutputTail
+		lines, outputBytes := 0, 0
+
+		for j := 0; j < appendCount; j++ {
+			if _, err := file.Write(chunk); err != nil {
+				b.Fatal(err)
+			}
+			b.StartTimer()
+			tail.read(path, func(s string) {
+				lines++
+				outputBytes += len(s)
+			}, false)
+			b.StopTimer()
+		}
+		if _, err := file.Write([]byte{'\n'}); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		tail.read(path, func(s string) {
+			lines++
+			outputBytes += len(s)
+		}, false)
+		b.StopTimer()
+
+		if want := int64(appendCount*appendSize + 1); tail.offset != want {
+			b.Fatalf("final position = %d, want %d", tail.offset, want)
+		}
+		if lines != 1 || outputBytes != appendCount*appendSize {
+			b.Fatalf("output = %d lines/%d bytes, want 1 line/%d bytes", lines, outputBytes, appendCount*appendSize)
+		}
+	}
+}
+
+// One operation reads a static batch of 100 ordinary short lines.
+func BenchmarkCommandOutputShortLines100(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "stdout.log")
+	const line = "short output line"
+	content := bytes.Repeat([]byte(line+"\n"), 100)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		b.Fatal(err)
+	}
+
+	var pos int64
+	var lines, outputBytes int
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		lines, outputBytes = 0, 0
+		var tail commandOutputTail
+		tail.read(path, func(s string) {
+			lines++
+			outputBytes += len(s)
+		}, false)
+		pos = tail.offset
+	}
+	b.StopTimer()
+	if pos != int64(len(content)) {
+		b.Fatalf("final position = %d, want %d", pos, len(content))
+	}
+	if lines != 100 || outputBytes != 100*len(line) {
+		b.Fatalf("output = %d lines/%d bytes, want 100 lines/%d bytes", lines, outputBytes, 100*len(line))
+	}
+}

--- a/components/execd/pkg/runtime/command_test.go
+++ b/components/execd/pkg/runtime/command_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -30,18 +29,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReadFromPos_SplitsOnCRAndLF(t *testing.T) {
+func TestCommandOutputTail_SplitsOnCRAndLF(t *testing.T) {
 	tmp := t.TempDir()
 	logFile := filepath.Join(tmp, "stdout.log")
-
-	mutex := &sync.Mutex{}
 
 	initial := "line1\nprog 10%\rprog 20%\rprog 30%\nlast\n"
 	require.NoError(t, os.WriteFile(logFile, []byte(initial), 0o644))
 
 	var got []string
-	c := &Controller{}
-	nextPos := c.readFromPos(mutex, logFile, 0, func(s string) { got = append(got, s) }, false, nil)
+	var tail commandOutputTail
+	tail.read(logFile, func(s string) { got = append(got, s) }, false)
 
 	want := []string{"line1", "prog 10%", "prog 20%", "prog 30%", "last"}
 	require.Len(t, got, len(want))
@@ -58,7 +55,7 @@ func TestReadFromPos_SplitsOnCRAndLF(t *testing.T) {
 	_ = f.Close()
 
 	got = got[:0]
-	c.readFromPos(mutex, logFile, nextPos, func(s string) { got = append(got, s) }, false, nil)
+	tail.read(logFile, func(s string) { got = append(got, s) }, false)
 	want = []string{"tail1", "tail2"}
 	require.Len(t, got, len(want))
 	for i := range want {
@@ -66,7 +63,7 @@ func TestReadFromPos_SplitsOnCRAndLF(t *testing.T) {
 	}
 }
 
-func TestReadFromPos_LongLine(t *testing.T) {
+func TestCommandOutputTail_LongLine(t *testing.T) {
 	tmp := t.TempDir()
 	logFile := filepath.Join(tmp, "stdout.log")
 
@@ -75,38 +72,40 @@ func TestReadFromPos_LongLine(t *testing.T) {
 	require.NoError(t, os.WriteFile(logFile, []byte(longLine), 0o644))
 
 	var got []string
-	c := &Controller{}
-	c.readFromPos(&sync.Mutex{}, logFile, 0, func(s string) { got = append(got, s) }, false, nil)
+	var tail commandOutputTail
+	tail.read(logFile, func(s string) { got = append(got, s) }, false)
 
 	require.Len(t, got, 1, "expected one token")
 	require.Equal(t, strings.TrimSuffix(longLine, "\n"), got[0], "long line mismatch")
 }
 
-func TestReadFromPos_FlushesTrailingLine(t *testing.T) {
+func TestCommandOutputTail_FlushesTrailingLine(t *testing.T) {
 	tmpDir := t.TempDir()
 	file := filepath.Join(tmpDir, "stdout.log")
 	content := []byte("line1\nlastline-without-newline")
 	err := os.WriteFile(file, content, 0o644)
 	assert.NoError(t, err)
 
-	c := NewController("", "")
-	mutex := &sync.Mutex{}
+	var tail commandOutputTail
 	var lines []string
 	onExecute := func(text string) {
 		lines = append(lines, text)
 	}
 
 	// First read: should only get complete lines with newlines
-	pos := c.readFromPos(mutex, file, 0, onExecute, false, nil)
-	assert.GreaterOrEqual(t, pos, int64(0))
+	tail.read(file, onExecute, false)
+	assert.Equal(t, int64(len(content)), tail.offset)
 	assert.Equal(t, []string{"line1"}, lines)
 
 	// Flush at end: should output the last line (without newline)
-	c.readFromPos(mutex, file, pos, onExecute, true, nil)
+	tail.read(file, onExecute, true)
 	assert.Equal(t, []string{"line1", "lastline-without-newline"}, lines)
+	tail.read(file, onExecute, true)
+	assert.Len(t, lines, 2, "final flush must not duplicate output")
+	assert.Zero(t, tail.pending.Cap())
 }
 
-func TestReadFromPos_PreservesBlankLines(t *testing.T) {
+func TestCommandOutputTail_PreservesBlankLines(t *testing.T) {
 	tmp := t.TempDir()
 	logFile := filepath.Join(tmp, "stdout.log")
 
@@ -115,29 +114,30 @@ func TestReadFromPos_PreservesBlankLines(t *testing.T) {
 	require.NoError(t, os.WriteFile(logFile, []byte(initial), 0o644))
 
 	var got []string
-	c := &Controller{}
-	c.readFromPos(&sync.Mutex{}, logFile, 0, func(s string) { got = append(got, s) }, false, nil)
+	var tail commandOutputTail
+	tail.read(logFile, func(s string) { got = append(got, s) }, false)
 
 	want := []string{"a", "\n", "b", "\n", "\n", "c", "\n", "d"}
 	require.Equal(t, want, got)
 }
 
-// TestReadFromPos_CRLFAcrossPolls ensures a \r\n pair that arrives in two
+// TestCommandOutputTail_CRLFAcrossPolls ensures a \r\n pair that arrives in two
 // successive polls does not emit a spurious blank line for the trailing \n.
 // Reproduces the regression on Windows/cmd writers that flush \r before \n.
-func TestReadFromPos_CRLFAcrossPolls(t *testing.T) {
+func TestCommandOutputTail_CRLFAcrossPolls(t *testing.T) {
 	tmp := t.TempDir()
 	logFile := filepath.Join(tmp, "stdout.log")
 
 	require.NoError(t, os.WriteFile(logFile, []byte("a\r"), 0o644))
 
 	var got []string
-	c := &Controller{}
-	mutex := &sync.Mutex{}
-	var lastWasCR bool
-	pos := c.readFromPos(mutex, logFile, 0, func(s string) { got = append(got, s) }, false, &lastWasCR)
+	var tail commandOutputTail
+	tail.read(logFile, func(s string) { got = append(got, s) }, false)
 	require.Equal(t, []string{"a"}, got)
-	require.True(t, lastWasCR, "CR state must persist for next poll")
+	require.True(t, tail.lastWasCR, "CR state must persist for next poll")
+	tail.read(logFile, func(s string) { got = append(got, s) }, false)
+	require.Equal(t, []string{"a"}, got)
+	require.True(t, tail.lastWasCR, "idle polls must preserve CR state")
 
 	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY, 0o644)
 	require.NoError(t, err)
@@ -146,25 +146,23 @@ func TestReadFromPos_CRLFAcrossPolls(t *testing.T) {
 	_ = f.Close()
 
 	got = got[:0]
-	c.readFromPos(mutex, logFile, pos, func(s string) { got = append(got, s) }, false, &lastWasCR)
+	tail.read(logFile, func(s string) { got = append(got, s) }, false)
 	require.Equal(t, []string{"b"}, got, "trailing \\n of split CRLF must not emit a blank line")
 }
 
-// TestReadFromPos_BlankCRLFAcrossPolls ensures a blank \r\n line split across
+// TestCommandOutputTail_BlankCRLFAcrossPolls ensures a blank \r\n line split across
 // polls is emitted as a single blank, not duplicated.
-func TestReadFromPos_BlankCRLFAcrossPolls(t *testing.T) {
+func TestCommandOutputTail_BlankCRLFAcrossPolls(t *testing.T) {
 	tmp := t.TempDir()
 	logFile := filepath.Join(tmp, "stdout.log")
 
 	require.NoError(t, os.WriteFile(logFile, []byte("\r"), 0o644))
 
 	var got []string
-	c := &Controller{}
-	mutex := &sync.Mutex{}
-	var lastWasCR bool
-	pos := c.readFromPos(mutex, logFile, 0, func(s string) { got = append(got, s) }, false, &lastWasCR)
+	var tail commandOutputTail
+	tail.read(logFile, func(s string) { got = append(got, s) }, false)
 	require.Equal(t, []string{"\n"}, got)
-	require.True(t, lastWasCR)
+	require.True(t, tail.lastWasCR)
 
 	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY, 0o644)
 	require.NoError(t, err)
@@ -173,8 +171,42 @@ func TestReadFromPos_BlankCRLFAcrossPolls(t *testing.T) {
 	_ = f.Close()
 
 	got = got[:0]
-	c.readFromPos(mutex, logFile, pos, func(s string) { got = append(got, s) }, false, &lastWasCR)
+	tail.read(logFile, func(s string) { got = append(got, s) }, false)
 	require.Empty(t, got, "trailing \\n of split blank CRLF must not emit a second blank")
+}
+
+func TestCommandOutputTail_RetainsGrowingLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stdout.log")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	defer file.Close()
+
+	var tail commandOutputTail
+	var got []string
+	emit := func(s string) { got = append(got, s) }
+	chunk := strings.Repeat("x", 64*1024)
+	for i := 1; i <= 4; i++ {
+		_, err := file.WriteString(chunk)
+		require.NoError(t, err)
+		for poll := 0; poll < 3; poll++ {
+			tail.read(path, emit, false)
+			require.Equal(t, int64(i*len(chunk)), tail.offset)
+			require.Equal(t, strings.Repeat(chunk, i), tail.pending.String())
+			require.Empty(t, got)
+		}
+	}
+	// A failed open must leave the unfinished output intact.
+	tail.read(path+".missing", emit, false)
+	require.Equal(t, int64(4*len(chunk)), tail.offset)
+	require.Equal(t, strings.Repeat(chunk, 4), tail.pending.String())
+
+	_, err = file.WriteString("\nnext\n")
+	require.NoError(t, err)
+	tail.read(path, emit, false)
+	require.Equal(t, []string{strings.Repeat(chunk, 4), "next"}, got)
+	require.Zero(t, tail.pending.Cap())
+	tail.read(path, emit, true)
+	require.Len(t, got, 2)
 }
 
 func TestRunCommand_Echo(t *testing.T) {

--- a/components/execd/pkg/runtime/command_test.go
+++ b/components/execd/pkg/runtime/command_test.go
@@ -209,6 +209,32 @@ func TestCommandOutputTail_RetainsGrowingLine(t *testing.T) {
 	require.Len(t, got, 2)
 }
 
+func TestCommandOutputTail_ReleasesCompletedLineCapacity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stdout.log")
+	longLine := strings.Repeat("x", 1<<20)
+	require.NoError(t, os.WriteFile(path, []byte(longLine+"\nprompt"), 0o600))
+
+	var tail commandOutputTail
+	var got []string
+	emit := func(s string) { got = append(got, s) }
+	tail.read(path, emit, false)
+	require.Equal(t, []string{longLine}, got)
+	require.Equal(t, "prompt", tail.pending.String())
+	require.LessOrEqual(t, tail.pending.Cap(), 4096, "a short fragment must not retain the completed line's storage")
+
+	tail.read(path, emit, false)
+	require.Len(t, got, 1)
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = file.WriteString(" continued\n")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	tail.read(path, emit, true)
+	require.Equal(t, []string{longLine, "prompt continued"}, got)
+	require.Equal(t, int64(len(longLine+"\nprompt continued\n")), tail.offset)
+	require.Zero(t, tail.pending.Cap())
+}
+
 func TestRunCommand_Echo(t *testing.T) {
 	if goruntime.GOOS == "windows" {
 		t.Skip("bash not available on windows")


### PR DESCRIPTION
# Summary
Foreground command output rereads an entire unfinished line every 100 ms. Keep the consumed offset, unfinished line, and CRLF state per stream so subsequent polls read only appended bytes. Preserve complete-line emission and final trailing-output flush; release completed-line buffer storage between polls.

Regression coverage includes growing output with idle polls, CRLF split across polls, blank lines, failed opens, long lines, and repeated final flush. Add benchmarks for idle polls, a line grown in 16 chunks, and ordinary short lines.

Local before/after benchmarks on Apple M3 Pro, darwin/arm64 (median of 3 runs, 200 ms per sample):

| Workload | Before | After | Allocated bytes/op before → after |
| --- | ---: | ---: | ---: |
| Idle poll after a primed 1 MiB unfinished line | 3.106 ms | 12.421 µs | 2,101,493 → 4,328 |
| 16 × 64 KiB appends, polling each, then newline | 52.091 ms | 8.109 ms | 25,631,348 → 3,218,981 |
| Read 100 short lines | 21.648 µs | 20.530 µs | 6,776 → 6,776 |

Command: `go test -run '^$' -bench '^BenchmarkCommandOutput' -benchmem -benchtime=200ms -count=3 ./pkg/runtime` from `components/execd`.
File writes are excluded from timing for the growing-line benchmark. These are local reader microbenchmarks, not end-to-end CPU or latency measurements; growing-line timing is noisy. The unfinished line now stays resident between polls, using memory proportional to its length. Poll frequency remains 100 ms.

# Testing
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

- Focused tail tests passed.
- `go test -race -run '^(TestCommandOutputTail|TestRunCommand|TestStdLogDescriptor|TestCombinedOutputDescriptor)' ./pkg/runtime` passed.
- Linux/amd64 and Windows/amd64 runtime test binaries cross-compiled with CGO disabled.
- No live Docker/server/Jupyter or full integration suite was run.

# Breaking Changes
- [x] None

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed): no public behavior or configuration change
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
