### PR TITLE
feat(egress): add request-weighted TLS shadow observations

### DIFF
--- a/components/egress/docs/opentelemetry.md
+++ b/components/egress/docs/opentelemetry.md
@@ -69,36 +69,12 @@ per-exchange cap — has bigger problems than a percentile.
 Note both successful and failed lookups feed this histogram, so its tail mixes slow
 resolutions with exhausted retry chains.
 
-## TLS shadow request samples
+## TLS shadow implementation
 
-`egress.mitm.shadow.requests_total` is an opt-in diagnostic counter for
-OSEP-0023. Set `OPENSANDBOX_EGRESS_MITMPROXY_SHADOW=true` on egress and configure
-the normal OTLP metrics endpoint. No samples are produced by default.
-
-| `decision` | `reason` | Meaning at the existing HTTPS/443 request Vault lookup |
-|---|---|---|
-| `decrypt` | `binding_host` | SNI is covered by an HTTPS binding host selector; method/path do not affect this host-level projection |
-| `passthrough` | `no_binding_host` | Validated Vault has no HTTPS selector covering SNI |
-| `passthrough` | `no_vault` | Sidecar active-Vault API returned authoritative absence; not proof of a future startup empty-snapshot transaction |
-| `unavailable` | `unknown_subject_or_vault` | Fleet 404 cannot distinguish an unknown source identity from absent Vault state |
-| `unavailable` | `lookup_failed` | The existing lookup failed; no cached result is used to guess |
-| `unavailable` | `missing_sni`, `invalid_sni` | No usable ASCII SNI in this observed request |
-| `unavailable` | `invalid_snapshot`, `observer_error` | Shadow projection could not interpret the sample |
-
-Only these fixed reasons and decisions plus existing shared attributes are
-exported. No hostname, path, credential, revision, or fleet subject ID is added.
-The Python addon emits a fixed outcome through its existing stdout pipe; Go
-consumes it as a metric instead of forwarding it to the application log sink.
-Unknown outcomes are discarded. Operator addons and the child process remain
-trusted diagnostic producers; this is not an audit record.
-
-Delivery is best effort. Process failure, pipe/log filtering, or exporter
-failure can lose observations; no-exporter deployments must not expect a stored
-log substitute. These are request-weighted observations after TLS termination,
-not ClientHello-time decisions: pooled requests count repeatedly, while opaque
-connections and failed handshakes never reach this hook. Shadow failures never
-change traffic. Evaluate `unavailable` alongside other outcomes rather than
-treating missing samples as successful pass-through.
+The system addon emits fixed outcomes through the existing child stdout pipe;
+the Go relay consumes them via `RecordTLSShadow` as bounded-label OTLP samples.
+Unknown outcomes are discarded. The operator contract is maintained in
+[Egress: TLS shadow observations](../../../docs/components/egress.md#experimental-tls-shadow-observations).
 
 ## Failure Signals
 

--- a/components/egress/docs/opentelemetry.md
+++ b/components/egress/docs/opentelemetry.md
@@ -69,6 +69,37 @@ per-exchange cap — has bigger problems than a percentile.
 Note both successful and failed lookups feed this histogram, so its tail mixes slow
 resolutions with exhausted retry chains.
 
+## TLS shadow request samples
+
+`egress.mitm.shadow.requests_total` is an opt-in diagnostic counter for
+OSEP-0023. Set `OPENSANDBOX_EGRESS_MITMPROXY_SHADOW=true` on egress and configure
+the normal OTLP metrics endpoint. No samples are produced by default.
+
+| `decision` | `reason` | Meaning at the existing HTTPS/443 request Vault lookup |
+|---|---|---|
+| `decrypt` | `binding_host` | SNI is covered by an HTTPS binding host selector; method/path do not affect this host-level projection |
+| `passthrough` | `no_binding_host` | Validated Vault has no HTTPS selector covering SNI |
+| `passthrough` | `no_vault` | Sidecar active-Vault API returned authoritative absence; not proof of a future startup empty-snapshot transaction |
+| `unavailable` | `unknown_subject_or_vault` | Fleet 404 cannot distinguish an unknown source identity from absent Vault state |
+| `unavailable` | `lookup_failed` | The existing lookup failed; no cached result is used to guess |
+| `unavailable` | `missing_sni`, `invalid_sni` | No usable ASCII SNI in this observed request |
+| `unavailable` | `invalid_snapshot`, `observer_error` | Shadow projection could not interpret the sample |
+
+Only these fixed reasons and decisions plus existing shared attributes are
+exported. No hostname, path, credential, revision, or fleet subject ID is added.
+The Python addon emits a fixed outcome through its existing stdout pipe; Go
+consumes it as a metric instead of forwarding it to the application log sink.
+Unknown outcomes are discarded. Operator addons and the child process remain
+trusted diagnostic producers; this is not an audit record.
+
+Delivery is best effort. Process failure, pipe/log filtering, or exporter
+failure can lose observations; no-exporter deployments must not expect a stored
+log substitute. These are request-weighted observations after TLS termination,
+not ClientHello-time decisions: pooled requests count repeatedly, while opaque
+connections and failed handshakes never reach this hook. Shadow failures never
+change traffic. Evaluate `unavailable` alongside other outcomes rather than
+treating missing samples as successful pass-through.
+
 ## Failure Signals
 
 `egress.dns.query.failed_total` and `egress.policy.denied_total` answer different

--- a/components/egress/mitmscripts/host_selectors.py
+++ b/components/egress/mitmscripts/host_selectors.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""OSEP-0023 canonical snapshot selectors; not loaded by the system addon yet.
+"""OSEP-0023 canonical snapshot selectors, also used by shadow observations.
 
 Go owns Unicode/IDNA normalization at the control-plane input boundary. This
 module validates the resulting ASCII structure, never reinterpreting U-labels

--- a/components/egress/mitmscripts/system.py
+++ b/components/egress/mitmscripts/system.py
@@ -129,6 +129,11 @@ class ActiveVaultLookupError(Exception):
 
 _vault_cache: ActiveVault | None = None
 
+# Operator-only diagnostics; no public interception mode is enabled here.
+_tls_shadow_enabled = os.environ.get(
+    "OPENSANDBOX_EGRESS_MITMPROXY_SHADOW", ""
+).strip().lower() in {"1", "true", "on"}
+
 # Fleet profile: one shared mitmdump serving N sandboxes; the active vault is
 # selected by the client's source IP (preserved by the interception DNAT), so
 # the immutable snapshot cache is keyed per client IP. Every flow performs a
@@ -1001,6 +1006,30 @@ def _flow_client_ip(flow: http.HTTPFlow) -> str | None:
         return None
 
 
+def _observe_tls_shadow(
+    flow: http.HTTPFlow, vault: ActiveVault | None, *, lookup_failed: bool = False
+) -> None:
+    if not _tls_shadow_enabled:
+        return
+    try:
+        if flow.request.scheme != "https" or flow.request.port != 443:
+            return
+        from tls_shadow import project
+
+        sni = getattr(getattr(flow, "client_conn", None), "sni", None)
+        outcome = project(
+            sni, None if vault is None else vault.bindings, lookup_failed=lookup_failed
+        )
+        if _fleet_mode_enabled and vault is None and not lookup_failed:
+            # Fleet 404 also means unknown source identity, not just no vault.
+            outcome = "unknown_subject_or_vault"
+        # Fixed vocabulary only: no hostname, revision, subject, path, or secret.
+        ctx.log.warn("credential proxy: tls-shadow " + outcome)
+    except Exception:  # noqa: BLE001 - diagnostics must never change traffic
+        with suppress(Exception):
+            ctx.log.warn("credential proxy: tls-shadow observer_error")
+
+
 def requestheaders(flow: http.HTTPFlow) -> None:
     """Credential proxy phase 1: binding match and request metadata rewrite.
 
@@ -1011,6 +1040,7 @@ def requestheaders(flow: http.HTTPFlow) -> None:
     try:
         vault = _load_active_vault(_flow_client_ip(flow))
     except ActiveVaultLookupError as exc:
+        _observe_tls_shadow(flow, None, lookup_failed=True)
         ctx.log.warn(f"credential proxy: {exc}; request denied")
         _reject_request(
             flow,
@@ -1018,6 +1048,7 @@ def requestheaders(flow: http.HTTPFlow) -> None:
             status_code=503,
         )
         return
+    _observe_tls_shadow(flow, vault)
     if vault is None:
         return
 

--- a/components/egress/mitmscripts/tls_shadow.py
+++ b/components/egress/mitmscripts/tls_shadow.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Request-weighted shadow projection, not a TLS admission decision.
+
+Only consumes the validated snapshot already obtained for this HTTP flow.
+No IPC, retained vault, subject cache, or flow mutation is permitted here.
+"""
+
+from __future__ import annotations
+
+from host_selectors import parse_canonical
+
+
+def project(
+    sni: str | None, bindings: list[dict] | None, *, lookup_failed: bool = False
+) -> str:
+    """Return one bounded outcome without retaining or exposing request data."""
+    if lookup_failed:
+        return "lookup_failed"
+    if not sni:
+        return "missing_sni"
+    if not sni.isascii():
+        return "invalid_sni"
+    try:
+        host = parse_canonical(sni.lower().removesuffix("."))
+    except ValueError:
+        return "invalid_sni"
+    if host.wildcard:
+        return "invalid_sni"
+    if bindings is None:
+        return "no_vault"
+    matched = False
+    try:
+        # Validate all eligible selectors, even if an earlier selector matches.
+        for binding in bindings:
+            match = binding["match"]
+            if "https" not in match["schemes"]:
+                continue
+            for text in match["hosts"]:
+                selector = parse_canonical(text)
+                matched = selector.matches(host.text) or matched
+    except (KeyError, TypeError, ValueError, AttributeError):
+        return "invalid_snapshot"
+    return "binding_host" if matched else "no_binding_host"

--- a/components/egress/mitmscripts/tls_shadow.py
+++ b/components/egress/mitmscripts/tls_shadow.py
@@ -49,6 +49,15 @@ def project(
             if "https" not in match["schemes"]:
                 continue
             for text in match["hosts"]:
+                if text.startswith("*.") and len(text[2:]) > 251:
+                    # Legacy Vault accepts 252/253-byte suffixes. A proper
+                    # subdomain would exceed the 253-byte DNS limit, so this
+                    # selector has no members. Still validate the suffix:
+                    # malformed or oversized hosts must remain unavailable.
+                    suffix = parse_canonical(text[2:])
+                    if suffix.wildcard:
+                        return "invalid_snapshot"
+                    continue
                 selector = parse_canonical(text)
                 matched = selector.matches(host.text) or matched
     except (KeyError, TypeError, ValueError, AttributeError):

--- a/components/egress/pkg/mitmproxy/launch.go
+++ b/components/egress/pkg/mitmproxy/launch.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/alibaba/opensandbox/egress/pkg/constants"
 	"github.com/alibaba/opensandbox/egress/pkg/log"
+	"github.com/alibaba/opensandbox/egress/pkg/telemetry"
 	"github.com/alibaba/opensandbox/internal/safego"
 )
 
@@ -186,6 +187,10 @@ func forwardMitmdumpOutput(r io.ReadCloser) {
 		line := strings.TrimRight(scanner.Text(), " \t\r")
 		msg, ok := credentialProxyMessage(line)
 		if !ok {
+			continue
+		}
+		if strings.HasPrefix(msg, "credential proxy: tls-shadow ") {
+			telemetry.RecordTLSShadow(strings.TrimPrefix(msg, "credential proxy: tls-shadow "))
 			continue
 		}
 		log.Warnf("[mitmproxy] %s", msg)

--- a/components/egress/pkg/mitmproxy/tls_shadow_test.go
+++ b/components/egress/pkg/mitmproxy/tls_shadow_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mitmproxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alibaba/opensandbox/egress/pkg/telemetry"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	collectormetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestShadowOutputReachesOTLP(t *testing.T) {
+	received := make(chan []byte, 8)
+	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(500)
+			return
+		}
+		received <- body
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(200)
+	}))
+	defer endpoint.Close()
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", endpoint.URL+"/v1/metrics")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_COMPRESSION", "none")
+	t.Setenv("OTEL_EXPORTER_OTLP_COMPRESSION", "none")
+	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "600000")
+	previousMeter, previousTracer := otel.GetMeterProvider(), otel.GetTracerProvider()
+	t.Cleanup(func() { otel.SetMeterProvider(previousMeter); otel.SetTracerProvider(previousTracer) })
+	shutdown, err := telemetry.Init(context.Background())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, shutdown(context.Background())) }()
+	forwardMitmdumpOutput(io.NopCloser(strings.NewReader(
+		"[12:34:56.000] credential proxy: tls-shadow binding_host\n" +
+			"credential proxy: tls-shadow binding_host\n" +
+			"credential proxy: tls-shadow lookup_failed\n" +
+			"credential proxy: tls-shadow secret.example.com\n" +
+			"10.0.0.1: GET /credential proxy: tls-shadow binding_host\n")))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, telemetry.ForceFlush(ctx))
+	select {
+	case body := <-received:
+		var req collectormetrics.ExportMetricsServiceRequest
+		require.NoError(t, proto.Unmarshal(body, &req))
+		counts := map[string]int64{}
+		for _, resource := range req.ResourceMetrics {
+			for _, scope := range resource.ScopeMetrics {
+				for _, metric := range scope.Metrics {
+					if metric.Name != "egress.mitm.shadow.requests_total" {
+						continue
+					}
+					for _, point := range metric.GetSum().DataPoints {
+						for _, attr := range point.Attributes {
+							if attr.Key == "reason" {
+								counts[attr.Value.GetStringValue()] += point.GetAsInt()
+							}
+						}
+					}
+				}
+			}
+		}
+		require.Equal(t, map[string]int64{"binding_host": 2, "lookup_failed": 1}, counts)
+	case <-ctx.Done():
+		t.Fatal("shadow samples never reached the OTLP receiver")
+	}
+}

--- a/components/egress/pkg/telemetry/metrics.go
+++ b/components/egress/pkg/telemetry/metrics.go
@@ -32,12 +32,13 @@ import (
 var (
 	meter metric.Meter
 
-	dnsQueryDur     metric.Float64Histogram
-	dnsQueryFailed  metric.Int64Counter
-	dnsReplyFailed  metric.Int64Counter
-	policyDenied    metric.Int64Counter
-	nftUpdates      metric.Int64Counter
-	nftUpdateFailed metric.Int64Counter
+	dnsQueryDur       metric.Float64Histogram
+	dnsQueryFailed    metric.Int64Counter
+	dnsReplyFailed    metric.Int64Counter
+	policyDenied      metric.Int64Counter
+	nftUpdates        metric.Int64Counter
+	nftUpdateFailed   metric.Int64Counter
+	tlsShadowRequests metric.Int64Counter
 
 	lastNftRuleCount atomic.Int64
 )
@@ -145,6 +146,13 @@ func registerEgressMetrics() error {
 		"egress.dns.reply.failed_total",
 		metric.WithDescription("DNS reply writes that failed after a decision, by stage. "+
 			"A nonzero count means a query was handled but its answer never reached the client."),
+	)
+	if err != nil {
+		return err
+	}
+	tlsShadowRequests, err = meter.Int64Counter(
+		"egress.mitm.shadow.requests_total",
+		metric.WithDescription("Request-weighted TLS host-scope projections after the existing vault lookup; not connection counts or enforcement decisions."),
 	)
 	if err != nil {
 		return err

--- a/components/egress/pkg/telemetry/tls_shadow.go
+++ b/components/egress/pkg/telemetry/tls_shadow.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// RecordTLSShadow records a request-weighted projection received from the
+// trusted system addon. Unknown outcomes are discarded, never made labels.
+// These are observations after the existing vault lookup, not TLS decisions.
+func RecordTLSShadow(outcome string) {
+	var decision string
+	switch outcome {
+	case "binding_host":
+		decision = "decrypt"
+	case "no_binding_host", "no_vault":
+		decision = "passthrough"
+	case "lookup_failed", "missing_sni", "invalid_sni", "invalid_snapshot", "observer_error", "unknown_subject_or_vault":
+		decision = "unavailable"
+	default:
+		return
+	}
+	if tlsShadowRequests == nil {
+		return
+	}
+	attrs := append([]attribute.KeyValue(nil), egressSharedAttrs()...)
+	attrs = append(attrs, attribute.String("decision", decision), attribute.String("reason", outcome))
+	tlsShadowRequests.Add(context.Background(), 1, metric.WithAttributes(attrs...))
+}

--- a/components/egress/pkg/telemetry/tls_shadow_test.go
+++ b/components/egress/pkg/telemetry/tls_shadow_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"testing"
+)
+
+func TestTLSShadowHasBoundedAttributes(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	old := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(old) })
+	require.NoError(t, registerEgressMetrics())
+	for _, outcome := range []string{"binding_host", "no_binding_host", "no_vault", "lookup_failed", "missing_sni", "invalid_sni", "invalid_snapshot", "observer_error", "unknown_subject_or_vault"} {
+		RecordTLSShadow(outcome)
+	}
+	RecordTLSShadow("binding_host")
+	RecordTLSShadow("secret.example.com")
+	RecordTLSShadow("binding_host host=private.example.com")
+	RecordTLSShadow("")
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	found := false
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != "egress.mitm.shadow.requests_total" {
+				continue
+			}
+			found = true
+			sum := m.Data.(metricdata.Sum[int64])
+			require.Len(t, sum.DataPoints, 9)
+			for _, dp := range sum.DataPoints {
+				reason, ok := dp.Attributes.Value("reason")
+				require.True(t, ok)
+				decision, ok := dp.Attributes.Value("decision")
+				require.True(t, ok)
+				switch reason.AsString() {
+				case "binding_host":
+					require.Equal(t, "decrypt", decision.AsString())
+					require.EqualValues(t, 2, dp.Value)
+				case "no_binding_host", "no_vault":
+					require.Equal(t, "passthrough", decision.AsString())
+					require.EqualValues(t, 1, dp.Value)
+				default:
+					require.Equal(t, "unavailable", decision.AsString())
+					require.EqualValues(t, 1, dp.Value)
+				}
+				require.Equal(t, len(egressSharedAttrs())+2, dp.Attributes.Len())
+			}
+		}
+	}
+	require.True(t, found, "shadow instrument not registered")
+}

--- a/components/egress/tests/test_tls_shadow.py
+++ b/components/egress/tests/test_tls_shadow.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shadow observations must not affect traffic or perform another vault lookup."""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from test_mitmscripts_system import _Flow, _load_system_module
+
+
+class TLSShadowTest(unittest.TestCase):
+    def setUp(self):
+        paths = patch.object(
+            sys,
+            "path",
+            [str(Path(__file__).resolve().parents[1] / "mitmscripts"), *sys.path],
+        )
+        paths.start()
+        self.addCleanup(paths.stop)
+        self.system = _load_system_module()
+        self.system._tls_shadow_enabled = True
+
+    def flow(self, sni="api.example.com"):
+        f = _Flow()
+        f.request.scheme, f.request.port = "https", 443
+        f.request.pretty_host = f.request.host = "api.example.com"
+        f.request.method, f.request.path = "GET", "/"
+        f.client_conn = types.SimpleNamespace(sni=sni, peername=("10.0.0.1", 1234))
+        return f
+
+    def vault(self, host="api.example.com", scheme="https"):
+        return self.system.ActiveVault(
+            1,
+            [
+                {
+                    "name": "private-binding",
+                    "match": {
+                        "hosts": [host],
+                        "schemes": [scheme],
+                        "methods": ["GET"],
+                        "paths": ["/"],
+                    },
+                    "headers": [{"name": "x-key", "value": "never-log-secret"}],
+                }
+            ],
+            ["never-log-secret"],
+        )
+
+    def test_projection(self):
+        for sni, vault, failed, want in [
+            ("API.EXAMPLE.COM.", self.vault(), False, "binding_host"),
+            ("api.example.com", self.vault("*.example.com"), False, "binding_host"),
+            ("example.com", self.vault("*.example.com"), False, "no_binding_host"),
+            ("other.example.com", self.vault(), False, "no_binding_host"),
+            ("api.example.com", self.vault(scheme="http"), False, "no_binding_host"),
+            ("api.example.com", None, False, "no_vault"),
+            ("api.example.com", None, True, "lookup_failed"),
+            (None, self.vault(), False, "missing_sni"),
+            ("bad host", self.vault(), False, "invalid_sni"),
+            ("api.example.com", self.vault("*.invalid.*"), False, "invalid_snapshot"),
+        ]:
+            with self.subTest(want=want):
+                flow = self.flow(sni)
+                flow.request.method, flow.request.path = "POST", "/unmatched"
+                self.system._observe_tls_shadow(flow, vault, lookup_failed=failed)
+                self.assertEqual(
+                    self.system.ctx.log.messages[-1],
+                    "credential proxy: tls-shadow " + want,
+                )
+                self.assertFalse(flow.killed)
+
+    def test_disabled_and_noncanonical_ports(self):
+        self.system._tls_shadow_enabled = False
+        self.system._observe_tls_shadow(self.flow(), self.vault())
+        self.system._tls_shadow_enabled = True
+        for scheme, port in [("https", 8443), ("http", 80)]:
+            f = self.flow()
+            f.request.scheme, f.request.port = scheme, port
+            self.system._observe_tls_shadow(f, self.vault())
+        self.assertEqual(self.system.ctx.log.messages, [])
+
+    def test_fleet_absence_does_not_claim_passthrough(self):
+        self.system._set_fleet_mode(True)
+        self.system._observe_tls_shadow(self.flow(), None)
+        self.assertEqual(
+            self.system.ctx.log.messages[-1],
+            "credential proxy: tls-shadow unknown_subject_or_vault",
+        )
+
+    def test_hook_reuses_lookup_and_preserves_injection(self):
+        f = self.flow()
+        with patch.object(
+            self.system, "_load_active_vault", return_value=self.vault()
+        ) as lookup:
+            self.system.requestheaders(f)
+            lookup.assert_called_once()
+        self.assertEqual(f.request.headers.get("x-key"), "never-log-secret")
+        self.assertFalse(f.killed)
+        self.assertEqual(
+            self.system.ctx.log.messages[0], "credential proxy: tls-shadow binding_host"
+        )
+        self.assertNotIn("never-log-secret", "\n".join(self.system.ctx.log.messages))
+
+    def test_observer_error_cannot_change_request(self):
+        import tls_shadow
+
+        f = self.flow()
+        with patch.object(
+            tls_shadow, "project", side_effect=RuntimeError("secret-error")
+        ):
+            self.system._observe_tls_shadow(f, self.vault())
+        self.assertFalse(f.killed)
+        self.assertNotIn("secret-error", "\n".join(self.system.ctx.log.messages))
+
+    def test_lookup_failure_preserves_rejection(self):
+        f = self.flow()
+        with patch.object(
+            self.system,
+            "_load_active_vault",
+            side_effect=self.system.ActiveVaultLookupError("unavailable"),
+        ) as lookup:
+            self.system.requestheaders(f)
+            lookup.assert_called_once()
+        self.assertIn(
+            "credential proxy: tls-shadow lookup_failed", self.system.ctx.log.messages
+        )
+        self.assertEqual(f.response.status_code, 503)

--- a/components/egress/tests/test_tls_shadow.py
+++ b/components/egress/tests/test_tls_shadow.py
@@ -94,6 +94,41 @@ class TLSShadowTest(unittest.TestCase):
             self.system._observe_tls_shadow(f, self.vault())
         self.assertEqual(self.system.ctx.log.messages, [])
 
+    def test_accepted_empty_wildcard_language_does_not_poison_vault(self):
+        import tls_shadow
+
+        for size in (252, 253):
+            base = ".".join(["a" * 63, "b" * 63, "c" * 63, "d" * (size - 192)])
+            wildcard = "*." + base
+            self.assertEqual(
+                self.system._normalize_active_vault_host(wildcard, "test"), wildcard
+            )
+            impossible = self.vault(wildcard).bindings
+            self.assertEqual(
+                tls_shadow.project("api.example.com", impossible), "no_binding_host"
+            )
+            for bindings in (
+                impossible + self.vault().bindings,
+                self.vault().bindings + impossible,
+            ):
+                self.assertEqual(
+                    tls_shadow.project("api.example.com", bindings), "binding_host"
+                )
+        base = ".".join(["a" * 63, "b" * 63, "c" * 63, "d" * 59])
+        self.assertEqual(
+            tls_shadow.project("x." + base, self.vault("*." + base).bindings),
+            "binding_host",
+        )
+        for malformed in (
+            "*.*." + base[:-1],
+            "*." + base + "dddd",
+            "*." + "a" * 64 + "." + "b" * 63 + "." + "c" * 63 + "." + "d" * 59,
+        ):
+            self.assertEqual(
+                tls_shadow.project("api.example.com", self.vault(malformed).bindings),
+                "invalid_snapshot",
+            )
+
     def test_fleet_absence_does_not_claim_passthrough(self):
         self.system._set_fleet_mode(True)
         self.system._observe_tls_shadow(self.flow(), None)

--- a/components/egress/tests/test_tls_shadow_runtime.py
+++ b/components/egress/tests/test_tls_shadow_runtime.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exercise shadow imports and logging inside a real mitmdump TLS connection."""
+
+import http.client
+import json
+import os
+import shutil
+import socket
+import ssl
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from test_mitmproxy_runtime import _free_port, _VaultUnixServer
+
+MITMDUMP = shutil.which("mitmdump")
+
+
+@unittest.skipUnless(MITMDUMP, "mitmdump is not installed")
+class TLSShadowRuntimeTest(unittest.TestCase):
+    def test_real_tls_request_preserves_injection_and_emits_shadow(self):
+        payload = json.dumps(
+            {
+                "revision": 1,
+                "bindings": [
+                    {
+                        "name": "local-test",
+                        "match": {
+                            "hosts": ["api.example.com"],
+                            "schemes": ["https"],
+                            "methods": ["GET"],
+                            "paths": ["/"],
+                        },
+                        "headers": [{"name": "x-key", "value": "never-log-secret"}],
+                    }
+                ],
+                "redactions": ["never-log-secret"],
+            }
+        ).encode()
+        # Short path stays within macOS Unix-socket path limits.
+        with tempfile.TemporaryDirectory(prefix="tls-shadow-", dir="/tmp") as tmp:
+            root = Path(tmp)
+            vault = _VaultUnixServer(str(root / "vault.sock"), payload)
+            vault.start()
+            self.addCleanup(vault.stop)
+            responder = root / "responder.py"
+            responder.write_text(
+                "from mitmproxy import http\n"
+                "def requestheaders(flow):\n"
+                "    body = b'injected' if flow.request.headers.get('x-key') == 'never-log-secret' else b'missing'\n"
+                "    flow.response = http.Response.make(200, body)\n"
+            )
+            system = Path(__file__).resolve().parents[1] / "mitmscripts" / "system.py"
+            port = _free_port()
+            with (root / "proxy.log").open("w+") as log:
+                proc = subprocess.Popen(
+                    [
+                        MITMDUMP,
+                        "--listen-host",
+                        "127.0.0.1",
+                        "--listen-port",
+                        str(port),
+                        "--set",
+                        "confdir=" + str(root / "ca"),
+                        "--set",
+                        "upstream_cert=false",
+                        "--set",
+                        "connection_strategy=lazy",
+                        "--set",
+                        "flow_detail=0",
+                        "-s",
+                        str(system),
+                        "-s",
+                        str(responder),
+                    ],
+                    env={
+                        **os.environ,
+                        "OPENSANDBOX_EGRESS_MITMPROXY_SHADOW": "true",
+                        "OPENSANDBOX_EGRESS_PROFILE": "sidecar",
+                        "OPENSANDBOX_CREDENTIAL_PROXY_SOCKET": vault.socket_path,
+                    },
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                )
+                try:
+                    ca = root / "ca" / "mitmproxy-ca-cert.pem"
+                    deadline = time.monotonic() + 10
+                    while time.monotonic() < deadline:
+                        if proc.poll() is not None:
+                            self.fail("mitmdump exited before readiness")
+                        try:
+                            with socket.create_connection(
+                                ("127.0.0.1", port), timeout=0.2
+                            ):
+                                if ca.exists():
+                                    break
+                        except OSError:
+                            pass
+                        time.sleep(0.05)
+                    else:
+                        self.fail("mitmdump did not become ready")
+                    conn = http.client.HTTPSConnection(
+                        "127.0.0.1",
+                        port,
+                        context=ssl.create_default_context(cafile=str(ca)),
+                        timeout=5,
+                    )
+                    try:
+                        conn.set_tunnel("api.example.com", 443)
+                        conn.request("GET", "/")
+                        response = conn.getresponse()
+                        self.assertEqual(response.status, 200)
+                        self.assertEqual(response.read(), b"injected")
+                    finally:
+                        conn.close()
+                finally:
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()
+                        proc.wait(timeout=5)
+                log.seek(0)
+                output = log.read()
+                self.assertIn("credential proxy: tls-shadow binding_host", output)
+                self.assertNotIn("observer_error", output)
+                self.assertNotIn("never-log-secret", output)

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -211,8 +211,32 @@ or to prove OSEP revision acknowledgement or enforcement correctness.
 `decision=decrypt|passthrough|unavailable` is a hypothetical SNI/HTTPS-host-scope
 projection at the existing request lookup. Lookup errors are `unavailable`,
 never a successful no-binding result. Network-policy outcomes and DLP coverage
-are not inferred. See the [metric reference](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/egress/docs/opentelemetry.md)
-for the bounded reasons and delivery limitations.
+are not inferred.
+
+| `decision` | `reason` | Meaning at the existing HTTPS/443 request Vault lookup |
+|---|---|---|
+| `decrypt` | `binding_host` | SNI is covered by an HTTPS binding host selector; method/path do not affect this host-level projection |
+| `passthrough` | `no_binding_host` | Validated Vault has no HTTPS selector covering SNI |
+| `passthrough` | `no_vault` | Sidecar active-Vault API returned authoritative absence; not proof of a future startup empty-snapshot transaction |
+| `unavailable` | `unknown_subject_or_vault` | Fleet 404 cannot distinguish an unknown source identity from absent Vault state |
+| `unavailable` | `lookup_failed` | The existing lookup failed; no cached result is used to guess |
+| `unavailable` | `missing_sni`, `invalid_sni` | No usable ASCII SNI in this observed request |
+| `unavailable` | `invalid_snapshot`, `observer_error` | Shadow projection could not interpret the sample |
+
+Only these fixed reasons and decisions plus existing shared attributes are
+exported. No hostname, path, credential, revision, or fleet subject ID is added.
+The Python addon emits a fixed outcome through its existing stdout pipe; Go
+consumes it as a metric instead of forwarding it to the application log sink.
+Unknown outcomes are discarded. Operator addons and the child process remain
+trusted diagnostic producers; this is not an audit record.
+
+Delivery is best effort. Process failure, pipe/log filtering, or exporter
+failure can lose observations; no-exporter deployments must not expect a stored
+log substitute. These are request-weighted observations after TLS termination,
+not ClientHello-time decisions: pooled requests count repeatedly, while opaque
+connections and failed handshakes never reach this hook. Shadow failures never
+change traffic. Evaluate `unavailable` alongside other outcomes rather than
+treating missing samples as successful pass-through.
 
 #### Enabling export from the server
 

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -187,7 +187,32 @@ See [Credential Vault](/guides/credential-vault) for full API usage, binding rul
 
 ### Observability (OpenTelemetry)
 
-Egress can export **OTLP metrics**; application logs use the **native zap** logger (JSON to stdout by default, configurable via `OPENSANDBOX_LOG_OUTPUT` / `OPENSANDBOX_EGRESS_LOG_LEVEL`). The credential proxy's log lines from mitmdump are piped into the same zap sink at warn level, so they land in the egress log file when `OPENSANDBOX_LOG_OUTPUT` points at one; mitmproxy's own flow logs are not forwarded. OTLP log export is not used.
+Egress can export **OTLP metrics**; application logs use the **native zap** logger (JSON to stdout by default, configurable via `OPENSANDBOX_LOG_OUTPUT` / `OPENSANDBOX_EGRESS_LOG_LEVEL`). The credential proxy's log lines from mitmdump are piped into the same zap sink at warn level; shadow outcome records described below are consumed as metrics instead. mitmproxy's own flow logs are not forwarded. OTLP log export is not used.
+
+#### Experimental TLS shadow observations
+
+Operators may set `OPENSANDBOX_EGRESS_MITMPROXY_SHADOW=true` directly on the
+egress process to collect `egress.mitm.shadow.requests_total` through the
+existing OTLP exporter. It defaults to off; this is not the public
+`credentialProxy.interceptionMode` option and is not forwarded through SDK
+sandbox environment settings. Enable it only for targeted diagnostic windows:
+it adds host matching and one fixed-format child-process record per sample.
+
+Samples are **HTTPS/443 request-header observations**, not TLS connection
+counts. They reuse the request's existing validated Vault result/ETag check;
+the observer performs no extra Vault lookup, retains no snapshot, and does not
+change TLS interception, credential injection, or rejection. A pooled
+connection may contribute many samples, and a binding change between handshake
+and request may change the projection. Early `ignore_hosts`/no-SNI/ECH opaque
+traffic, failed handshakes (including CA failures), and noncanonical ports are
+not represented. Do not use these samples to estimate total handshake savings
+or to prove OSEP revision acknowledgement or enforcement correctness.
+
+`decision=decrypt|passthrough|unavailable` is a hypothetical SNI/HTTPS-host-scope
+projection at the existing request lookup. Lookup errors are `unavailable`,
+never a successful no-binding result. Network-policy outcomes and DLP coverage
+are not inferred. See the [metric reference](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/egress/docs/opentelemetry.md)
+for the bounded reasons and delivery limitations.
 
 #### Enabling export from the server
 

--- a/oseps/0023-credential-bound-tls-interception.md
+++ b/oseps/0023-credential-bound-tls-interception.md
@@ -231,9 +231,11 @@ Both routes send all matching destinations to mitmdump.
 The system addon selects a credential binding in `requestheaders`, which runs
 after the TLS ClientHello and TLS termination. A request outside binding scope
 returns from the addon unchanged, but HTTPS was already decrypted. The active
-vault is pulled from a private Unix socket and cached for 0.5 seconds. Runtime
-vault writes update the Go store and return before that time-based cache is
-explicitly invalidated.
+vault is pulled from a private Unix socket with a per-request conditional ETag
+check; the full snapshot is reused only when its tag is confirmed. Runtime
+vault writes update the Go store, while the addon observes the update on a
+subsequent request. This is not the push-install acknowledgement protocol
+proposed below.
 
 Static `ignore_hosts` works earlier at ClientHello time and is therefore able
 to preserve opaque TLS, but it is fleet-wide static configuration rather than
@@ -800,8 +802,11 @@ it does not change traffic.
 Implementation has started with the internal host-selector algebra and shared
 Go/Python conformance vectors. The control plane owns non-transitional UTS #46
 normalization; the addon consumes canonical ASCII selectors and matches ASCII
-wire SNI. These helpers are not yet connected to the legacy Vault or TLS hooks.
-The public interception mode remains unavailable until the later phases pass.
+wire SNI. An opt-in request-level shadow observer now reuses the existing Vault
+lookup to project host coverage and exports a separate request-sample counter.
+It performs no ClientHello lookup and does not enable selective interception;
+opaque connections and failed handshakes are outside its observation set. The
+public interception mode remains unavailable until the later phases pass.
 
 1. **Decision telemetry and red tests**
    - Add fail-closed tests that distinguish authoritative empty from lookup


### PR DESCRIPTION
# Summary

The next OSEP-0023 observation step needs binding-host projections without adding a synchronous Vault lookup at ClientHello time. This PR adds opt-in, request-weighted shadow observations using the Vault result already validated for the current HTTPS/443 request.

- `OPENSANDBOX_EGRESS_MITMPROXY_SHADOW=true` enables operator diagnostics; default is off.
- Project SNI against HTTPS binding host selectors using the foundation from #1775. Do not change TLS, injection, or rejection behavior, perform another lookup, or retain a subject/Vault cache.
- Convert fixed-vocabulary child-process records into `egress.mitm.shadow.requests_total` through the existing Go OTLP exporter. Unknown outcomes never become labels. Fleet 404 ambiguity is `unavailable`, not a no-binding pass-through claim.
- Document the sampling boundary: observations occur after TLS termination, pooled requests count repeatedly, and opaque traffic/failed handshakes are excluded. These are not connection counts, enforcement decisions, or proof of future snapshot acknowledgement.

Related: #1713. Follows #1775; selective interception and acknowledged snapshot installation remain later OSEP phases. No public interception-mode field or SDK option is added.

# Testing

- [ ] Not run
- [x] Unit tests
- [x] Integration tests (local mitmdump TLS and stdout-to-OTLP pipeline)
- [ ] e2e / manual verification (Linux transparent netns, Docker/Kubernetes/fleet smoke not run)

Validation:

- New tests failed before implementation.
- Full egress `go test ./...` (375 tests), `go vet ./...`, `go build ./...` passed after updating to main at da268303.
- `go test -race ./pkg/telemetry ./pkg/mitmproxy` passed.
- Python discovery with Python 3.12 and mitmproxy 11.0.2: 85 tests passed, including a real local TLS request that retains credential injection and produces a shadow sample. Existing timeout tests emit BrokenPipe/ResourceWarning diagnostics.
- A real local OTLP receiver verifies timestamped child records produce the expected bounded-label metric counts and discard unknown outcomes.
- Focused Ruff checks/format passed for all new Python files. Whole `system.py` Ruff reports the same three existing I001/SIM102/SIM103 findings on base and head.
- Docs built with the repository-pinned pnpm 9.15.0; lockfile unchanged. Existing syntax-highlighting/chunk-size warnings remain.
- License verification and `git diff --check` passed.
- Independent scoped review passed. Real early-bypass/no-SNI/failed-handshake negative sampling tests remain a coverage gap; the hook boundary and documented exclusions are explicit.

# Breaking Changes

- [x] None
- [ ] Yes

The opt-in observer is best-effort diagnostic instrumentation. It adds request-path host matching and one fixed-format record per observed request; use targeted observation windows. Existing defaults and runtime behavior remain unchanged.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs
- [x] Added/updated tests
- [x] Security impact considered
- [x] Backward compatibility considered
