### PR TITLE
fix(kubernetes): compare pool replica counts by value

### DIFF
--- a/kubernetes/internal/controller/pool_controller.go
+++ b/kubernetes/internal/controller/pool_controller.go
@@ -577,6 +577,31 @@ func (r *PoolReconciler) calculateRevision(pool *sandboxv1alpha1.Pool) (string, 
 	return hex.EncodeToString(revision[:8]), nil
 }
 
+// shouldReconcilePoolForBatchSandboxUpdate filters updates that affect pool allocation.
+func shouldReconcilePoolForBatchSandboxUpdate(e event.UpdateEvent) bool {
+	oldObj, okOld := e.ObjectOld.(*sandboxv1alpha1.BatchSandbox)
+	newObj, okNew := e.ObjectNew.(*sandboxv1alpha1.BatchSandbox)
+	if !okOld || !okNew {
+		return false
+	}
+	if newObj.Spec.PoolRef == "" {
+		return false
+	}
+	oldVal := oldObj.Annotations[AnnoAllocReleaseKey]
+	newVal := newObj.Annotations[AnnoAllocReleaseKey]
+	if oldVal != newVal {
+		return true
+	}
+	if !equality.Semantic.DeepEqual(oldObj.Spec.Replicas, newObj.Spec.Replicas) {
+		return true
+	}
+	// Trigger reconcile when sandbox enters terminating state (DeletionTimestamp is set).
+	if oldObj.DeletionTimestamp.IsZero() && !newObj.DeletionTimestamp.IsZero() {
+		return true
+	}
+	return false
+}
+
 // SetupWithManager sets up the controller with the Manager.
 // Todo pod deletion expectations
 func (r *PoolReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
@@ -592,29 +617,7 @@ func (r *PoolReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconci
 			}
 			return bsb.Spec.PoolRef != ""
 		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldObj, okOld := e.ObjectOld.(*sandboxv1alpha1.BatchSandbox)
-			newObj, okNew := e.ObjectNew.(*sandboxv1alpha1.BatchSandbox)
-			if !okOld || !okNew {
-				return false
-			}
-			if newObj.Spec.PoolRef == "" {
-				return false
-			}
-			oldVal := oldObj.Annotations[AnnoAllocReleaseKey]
-			newVal := newObj.Annotations[AnnoAllocReleaseKey]
-			if oldVal != newVal {
-				return true
-			}
-			if oldObj.Spec.Replicas != newObj.Spec.Replicas {
-				return true
-			}
-			// Trigger reconcile when sandbox enters terminating state (DeletionTimestamp is set).
-			if oldObj.DeletionTimestamp.IsZero() && !newObj.DeletionTimestamp.IsZero() {
-				return true
-			}
-			return false
-		},
+		UpdateFunc: shouldReconcilePoolForBatchSandboxUpdate,
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			bsb, ok := e.Object.(*sandboxv1alpha1.BatchSandbox)
 			if !ok {

--- a/kubernetes/internal/controller/pool_predicate_test.go
+++ b/kubernetes/internal/controller/pool_predicate_test.go
@@ -1,0 +1,130 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	sandboxv1alpha1 "github.com/alibaba/OpenSandbox/sandbox-k8s/apis/sandbox/v1alpha1"
+)
+
+// TestPoolBatchSandboxUpdateReplicas 验证副本数按值比较：不同地址的相同值不触发，
+// 数值变化触发，双方 nil 不触发，nil 与显式零值之间的两个方向均触发。
+func TestPoolBatchSandboxUpdateReplicas(t *testing.T) {
+	cases := []struct {
+		name                     string
+		oldReplicas, newReplicas *int32
+		want                     bool
+	}{
+		{name: "equal-values-at-different-addresses", oldReplicas: ptr.To(int32(1)), newReplicas: ptr.To(int32(1))},
+		{name: "changed-values", oldReplicas: ptr.To(int32(1)), newReplicas: ptr.To(int32(2)), want: true},
+		{name: "both-nil"},
+		{name: "nil-to-zero", newReplicas: ptr.To(int32(0)), want: true},
+		{name: "zero-to-nil", oldReplicas: ptr.To(int32(0)), want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldObj := &sandboxv1alpha1.BatchSandbox{
+				Spec: sandboxv1alpha1.BatchSandboxSpec{PoolRef: "warm-pool", Replicas: tc.oldReplicas},
+			}
+			newObj := oldObj.DeepCopy()
+			newObj.Spec.Replicas = tc.newReplicas
+			got := shouldReconcilePoolForBatchSandboxUpdate(event.UpdateEvent{ObjectOld: oldObj, ObjectNew: newObj})
+			if got != tc.want {
+				t.Errorf("update predicate = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPoolBatchSandboxUpdateFilters 验证深拷贝后无关更新仍被过滤：状态、普通注解和
+// 已处于删除状态的更新不触发；释放注解变化、首次进入删除状态仍触发；无池引用和错误类型被过滤。
+func TestPoolBatchSandboxUpdateFilters(t *testing.T) {
+	cases := []struct {
+		name   string
+		update func(*event.UpdateEvent)
+		want   bool
+	}{
+		{
+			name: "status-only",
+			update: func(e *event.UpdateEvent) {
+				e.ObjectNew.(*sandboxv1alpha1.BatchSandbox).Status.Ready = 1
+			},
+		},
+		{
+			name: "unrelated-annotation",
+			update: func(e *event.UpdateEvent) {
+				e.ObjectNew.SetAnnotations(map[string]string{"example.com/note": "updated"})
+			},
+		},
+		{
+			name: "release-annotation",
+			update: func(e *event.UpdateEvent) {
+				e.ObjectNew.SetAnnotations(map[string]string{AnnoAllocReleaseKey: `{"pods":["warm-pod"]}`})
+			},
+			want: true,
+		},
+		{
+			name: "entering-terminating-state",
+			update: func(e *event.UpdateEvent) {
+				timestamp := metav1.Now()
+				e.ObjectNew.SetDeletionTimestamp(&timestamp)
+			},
+			want: true,
+		},
+		{
+			name: "already-terminating",
+			update: func(e *event.UpdateEvent) {
+				timestamp := metav1.Now()
+				e.ObjectOld.SetDeletionTimestamp(&timestamp)
+				e.ObjectNew.SetDeletionTimestamp(&timestamp)
+			},
+		},
+		{
+			name: "no-pool-reference",
+			update: func(e *event.UpdateEvent) {
+				newObj := e.ObjectNew.(*sandboxv1alpha1.BatchSandbox)
+				newObj.Spec.PoolRef = ""
+				newObj.Spec.Replicas = ptr.To(int32(2))
+			},
+		},
+		{
+			name:   "invalid-old-object",
+			update: func(e *event.UpdateEvent) { e.ObjectOld = &corev1.Pod{} },
+		},
+		{
+			name:   "invalid-new-object",
+			update: func(e *event.UpdateEvent) { e.ObjectNew = &corev1.Pod{} },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldObj := &sandboxv1alpha1.BatchSandbox{
+				Spec: sandboxv1alpha1.BatchSandboxSpec{PoolRef: "warm-pool", Replicas: ptr.To(int32(1))},
+			}
+			// DeepCopy gives the new object its own Replicas pointer, as on an unrelated update.
+			update := event.UpdateEvent{ObjectOld: oldObj, ObjectNew: oldObj.DeepCopy()}
+			tc.update(&update)
+			if got := shouldReconcilePoolForBatchSandboxUpdate(update); got != tc.want {
+				t.Errorf("update predicate = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Summary

Fixes #1778.

The Pool controller currently treats two `Replicas` pointers with equal values as a replica change, so status-only or unrelated annotation updates can enqueue the entire Pool. Compare the values with the existing `equality.Semantic.DeepEqual`, preserving nil handling.

Extract the existing update predicate into an unexported function so regression tests exercise the same logic registered with the watch. Release-annotation and terminating-state triggers remain unchanged.

# Testing

- [x] Unit tests: `go test ./internal/controller/ -run '^TestPoolBatchSandboxUpdate' -count=1 -v` — all 13 cases pass.
- Verified the regression tests fail with the original pointer comparison (equal values at different addresses, status-only updates, unrelated annotations, and already-terminating updates).
- `make test` was attempted: manifest/DeepCopy generation, formatting, and `go vet ./...` passed. The full suite could not start because downloading the envtest Kubernetes binaries/index timed out; the alternate official asset download was also too slow to complete locally.
- [ ] Full envtest suite — blocked by the download issue above.
- [ ] e2e / manual cluster verification — not run.

# Breaking Changes

- [x] None

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed) — no public API or configuration changes
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
