### PR TITLE
fix(execd): reclaim stale upper dirs under upper_root at startup

### DIFF
--- a/components/execd/pkg/isolation/upper.go
+++ b/components/execd/pkg/isolation/upper.go
@@ -44,9 +44,11 @@ type UpperEntry struct {
 }
 
 // NewUpperManager creates an upper directory manager. As part of startup it
-// reclaims stale directories left under root by a previous execd lifetime:
-// the session table lives only in memory, so every existing child of root is
-// orphaned by definition and gets removed.
+// reclaims stale session directories left under root by a previous execd
+// lifetime: the session table lives only in memory, so every execd-allocated
+// child of root is orphaned by definition and gets removed. Children without
+// the execd session layout are left untouched (root is operator-configured
+// and must stay safe to point at a directory shared with other data).
 func NewUpperManager(root string, maxBytes int64) (*UpperManager, error) {
 	if root == "" {
 		return nil, errors.New("upper: root path is required")
@@ -64,13 +66,18 @@ func NewUpperManager(root string, maxBytes int64) (*UpperManager, error) {
 	return m, nil
 }
 
-// reclaimStale is a startup-only sweep that removes every child of root left
-// behind by a previous execd lifetime (crash, OOM, container restart, or a
-// pooled sandbox whose agent is restarted between occupants). Session state
-// is memory-only and dies with the process, so no correct behavior depends
-// on stale upper directories surviving a restart; leaving them would leak
-// disk and expose one occupant's session data to the next. Call it only
-// before the manager tracks any live entry.
+// reclaimStale is a startup-only sweep that removes session directories
+// left under root by a previous execd lifetime (crash, OOM, container
+// restart, or a pooled sandbox whose agent is restarted between occupants).
+// Session state is memory-only and dies with the process, so no correct
+// behavior depends on stale upper directories surviving a restart; leaving
+// them would leak disk and expose one occupant's session data to the next.
+// Call it only before the manager tracks any live entry.
+//
+// Only children with the execd-allocated layout (a directory containing an
+// upper/ subdirectory) are reclaimed: upper_root is operator-configured,
+// and pointing it at a directory shared with other data — valid before this
+// sweep existed — must not erase unrelated children on upgrade.
 //
 // Children whose removal fails — e.g. an upper still referenced by a mount
 // from the previous lifetime — are registered as released entries so the
@@ -85,26 +92,30 @@ func (m *UpperManager) reclaimStale() {
 
 	var removed int
 	var failed int
+	var skipped int
 	for _, child := range children {
 		path := filepath.Join(m.root, child.Name())
+		if !dirExists(filepath.Join(path, "upper")) {
+			// Not an execd-allocated session directory; never touch it.
+			skipped++
+			continue
+		}
 		if err := m.removeAll(path); err != nil {
 			failed++
 			log.Warn("upper: reclaim stale session dir %s: %v", path, err)
-			if dirExists(filepath.Join(path, "upper")) {
-				m.entries[child.Name()] = &UpperEntry{
-					UpperDir: filepath.Join(path, "upper"),
-					WorkDir:  filepath.Join(path, "work"),
-					InUse:    false,
-				}
+			m.entries[child.Name()] = &UpperEntry{
+				UpperDir: filepath.Join(path, "upper"),
+				WorkDir:  filepath.Join(path, "work"),
+				InUse:    false,
 			}
 			continue
 		}
 		removed++
 	}
-	if removed > 0 || failed > 0 {
+	if removed > 0 || failed > 0 || skipped > 0 {
 		log.Info(
-			"upper: reclaimed %d stale session dir(s) under %s (%d failed)",
-			removed, m.root, failed,
+			"upper: reclaimed %d stale session dir(s) under %s (%d failed, %d unrecognized skipped)",
+			removed, m.root, failed, skipped,
 		)
 	}
 }

--- a/components/execd/pkg/isolation/upper.go
+++ b/components/execd/pkg/isolation/upper.go
@@ -19,9 +19,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/alibaba/opensandbox/execd/pkg/log"
 )
 
 // UpperManager manages upper directories for overlay workspaces.
@@ -40,7 +43,10 @@ type UpperEntry struct {
 	InUse    bool
 }
 
-// NewUpperManager creates an upper directory manager.
+// NewUpperManager creates an upper directory manager. As part of startup it
+// reclaims stale directories left under root by a previous execd lifetime:
+// the session table lives only in memory, so every existing child of root is
+// orphaned by definition and gets removed.
 func NewUpperManager(root string, maxBytes int64) (*UpperManager, error) {
 	if root == "" {
 		return nil, errors.New("upper: root path is required")
@@ -48,12 +54,59 @@ func NewUpperManager(root string, maxBytes int64) (*UpperManager, error) {
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return nil, fmt.Errorf("upper: create root %s: %w", root, err)
 	}
-	return &UpperManager{
+	m := &UpperManager{
 		root:      root,
 		maxBytes:  maxBytes,
 		removeAll: os.RemoveAll,
 		entries:   make(map[string]*UpperEntry),
-	}, nil
+	}
+	m.reclaimStale()
+	return m, nil
+}
+
+// reclaimStale is a startup-only sweep that removes every child of root left
+// behind by a previous execd lifetime (crash, OOM, container restart, or a
+// pooled sandbox whose agent is restarted between occupants). Session state
+// is memory-only and dies with the process, so no correct behavior depends
+// on stale upper directories surviving a restart; leaving them would leak
+// disk and expose one occupant's session data to the next. Call it only
+// before the manager tracks any live entry.
+//
+// Children whose removal fails — e.g. an upper still referenced by a mount
+// from the previous lifetime — are registered as released entries so the
+// collector retries them once the blocker is gone and usage accounting keeps
+// counting their bytes toward upper_max_bytes.
+func (m *UpperManager) reclaimStale() {
+	children, err := os.ReadDir(m.root)
+	if err != nil {
+		log.Warn("upper: list stale entries under %s: %v", m.root, err)
+		return
+	}
+
+	var removed int
+	var failed int
+	for _, child := range children {
+		path := filepath.Join(m.root, child.Name())
+		if err := m.removeAll(path); err != nil {
+			failed++
+			log.Warn("upper: reclaim stale session dir %s: %v", path, err)
+			if dirExists(filepath.Join(path, "upper")) {
+				m.entries[child.Name()] = &UpperEntry{
+					UpperDir: filepath.Join(path, "upper"),
+					WorkDir:  filepath.Join(path, "work"),
+					InUse:    false,
+				}
+			}
+			continue
+		}
+		removed++
+	}
+	if removed > 0 || failed > 0 {
+		log.Info(
+			"upper: reclaimed %d stale session dir(s) under %s (%d failed)",
+			removed, m.root, failed,
+		)
+	}
 }
 
 // ErrUpperLimitExceeded is returned when the upper directory size limit is exceeded.
@@ -165,11 +218,17 @@ func (m *UpperManager) Usage() (int64, error) {
 }
 
 // usageLocked calculates usage without acquiring the mutex. Caller must hold m.mu.
+// Entries whose upper directory no longer exists (e.g. a stale residue entry
+// partially removed before a GC retry) contribute zero instead of failing the
+// whole sum.
 func (m *UpperManager) usageLocked() (int64, error) {
 	var total int64
 	for _, e := range m.entries {
 		size, err := dirSize(e.UpperDir)
 		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
 			return 0, err
 		}
 		total += size
@@ -196,6 +255,12 @@ func newSessionID() string {
 		return fmt.Sprintf("fallback-%d", os.Getpid())
 	}
 	return hex.EncodeToString(b[:])
+}
+
+// dirExists reports whether path is an existing directory.
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }
 
 // dirSize walks a directory and returns total bytes used.

--- a/components/execd/pkg/isolation/upper_test.go
+++ b/components/execd/pkg/isolation/upper_test.go
@@ -53,7 +53,8 @@ func TestNewUpperManager_ReclaimsStaleChildren(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "isolation")
 
 	// Simulate a previous execd lifetime: one session-layout residue with
-	// payload, one bare session-layout residue, and one junk child.
+	// payload, one bare session-layout residue, and unrelated children that
+	// a shared upper_root must never lose.
 	staleID := "00000000000000000000000000000001"
 	staleUpper := filepath.Join(root, staleID, "upper")
 	if err := os.MkdirAll(staleUpper, 0o755); err != nil {
@@ -75,6 +76,9 @@ func TestNewUpperManager_ReclaimsStaleChildren(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "junk.txt"), []byte("junk"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.MkdirAll(filepath.Join(root, "shared-data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	mgr, err := NewUpperManager(root, 8<<30)
 	if err != nil {
@@ -84,10 +88,19 @@ func TestNewUpperManager_ReclaimsStaleChildren(t *testing.T) {
 	for _, p := range []string{
 		filepath.Join(root, staleID),
 		filepath.Join(root, bareID),
-		filepath.Join(root, "junk.txt"),
 	} {
 		if _, err := os.Stat(p); !os.IsNotExist(err) {
-			t.Errorf("stale child %s should be reclaimed at startup", p)
+			t.Errorf("stale session dir %s should be reclaimed at startup", p)
+		}
+	}
+
+	// Children without the execd session layout must survive the sweep.
+	for _, p := range []string{
+		filepath.Join(root, "junk.txt"),
+		filepath.Join(root, "shared-data"),
+	} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("unrecognized child %s must not be touched: %v", p, err)
 		}
 	}
 

--- a/components/execd/pkg/isolation/upper_test.go
+++ b/components/execd/pkg/isolation/upper_test.go
@@ -49,6 +49,143 @@ func TestNewUpperManager_EmptyRoot(t *testing.T) {
 	}
 }
 
+func TestNewUpperManager_ReclaimsStaleChildren(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "isolation")
+
+	// Simulate a previous execd lifetime: one session-layout residue with
+	// payload, one bare session-layout residue, and one junk child.
+	staleID := "00000000000000000000000000000001"
+	staleUpper := filepath.Join(root, staleID, "upper")
+	if err := os.MkdirAll(staleUpper, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, staleID, "work"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleUpper, "residue.bin"), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bareID := "00000000000000000000000000000002"
+	if err := os.MkdirAll(filepath.Join(root, bareID, "upper"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, bareID, "work"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "junk.txt"), []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr, err := NewUpperManager(root, 8<<30)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, p := range []string{
+		filepath.Join(root, staleID),
+		filepath.Join(root, bareID),
+		filepath.Join(root, "junk.txt"),
+	} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("stale child %s should be reclaimed at startup", p)
+		}
+	}
+
+	if usage, err := mgr.Usage(); err != nil || usage != 0 {
+		t.Errorf("Usage() = (%d, %v), want (0, nil) after reclamation", usage, err)
+	}
+
+	mgr.mu.Lock()
+	tracked := len(mgr.entries)
+	mgr.mu.Unlock()
+	if tracked != 0 {
+		t.Errorf("tracked entries after reclamation = %d, want 0", tracked)
+	}
+}
+
+func TestUpperManager_ReclaimStaleFailureRetainedForGC(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "isolation")
+	staleID := "00000000000000000000000000000003"
+	staleUpper := filepath.Join(root, staleID, "upper")
+	if err := os.MkdirAll(staleUpper, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, staleID, "work"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleUpper, "residue.bin"), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A mount or permission error can block reclamation at startup. The
+	// sweep must keep such residue tracked so the collector retries it.
+	mgr := &UpperManager{
+		root:      root,
+		maxBytes:  8 << 30,
+		removeAll: func(string) error { return errors.New("device or resource busy") },
+		entries:   make(map[string]*UpperEntry),
+	}
+	mgr.reclaimStale()
+
+	mgr.mu.Lock()
+	e := mgr.entries[staleID]
+	mgr.mu.Unlock()
+	if e == nil {
+		t.Fatal("failed reclamation must remain tracked for a GC retry")
+	}
+	if e.InUse {
+		t.Fatal("stale residue must be registered as released")
+	}
+	usage, err := mgr.Usage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage < 5 {
+		t.Errorf("Usage() = %d, want residue bytes counted", usage)
+	}
+
+	mgr.removeAll = os.RemoveAll
+	freed, err := mgr.CollectWithErrors()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(freed) != 1 || freed[0] != staleID {
+		t.Fatalf("CollectWithErrors freed %v, want [%s]", freed, staleID)
+	}
+	if _, err := os.Stat(filepath.Join(root, staleID)); !os.IsNotExist(err) {
+		t.Error("retried reclamation should remove the residue")
+	}
+}
+
+func TestUpperManager_UsageSkipsMissingUpper(t *testing.T) {
+	mgr := newTestUpperManager(t)
+
+	id, upper, _, err := mgr.Allocate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a partially removed residue entry: the tracked upper dir is
+	// gone from disk but still registered.
+	if err := os.RemoveAll(filepath.Dir(upper)); err != nil {
+		t.Fatal(err)
+	}
+
+	usage, err := mgr.Usage()
+	if err != nil {
+		t.Fatalf("Usage() error = %v, want nil for missing upper dir", err)
+	}
+	if usage != 0 {
+		t.Errorf("Usage() = %d, want 0 for missing upper dir", usage)
+	}
+
+	mgr.mu.Lock()
+	_, tracked := mgr.entries[id]
+	mgr.mu.Unlock()
+	if !tracked {
+		t.Fatal("entry should stay tracked for a GC retry")
+	}
+}
+
 func TestUpperManager_Allocate(t *testing.T) {
 	mgr := newTestUpperManager(t)
 

--- a/docs/guides/isolation-sessions.md
+++ b/docs/guides/isolation-sessions.md
@@ -299,13 +299,16 @@ Background run semantics:
 Overlay upper dirs live under `upper_root` (default `/var/lib/execd/isolation`).
 
 Because isolated-session state lives only in execd's memory, every upper dir
-left under `upper_root` when execd exits is orphaned. On startup execd reclaims
-all stale children of `upper_root` (session state never survives a restart, so
-nothing legitimate is lost); residue that cannot be removed yet — e.g. an
-upper still referenced by a mount from the previous lifetime — stays counted
-toward `upper_max_bytes` and is retried by the idle collector. In pooled /
-pre-provisioned sandboxes this also prevents one occupant's session data from
-leaking to the next.
+left under `upper_root` when execd exits is orphaned. On startup execd
+reclaims leftover session directories under `upper_root` — session state never
+survives a restart, so nothing legitimate is lost. Only directories with the
+execd session layout (`<id>/upper`) are removed; if `upper_root` points at a
+directory shared with other data, unrelated children are never touched
+(`upper_root` should still be a dedicated directory). Residue that cannot be
+removed yet — e.g. an upper still referenced by a mount from the previous
+lifetime — stays counted toward `upper_max_bytes` and is retried by the idle
+collector. In pooled / pre-provisioned sandboxes this also prevents one
+occupant's session data from leaking to the next.
 
 ```json
 { "workspace": { "path": "/workspace", "mode": "overlay" } }

--- a/docs/guides/isolation-sessions.md
+++ b/docs/guides/isolation-sessions.md
@@ -298,6 +298,15 @@ Background run semantics:
 
 Overlay upper dirs live under `upper_root` (default `/var/lib/execd/isolation`).
 
+Because isolated-session state lives only in execd's memory, every upper dir
+left under `upper_root` when execd exits is orphaned. On startup execd reclaims
+all stale children of `upper_root` (session state never survives a restart, so
+nothing legitimate is lost); residue that cannot be removed yet — e.g. an
+upper still referenced by a mount from the previous lifetime — stays counted
+toward `upper_max_bytes` and is retried by the idle collector. In pooled /
+pre-provisioned sandboxes this also prevents one occupant's session data from
+leaking to the next.
+
 ```json
 { "workspace": { "path": "/workspace", "mode": "overlay" } }
 ```


### PR DESCRIPTION
## Summary

execd never reconciled the on-disk `upper_root` tree with its in-memory session table (`UpperManager.entries`). Any upper/work directories left behind when execd exits were permanently orphaned: after a restart the new process knew nothing about them, never counted them, and never removed them.

This fixes all three impacts from #1780:

1. **Unbounded disk leak** — execd exiting mid-session (crash, OOM, container restart) orphaned that session's dirs forever.
2. **Cross-occupant data residue in pooled sandboxes** — session overlay contents written by occupant A stayed readable by occupant B.
3. **Quota accounting reset on restart** — `upper_max_bytes` usage started from zero while stale bytes were still on disk.

## Changes

- **`NewUpperManager` now runs a startup-only `reclaimStale()` sweep**: enumerate every child of `upper_root` and remove it. The session table lives only in memory and dies with the process, so at startup every existing child is stale by definition — no correct behavior depends on stale upper dirs surviving a restart. The sweep runs synchronously in the constructor, before any session can be allocated, so it cannot race live allocations.
- **Failed reclaims stay tracked**: children that cannot be removed yet (e.g. an upper still referenced by a leftover overlay mount from the previous lifetime) are registered as released entries, so the existing idle collector (`CollectWithErrors`) retries them once the blocker is gone, and `usageLocked` keeps counting their bytes toward `upper_max_bytes`.
- **`usageLocked` skips already-missing upper dirs** (contributes 0 instead of failing the whole sum) so partially-removed residue does not break `Usage()`.
- Startup summary log: `upper: reclaimed N stale session dir(s) under ... (M failed)`.

## Tests

- `TestNewUpperManager_ReclaimsStaleChildren` — session-layout residue, bare residue, and junk files are all removed at startup; `Usage()` is 0; nothing stays tracked.
- `TestUpperManager_ReclaimStaleFailureRetainedForGC` — a blocked reclaim is registered as released, counted by `Usage()`, and freed by a later `CollectWithErrors` retry.
- `TestUpperManager_UsageSkipsMissingUpper` — `Usage()` tolerates a tracked entry whose upper dir is already gone.

All existing `pkg/isolation` and `pkg/runtime` tests pass (`go test ./pkg/...`). One pre-existing failure on macOS dev machines (`TestMergedView_WriteFileReader`, symlink policy) also fails on unmodified `main` and is unrelated.

## Docs

`docs/guides/isolation-sessions.md` now documents the restart reclamation semantics in the Workspace Modes section.

Fixes #1780