### PR TITLE
test(execd): stabilize asynchronous completion assertions

### DIFF
--- a/components/execd/pkg/runtime/bash_session_test.go
+++ b/components/execd/pkg/runtime/bash_session_test.go
@@ -651,10 +651,13 @@ LOG_FILE=$(mktemp)
 export LOG_FILE
 exec 3>&1 4>&2
 exec > >(tee "$LOG_FILE") 2>&1
+tee_pid=$!
 
 set -x
 echo "from-complex-exec"
 exec 1>&3 2>&4 # step record
+# Drain the process substitution before the session captures its environment.
+wait "$tee_pid"
 echo "after-restore"
 `
 

--- a/components/execd/pkg/runtime/isolated_background_test.go
+++ b/components/execd/pkg/runtime/isolated_background_test.go
@@ -26,6 +26,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func waitForBackgroundRun(
@@ -596,13 +598,11 @@ func TestBackgroundRunLogCappedOnDisk(t *testing.T) {
 		t.Fatal("run record missing")
 	}
 	run := v.(*IsolatedBackgroundRun)
-	info, err := os.Stat(run.logPath)
-	if err != nil {
-		t.Fatalf("stat log: %v", err)
-	}
-	if info.Size() != maxBackgroundLogReadBytes {
-		t.Errorf("log size = %d, want %d (capped)", info.Size(), maxBackgroundLogReadBytes)
-	}
+	// The completion flag is published before the monitor caps the log.
+	require.Eventually(t, func() bool {
+		info, err := os.Stat(run.logPath)
+		return err == nil && info.Size() == maxBackgroundLogReadBytes
+	}, 5*time.Second, 10*time.Millisecond, "completed run log should be capped")
 }
 
 // TestSeekIsolatedBackgroundOutput_ClampsCursorPastEOF verifies a cursor beyond

--- a/components/execd/pkg/web/controller/pty_ws_test.go
+++ b/components/execd/pkg/web/controller/pty_ws_test.go
@@ -362,9 +362,20 @@ func TestPTYWS_ViewerClosesAfterReadOnlyViolationLimit(t *testing.T) {
 		require.Equal(t, model.WSErrCodeReadOnly, f.Code)
 	}
 
-	_ = viewer.SetReadDeadline(time.Now().Add(5 * time.Second))
-	_, _, err := viewer.ReadMessage()
-	require.Error(t, err, "viewer should close after repeated read-only violations")
+	// The output pump can send replay after the final READ_ONLY error but
+	// before cancellation closes the socket. Drain it within one deadline;
+	// a timeout or malformed frame must not be mistaken for peer closure.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		frame, err := ptyReadFrame(viewer, time.Until(deadline))
+		if err != nil {
+			var closeErr *websocket.CloseError
+			require.ErrorAs(t, err, &closeErr, "viewer should close after repeated read-only violations")
+			return
+		}
+		require.Equal(t, "replay", frame.Type, "unexpected frame while waiting for viewer closure")
+	}
+	t.Fatal("viewer did not close after repeated read-only violations")
 }
 
 func TestPTYWS_ViewerFlushesOutputBeforeExit(t *testing.T) {

--- a/components/execd/pkg/web/controller/pty_ws_test.go
+++ b/components/execd/pkg/web/controller/pty_ws_test.go
@@ -366,8 +366,12 @@ func TestPTYWS_ViewerClosesAfterReadOnlyViolationLimit(t *testing.T) {
 	// before cancellation closes the socket. Drain it within one deadline;
 	// a timeout or malformed frame must not be mistaken for peer closure.
 	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		frame, err := ptyReadFrame(viewer, time.Until(deadline))
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		frame, err := ptyReadFrame(viewer, remaining)
 		if err != nil {
 			var closeErr *websocket.CloseError
 			require.ErrorAs(t, err, &closeErr, "viewer should close after repeated read-only violations")


### PR DESCRIPTION
# Summary

Follow-up to #1420 and [Elioooon's report and proposed assertion fix](https://github.com/opensandbox-group/OpenSandbox/pull/1420#issuecomment-5596460820).

The viewer output pump can send a replay frame after the fifth READ_ONLY error and before cancellation closes the socket. The previous single-read assertion rejected this valid ordering, while accepting a read timeout even when the peer remained open. Drain only replay frames within one five-second deadline and require a WebSocket CloseError. Malformed frames, unexpected application messages, and timeouts fail the test.

The Bash complex-exec fixture also waits for its process-substitution tee after restoring stdout and stderr. Without that wait, delayed tee output can overlap the session environment snapshot and disappear from the stdout hook, causing the CI assertion to fail intermittently. The background log-cap assertion now waits for truncation after the completion flag, matching the existing monitor ordering while still failing if the cap is never applied. All changes are test-only; runtime behavior remains unchanged.

# Testing

- [x] Linux server (non-root) and local Ubuntu, both Go 1.25.9: full CI coverage command `go test -v -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./pkg/...` passed (local run omitted only `-v`).
- [x] Log-cap test passed 20 repeats with `-race`; a test-only overlay disabling truncation failed with the expected cap assertion.
- [x] `go vet ./pkg/runtime ./pkg/web/controller`, `gofmt`, and `git diff --check` passed.

- [x] Linux server / Go 1.25.9: `TestBashSession_complexExec` passed 1,000 repetitions with `-race`. A test-only overlay delaying tee and environment export reproduced the CI failure in all 3 original runs; the synchronized fixture passed all 20 runs under the same injected timing.
- [x] Linux server / Go 1.26.3: `go test -race -count=100 -run '^TestPTYWS_ViewerClosesAfterReadOnlyViolationLimit$' ./pkg/web/controller` passed.
- [x] Linux server: complete controller package with `-race -count=1` passed all 96 top-level tests, no skips; `go vet ./pkg/web/controller` and formatting checks passed.
- [x] Local Ubuntu / Go 1.25.9: complete controller package with `-race -count=1` and `go vet ./pkg/web/controller` passed.
- [x] Test-only Go overlays against the real PTY WebSocket route confirmed these outcomes:

| Injected behavior | Original assertion | Fixed assertion |
|---|---|---|
| Binary replay after final READ_ONLY, then close | Fails | Passes |
| Suppress violation-limit closure; silent pipe-mode holder | Incorrectly passes on timeout | Fails on timeout |
| Truncated binary replay | Fails | Fails |
| Unexpected pong application frame | Fails | Fails |

The replay was injected through the viewer writer before cancellation; the silent case used a pipe-mode holder to avoid unrelated shell-prompt output. These are controlled test mutations, not a claim of reproducing a production scheduling failure. No mutation was applied to committed production code.

- [ ] Live Pod / remote-network E2E: not run; validation uses real local sockets and shell processes on the Linux server.

# Breaking Changes

- [x] None

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated tests
- [x] Documentation not required for a test-only assertion change
- [x] Security impact considered: retains existing viewer mutation checks
- [x] Backward compatibility considered
