### PR TITLE
fix(sdk/csharp): bound readiness polling sleeps

### DIFF
--- a/sdks/sandbox/csharp/src/OpenSandbox/Sandbox.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Sandbox.cs
@@ -805,7 +805,8 @@ public sealed class Sandbox : IAsyncDisposable
         CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Start readiness check for sandbox {SandboxId} (timeoutSeconds={TimeoutSeconds})", Id, options.ReadyTimeoutSeconds);
-        var deadline = DateTime.UtcNow.AddSeconds(options.ReadyTimeoutSeconds);
+        var timeout = TimeSpan.FromSeconds(options.ReadyTimeoutSeconds);
+        var stopwatch = Stopwatch.StartNew();
         var attempt = 0;
         var errorDetail = "Health check returned false continuously.";
 
@@ -813,7 +814,7 @@ public sealed class Sandbox : IAsyncDisposable
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (DateTime.UtcNow > deadline)
+            if (stopwatch.Elapsed > timeout)
             {
                 var context = $"domain={ConnectionConfig.Domain}, useServerProxy={ConnectionConfig.UseServerProxy}";
                 throw new SandboxReadyTimeoutException(
@@ -847,7 +848,15 @@ public sealed class Sandbox : IAsyncDisposable
                 errorDetail = $"Last health check error: {ex.Message}";
             }
 
-            await Task.Delay(options.PollingIntervalMillis, cancellationToken).ConfigureAwait(false);
+            var remaining = timeout - stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                continue;
+            }
+
+            var pollingInterval = TimeSpan.FromMilliseconds(options.PollingIntervalMillis);
+            var delay = pollingInterval < remaining ? pollingInterval : remaining;
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxReadinessDiagnosticsTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxReadinessDiagnosticsTests.cs
@@ -19,12 +19,45 @@ using OpenSandbox.Core;
 using OpenSandbox.Factory;
 using OpenSandbox.Models;
 using OpenSandbox.Services;
+using System.Diagnostics;
 using Xunit;
 
 namespace OpenSandbox.Tests;
 
 public class SandboxReadinessDiagnosticsTests
 {
+    [Fact]
+    public async Task WaitUntilReadyAsync_WhenTimeoutIsShorterThanPollingInterval_DoesNotOvershoot()
+    {
+        // Arrange
+        var healthMock = new Mock<IExecdHealth>();
+        healthMock
+            .Setup(x => x.PingAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var sandbox = await CreateSandboxForReadinessTestAsync(healthMock, useServerProxy: true);
+        var stopwatch = Stopwatch.StartNew();
+
+        // Act
+        try
+        {
+            Func<Task> action = async () =>
+                await sandbox.WaitUntilReadyAsync(new WaitUntilReadyOptions
+                {
+                    ReadyTimeoutSeconds = 1,
+                    PollingIntervalMillis = 5_000
+                });
+
+            // Assert
+            await action.Should().ThrowAsync<SandboxReadyTimeoutException>();
+            stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+        }
+        finally
+        {
+            await sandbox.DisposeAsync();
+        }
+    }
+
     [Fact]
     public async Task WaitUntilReadyAsync_WhenHealthCheckThrows_OmitsNetworkConfigurationHints()
     {


### PR DESCRIPTION
# Summary

- Use a monotonic Stopwatch for the C# readiness timeout.
- Clamp each failed probe's delay to the remaining timeout budget so the final backoff cannot overshoot by a full polling interval.
- Add a regression covering a timeout shorter than the polling interval.

Part of #1739 (C# SDK).

Before this change, the regression's 1-second timeout with a 5-second polling interval returned after 5.016 seconds. It now returns at the 1-second deadline.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Commands run:

- dotnet build OpenSandbox.sln --configuration Release /warnaserror
- dotnet test tests/OpenSandbox.Tests/OpenSandbox.Tests.csproj --configuration Release --no-build
- dotnet build OpenSandbox.CodeInterpreter.sln --configuration Release /warnaserror
- dotnet test tests/OpenSandbox.CodeInterpreter.Tests/OpenSandbox.CodeInterpreter.Tests.csproj --configuration Release --no-build

Results: 183 sandbox SDK tests and 22 code-interpreter SDK tests passed; both solutions built with zero warnings and zero errors.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (not needed; public API and documented behavior are unchanged)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
