### PR TITLE
fix(egress): require TLS SNI to match credential binding host scope

### DIFF
--- a/components/egress/mitmscripts/system.py
+++ b/components/egress/mitmscripts/system.py
@@ -416,6 +416,44 @@ def _binding_matches(flow: http.HTTPFlow, binding: dict[str, Any]) -> tuple[bool
     return best_precedence > 0, best_precedence
 
 
+def _flow_sni(flow: http.HTTPFlow) -> str | None:
+    """Normalized ClientHello SNI of the intercepted connection, or None.
+
+    Read from the client connection rather than the server connection: at
+    ``requestheaders`` time the upstream connection is not established yet, and
+    mitmproxy carries the client SNI into the upstream handshake, where it
+    becomes the hostname the upstream certificate is verified against.
+    """
+    sni = getattr(getattr(flow, "client_conn", None), "sni", None)
+    if not isinstance(sni, str) or not sni:
+        return None
+    return sni.rstrip(".").lower()
+
+
+def _sni_outside_binding_scope(flow: http.HTTPFlow, binding: dict[str, Any]) -> bool:
+    """True when the TLS endpoint identity falls outside the binding host scope.
+
+    A binding match alone is not enough to release a credential:
+    :func:`_binding_matches` runs on ``request.pretty_host``, which is the Host
+    (or HTTP/2 ``:authority``) header — unauthenticated client input. A sandbox
+    can open a TLS session to any reachable host and still send
+    ``Host: api.github.com``, which would hand that binding's credential to a
+    peer of its choosing. The SNI is the name mitmproxy verifies the upstream
+    certificate against, so requiring it to match ``match.hosts`` as well binds
+    the injection decision to an identity the peer had to prove with a
+    certificate.
+
+    Returns False when no SNI is available: plaintext HTTP carries none, and
+    no-SNI TLS never reaches this hook because :func:`tls_clienthello` passes it
+    through. For those flows the egress allow rules stay the only control.
+    """
+    sni = _flow_sni(flow)
+    if sni is None:
+        return False
+    patterns = (binding.get("match") or {}).get("hosts") or []
+    return not any(_host_matches(sni, pattern)[0] for pattern in patterns)
+
+
 def _request_may_be_streamed(flow: http.HTTPFlow) -> bool:
     """True if mitmproxy may enable request-body streaming for this flow.
 
@@ -715,6 +753,20 @@ def requestheaders(flow: http.HTTPFlow) -> None:
     # for credential injection, because no secret is at risk.
     binding = _select_binding(flow, vault)
     if not binding:
+        return
+
+    # A matched binding is not sufficient: the match ran on the Host header,
+    # which the sandbox controls. Release the credential only onto a TLS
+    # session whose peer had to prove a name the binding trusts.
+    if _sni_outside_binding_scope(flow, binding):
+        _reject_request(
+            flow, b"request endpoint identity does not match credential binding\n"
+        )
+        ctx.log.warn(
+            "credential proxy: rejected request whose TLS endpoint identity is "
+            f"outside binding={binding.get('name')} scope: sni={_flow_sni(flow)} "
+            f"host={_request_host(flow)}"
+        )
         return
 
     # Reject ambiguous paths only for requests that would receive credentials:

--- a/components/egress/tests/test_mitmscripts_system.py
+++ b/components/egress/tests/test_mitmscripts_system.py
@@ -1430,5 +1430,142 @@ class SystemAddonTlsClientHelloTest(unittest.TestCase):
         self.assertFalse(data.ignore_connection)
 
 
+class SystemAddonSniHostConsistencyTest(unittest.TestCase):
+    """Credentials must only be released onto a TLS session whose peer had to
+    prove ownership of a name the binding trusts.
+
+    The binding match runs on ``request.pretty_host`` (the Host / ``:authority``
+    header), which is pure client input and is never verified against the peer.
+    The ClientHello SNI is the name mitmproxy uses for upstream certificate
+    verification, so it is the only endpoint identity an attacker cannot forge.
+    """
+
+    def _make_system_with_vault(self):
+        system = _load_system_module()
+        system._load_active_vault = lambda _client_ip=None: system.ActiveVault(
+            1,
+            [
+                {
+                    "name": "gitlab-api",
+                    "match": {
+                        "hosts": ["code.example.com"],
+                        "methods": ["GET"],
+                        "paths": ["/api/v8/*"],
+                    },
+                    "headers": [{"name": "Private-Token", "value": "secret-token"}],
+                }
+            ],
+            ["secret-token"],
+        )
+        return system
+
+    @staticmethod
+    def _with_sni(flow, sni):
+        flow.client_conn = types.SimpleNamespace(sni=sni, peername=("10.0.0.2", 51234))
+        return flow
+
+    def test_spoofed_host_header_on_foreign_sni_is_rejected(self) -> None:
+        """SNI evil.example.com + Host code.example.com must not leak the token."""
+        system = self._make_system_with_vault()
+        flow = self._with_sni(_Flow(), "evil.example.com")
+
+        system.requestheaders(flow)
+
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(403, flow.response.status_code)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+        self.assertTrue(
+            any("endpoint identity" in message for message in system.ctx.log.messages)
+        )
+        self.assertFalse(
+            any("secret-token" in message for message in system.ctx.log.messages)
+        )
+
+    def test_matching_sni_injects_credential(self) -> None:
+        system = self._make_system_with_vault()
+        flow = self._with_sni(_Flow(), "code.example.com")
+
+        system.requestheaders(flow)
+
+        self.assertIsNone(getattr(flow.response, "status_code", None))
+        self.assertEqual("secret-token", flow.request.headers.get("Private-Token"))
+
+    def test_sni_is_normalized_before_comparison(self) -> None:
+        """Trailing dot and uppercase are the same name on the wire."""
+        system = self._make_system_with_vault()
+        flow = self._with_sni(_Flow(), "CODE.Example.com.")
+
+        system.requestheaders(flow)
+
+        self.assertEqual("secret-token", flow.request.headers.get("Private-Token"))
+
+    def test_wildcard_binding_accepts_covered_sni(self) -> None:
+        """A wildcard binding trusts every covered subdomain, so a Host that
+        differs from the SNI inside that scope stays injectable."""
+        system = self._make_system_with_vault()
+        system._load_active_vault = lambda _client_ip=None: system.ActiveVault(
+            1,
+            [
+                {
+                    "name": "gitlab-api",
+                    "match": {
+                        "hosts": ["*.example.com"],
+                        "methods": ["GET"],
+                        "paths": ["/api/v8/*"],
+                    },
+                    "headers": [{"name": "Private-Token", "value": "secret-token"}],
+                }
+            ],
+            ["secret-token"],
+        )
+        flow = self._with_sni(_Flow(), "mirror.example.com")
+
+        system.requestheaders(flow)
+
+        self.assertEqual("secret-token", flow.request.headers.get("Private-Token"))
+
+    def test_absent_sni_falls_back_to_host_header(self) -> None:
+        """Plaintext HTTP carries no SNI; there is no endpoint identity to
+        verify, so the binding decision stays as-is (egress allow rules remain
+        the only control). No-SNI TLS never reaches here - tls_clienthello
+        passes it through."""
+        system = self._make_system_with_vault()
+        system._load_active_vault = lambda _client_ip=None: system.ActiveVault(
+            1,
+            [
+                {
+                    "name": "gitlab-api",
+                    "match": {
+                        "hosts": ["code.example.com"],
+                        "methods": ["GET"],
+                        "paths": ["/api/v8/*"],
+                        "schemes": ["http"],
+                    },
+                    "headers": [{"name": "Private-Token", "value": "secret-token"}],
+                }
+            ],
+            ["secret-token"],
+        )
+        flow = self._with_sni(_Flow(), None)
+        flow.request.scheme = "http"
+        flow.request.port = 80
+
+        system.requestheaders(flow)
+
+        self.assertEqual("secret-token", flow.request.headers.get("Private-Token"))
+
+    def test_streamed_request_with_foreign_sni_is_killed_not_403(self) -> None:
+        """mitmproxy cannot serve a 403 once a large body is streaming, so the
+        flow must be killed instead."""
+        system = self._make_system_with_vault()
+        flow = self._with_sni(_Flow(), "evil.example.com")
+        flow.request.stream = True
+
+        system.requestheaders(flow)
+
+        self.assertTrue(flow.killed)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/guides/credential-vault.md
+++ b/docs/guides/credential-vault.md
@@ -61,6 +61,15 @@ Requests that do not match any credential binding are forwarded unchanged.
 Credential path-safety checks apply only after a binding matches and the request
 would otherwise receive credentials.
 
+Binding host matching runs on the `Host` (or HTTP/2 `:authority`) header, which
+the sandbox workload controls. For HTTPS, the sidecar additionally requires the
+TLS ClientHello SNI to fall inside the same binding's `match.hosts` scope before
+injecting anything: the SNI is the name the upstream certificate is verified
+against, so this keeps a credential from being released to a peer that merely
+claims the bound host name. Plaintext HTTP carries no SNI and therefore no
+verifiable endpoint identity — for `http` bindings the egress allow rules remain
+the only destination control.
+
 The active vault used by the MITM process is served over a local Unix domain
 socket inside the sidecar. The sandbox workload cannot fetch this active state
 over the normal server proxy path.
@@ -453,7 +462,8 @@ curl -fsS https://api.example.com/v1/projects/123/variables
 - Avoid overlapping bindings at the same precedence; ambiguous matches are
   rejected.
 - Rejected requests (ambiguous paths, encoded separators crossing a binding
-  boundary) return `403` when the request body is small and fully known.
+  boundary, a TLS SNI outside the matched binding's host scope) return `403`
+  when the request body is small and fully known.
   Requests with bodies above the mitmproxy streaming threshold (~1 MiB) or
   with unknown length (chunked) cannot be answered with a `403` while the
   body is being streamed, so the sidecar drops the connection instead —


### PR DESCRIPTION
# Summary
- Fixes #1758. Credential Vault selects a binding from `request.pretty_host` — the `Host` / HTTP/2 `:authority` header — which is unauthenticated input from the sandbox workload. Nothing checked it against the identity of the peer the request is delivered to, so a workload could open a TLS session to any host its egress policy allows, send `Host: <bound host>`, and have that binding's credential injected into a request delivered to a peer of its choosing.
- `requestheaders()` now requires the ClientHello SNI, when present, to fall inside the matched binding's `match.hosts` scope before anything is injected; mismatches go through the existing `_reject_request` path (403, or connection drop for streamed bodies).
- The SNI is the right anchor because mitmproxy propagates it to the upstream handshake and verifies the upstream certificate against it (`tlsconfig.py`: `server.sni = client.sni or server.address[0]`, then `X509_VERIFY_PARAM_set1_host`), so unlike the `Host` header it is an identity the peer must prove. The same asymmetry is already relied on by the `ignore_hosts` re-check in `tls_clienthello`.
- `Host`-header matching is kept for binding selection itself: it is per-request (HTTP/2 multiplexing, keep-alive), `http` bindings have no SNI at all, and transparent-mode `request.host` can be a bare IP. The new check is an additional condition, not a replacement.
- Flows without SNI keep previous behavior — plaintext HTTP carries none, and no-SNI TLS never reaches this hook because `tls_clienthello` passes it through. For `http` bindings the egress allow rules stay the only destination control; the guide now says so.

# Testing
- [x] Unit tests — `cd components/egress && python -m unittest discover -s tests -p "test_*.py"` (65 tests, OK; the 4 runtime tests skip locally because `mitmdump` is not installed). New `SystemAddonSniHostConsistencyTest` covers: spoofed `Host` on a foreign SNI rejected with 403 and no header injected, matching SNI still injects, SNI normalization (case + trailing dot), wildcard binding accepting a covered SNI with a differing `Host`, absent SNI falling back to previous behavior, and a streamed body being killed instead of 403.
- [ ] Not run: `docs` VitePress build (text-only edit to an existing page, no new links) and the egress e2e/smoke suites, which need the sidecar image.

# Breaking Changes
- [x] None for correctly configured clients: a normal HTTPS client sends SNI and `Host` for the same name. Two deliberate behavior changes worth calling out in review:
  - A client that coalesces an HTTP/2 connection across authorities (SNI `a.example.com`, `:authority` `b.example.com`) no longer receives an injected credential for a binding scoped to `b.example.com` alone, and gets a 403. This is fail-closed by design — the session is authenticated as a different name than the binding trusts. A binding whose `match.hosts` covers both names (for example `*.example.com`) keeps working; there is a test for that.
  - `http` bindings are unaffected.

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed) — `docs/guides/credential-vault.md`: how binding host matching relates to SNI, the new 403 reason, and the explicit statement that `http` bindings have no verifiable endpoint identity
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

Follow-up worth deciding separately: `oseps/0012-credential-vault.md` specifies `match.hosts` normalization and wildcard rules but never states which host of the request is matched, and carries no SNI/`Host` consistency requirement. Pinning that invariant down in the OSEP would keep it from being re-lost.
