### PR TITLE
feat(sdks): align Python sandbox pool warmup model with Kotlin

### DIFF
--- a/docs/guides/client-pool.md
+++ b/docs/guides/client-pool.md
@@ -38,14 +38,18 @@ across sandboxes today.
 Two flows happen concurrently:
 
 - **Warmup (leader-only).** A background reconcile loop runs on every node. Whichever
-  node holds the primary lock computes the idle deficit and replenishes it. Python and
-  Go use the configurable `reconcile_interval` and cap each tick with
-  `warmup_concurrency`. Kotlin reconciles once per second, admits at most
-  `warmup_create_qps` new creates per tick, and independently limits post-create
-  readiness and preparation work with `warmup_concurrency`. A successful warmup is
-  published to the idle buffer with a TTL of `idle_timeout`. Within a Python
-  reconcile tick, each successful warmup is published as soon as it completes;
-  slower peers in the same tick do not delay its availability.
+  node holds the primary lock computes the idle deficit and replenishes it. Python
+  uses the configurable `reconcile_interval`; like Kotlin, each tick only admits at
+  most `warmup_create_qps` new creates (in-flight warmups count toward `max_idle`
+  together with idle sandboxes) and returns without waiting: every admitted warmup
+  task creates, validates, renews, and commits its sandbox independently, bounded by
+  `warmup_concurrency` concurrent warmup workers (a semaphore in asyncio, executor
+  threads in sync). Go caps each tick with `warmup_concurrency` alone and waits for
+  the tick's warmups. Python and Kotlin also renew the primary lease with an
+  independent heartbeat at an interval no greater than one third of
+  `primary_lock_ttl`. A successful warmup is published to the idle buffer with a
+  TTL of `idle_timeout`; a slow warmup never delays the availability of its peers
+  or the next reconcile tick.
 - **Acquire (any node).** `acquire()` pops an idle ID from the store, connects a
   `Sandbox` client to it, optionally runs a health check and a `renew()` to the
   caller-supplied timeout, and hands it to the caller. Non-leader nodes can acquire
@@ -64,12 +68,12 @@ because it is the only part of the pool that is gated by a distributed lock:
 
 Each pool instance moves through `NOT_STARTED → STARTING → RUNNING → DRAINING → STOPPED`.
 Health is tracked separately as `HEALTHY | DEGRADED | DRAINING | STOPPED`; after
-`degraded_threshold` consecutive create failures the pool enters `DEGRADED`. Python and
-Go apply exponential replenish backoff while degraded. Kotlin continues its fixed
-one-second admission cadence: `warmup_create_qps` is its pressure control, and
-`snapshot().backoffActive` is retained only for compatibility and is always `false`.
-Callers do not need to observe these states directly — `snapshot()` exposes them for
-diagnostics.
+`degraded_threshold` consecutive create failures the pool enters `DEGRADED`. Go applies
+exponential replenish backoff while degraded. Kotlin and Python keep a fixed create
+admission cadence instead: `warmup_create_qps` is the pressure control, and
+`snapshot().backoffActive` / `snapshot().backoff_active` is retained only for
+compatibility and is always `false`. Callers do not need to observe these states
+directly — `snapshot()` exposes them for diagnostics.
 
 Kotlin's built-in warmup creates are single-attempt requests. They do not use the
 connection-level retry policy for HTTP 429, other retryable statuses, or transport
@@ -121,11 +125,11 @@ camelCase / snake_case naming.
 | `connection_config` | required | required | Used for lifecycle and execd calls |
 | `creation_spec` | required in Python; required in Go only when `sandbox_creator` is unset | required | Template for warmed sandboxes: `image`, `entrypoint`, `env`, `metadata`, `extensions`, `resource`, `network_policy`, `platform`, `volumes`, `secure_access` |
 | `sandbox_creator` | `null` | `null` | Optional callback that overrides `creation_spec` at runtime. Python and Kotlin still require `creation_spec` even when the creator is set; only Go allows a creator-only pool. |
-| `warmup_create_qps` | not available | `10` | Maximum warmup creates admitted by each Kotlin pool on one fixed one-second tick |
-| `warmup_concurrency` | `max(1, ceil(max_idle * 0.2))` | `128` | Python / Go: create cap per tick and worker concurrency. Kotlin: concurrent post-create stage workers; it does not control create QPS |
-| `primary_lock_ttl` | `60 s` | `60 s` | Leader lease TTL |
+| `warmup_create_qps` | `10` (per reconcile tick) | `10` (per fixed one-second tick) | Maximum warmup creates admitted per tick; in-flight warmups count toward `max_idle` alongside idle sandboxes. Go: not available |
+| `warmup_concurrency` | `max(1, ceil(max_idle * 0.2))` | `128` | Python: concurrent warmup workers (asyncio semaphore / executor threads); admissions queue against these slots and count toward `max_idle`. Kotlin: concurrent post-create stage workers; it does not control create QPS. Go: create cap per tick |
+| `primary_lock_ttl` | `60 s` | `60 s` | Leader lease TTL; Python and Kotlin renew it with an independent heartbeat at most `ttl / 3` |
 | `reconcile_interval` | `30 s`, configurable | fixed `1 s`, not exposed | Reconcile cadence |
-| `degraded_threshold` | `3` | `3` | Consecutive failures before `DEGRADED`; only Python / Go pause replenish with backoff |
+| `degraded_threshold` | `3` | `3` | Consecutive failures before `DEGRADED`; only Go pauses replenish with backoff |
 | `acquire_ready_timeout` | `30 s` | `30 s` | Max wait for the returned sandbox to become ready |
 | `acquire_health_check_polling_interval` | `200 ms` | `200 ms` | Ready-poll interval during acquire |
 | `acquire_health_check` | `null` | `null` | Custom readiness predicate for acquire |
@@ -133,11 +137,11 @@ camelCase / snake_case naming.
 | `acquire_min_remaining_ttl` | `min(60 s, idle_timeout / 2)` | `min(60 s, idle_timeout / 2)` | Discard idles closer to expiry than this on acquire |
 | `warmup_ready_timeout` | `30 s` | `30 s` | Max readiness-check window for a warmed sandbox |
 | `warmup_health_check_initial_delay` | not available | `0 s` | Kotlin delay between successful create and the first readiness check |
-| `warmup_health_check_polling_interval` | `200 ms` | `500 ms` | Ready-poll interval during warmup; Kotlin also uses it for post-prepare checks |
+| `warmup_health_check_polling_interval` | `200 ms` | `500 ms` | Ready-poll interval during warmup; Kotlin and Python also use it for post-prepare checks |
 | `warmup_health_check` | `null` | `null` | Custom warmup readiness predicate |
 | `warmup_sandbox_preparer` | `null` | `null` | Runs once after readiness and before publishing to the idle buffer |
-| `warmup_post_prepare_health_check` | not available | `null` | Optional Kotlin validation after the preparer; retries do not rerun the preparer |
-| `warmup_post_prepare_health_check_timeout` | not available | `30 s` | Kotlin retry window for post-prepare validation |
+| `warmup_post_prepare_health_check` | `null` | `null` | Optional validation after the preparer (Python and Kotlin); retries do not rerun the preparer. Go: not available |
+| `warmup_post_prepare_health_check_timeout` | `30 s` | `30 s` | Retry window for post-prepare validation (Python and Kotlin). Go: not available |
 | `warmup_skip_health_check` | `false` | `false` | Skip the pre-prepare readiness stage during warmup |
 | `idle_timeout` | `24 h` | `24 h` | Server-side TTL for pool-created sandboxes |
 | `drain_timeout` | `30 s` | `30 s` | Max wait for in-flight ops during graceful shutdown |

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -181,6 +181,30 @@ finally:
     await pool.shutdown(graceful=True)
 ```
 
+Warmup admission and health checks are aligned across SDKs:
+
+- `warmup_create_qps` (default `10`) caps new warmup creates admitted per reconcile
+  tick. The tick returns immediately after admitting: every warmup task creates,
+  validates, renews, and commits its sandbox independently, so a slow warmup never
+  delays its peers or the next tick. Already-admitted in-flight warmups count
+  toward `max_idle` together with idle sandboxes, so concurrent replenish work
+  cannot overshoot the target. `warmup_concurrency` bounds how many warmup tasks
+  run at once (an asyncio semaphore for `SandboxPoolAsync`, executor threads for
+  `SandboxPoolSync`); admitted-but-queued tasks count toward `max_idle` too.
+- After `warmup_sandbox_preparer` runs once, an optional
+  `warmup_post_prepare_health_check` callback is retried at
+  `warmup_health_check_polling_interval` until it returns `True` or
+  `warmup_post_prepare_health_check_timeout` (default `30 s`) elapses; the
+  preparer is never rerun. A timeout raises `SandboxReadyTimeoutException` and the
+  warmup sandbox is killed instead of being committed to the idle buffer.
+- `degraded_threshold` (default `3`) still controls the `HEALTHY → DEGRADED`
+  diagnostic state, but replenish no longer pauses with exponential backoff;
+  `snapshot().backoff_active` is always `False`. The primary lock is renewed by an
+  independent heartbeat at an interval no greater than
+  `min(reconcile_interval, primary_lock_ttl / 3)`, so a long reconcile cadence
+  cannot let the lease expire. A warmup whose commit finds the lease lost kills
+  its sandbox instead of publishing it.
+
 ::: tip AcquirePolicy
 `AcquirePolicy` controls what happens when the idle buffer is empty **or** the first idle candidate fails its readiness check:
 
@@ -251,6 +275,10 @@ For async pools, pass a `redis.asyncio` client to `AsyncRedisPoolStateStore`.
   `release_all_idle_parallel(max_workers=50)` for bounded parallel cleanup. The
   worker count must be positive, and the call waits for every drained ID to receive
   a best-effort kill attempt.
+- Use `warmup_sandbox_preparer` if you need to prepare a sandbox after warmup
+  readiness succeeds and before it is put into the idle pool. Add
+  `warmup_post_prepare_health_check` when the prepared service needs a separate
+  validation window; retries never rerun the preparer.
 - Configure `primary_lock_ttl` greater than `warmup_ready_timeout` plus expected
   warmup preparer time and buffer.
 - Redis outages are surfaced as pool state store errors. The pool fails closed; it

--- a/sdks/sandbox/python/src/opensandbox/_async_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_async_pool_reconciler.py
@@ -13,19 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Async sandbox pool reconciliation logic."""
+"""Async sandbox pool reconciliation logic.
+
+Aligned with the Kotlin ``PoolReconciler``: one tick only reaps expired idle,
+shrinks excess, computes the admission plan, and submits warmups through the
+caller-provided callback. The tick returns immediately; warmup tasks create,
+validate, renew, and commit their sandbox independently of the tick.
+"""
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 
-from opensandbox._pool_reconciler import ReconcileState
 from opensandbox.pool_types import (
     AsyncPoolConfig,
     AsyncPoolStateStore,
+    calculate_warmup_plan,
 )
 from opensandbox.pool_types import (
     reap_expired_idle_with_min_ttl_async as _reap_expired_idle_with_min_ttl_async,
@@ -38,33 +43,40 @@ async def run_async_reconcile_tick(
     *,
     config: AsyncPoolConfig,
     state_store: AsyncPoolStateStore,
-    create_one: Callable[[], Awaitable[str | None]],
     on_discard_sandbox: Callable[[str], Awaitable[None]],
-    reconcile_state: ReconcileState,
-) -> None:
+    submit_warmups: Callable[[int], None],
+    warming_count: int = 0,
+) -> bool:
+    """Async counterpart of ``run_reconcile_tick``.
+
+    Returns whether this node holds the primary lock. Warmup submission is
+    non-blocking; the tick does not wait for the admitted tasks.
+    """
     pool_name = config.pool_name
     owner_id = str(config.owner_id)
     ttl = config.primary_lock_ttl
 
     if not await state_store.try_acquire_primary_lock(pool_name, owner_id, ttl):
         logger.debug(f"Async reconcile skip (not primary): pool_name={pool_name}")
-        return
+        return False
     await _run_primary_replenish_once(
         config=config,
         state_store=state_store,
-        create_one=create_one,
         on_discard_sandbox=on_discard_sandbox,
-        reconcile_state=reconcile_state,
+        submit_warmups=submit_warmups,
+        warming_count=warming_count,
     )
+    # Do not release primary lock here; leader holds until renew fails or TTL expires.
+    return True
 
 
 async def _run_primary_replenish_once(
     *,
     config: AsyncPoolConfig,
     state_store: AsyncPoolStateStore,
-    create_one: Callable[[], Awaitable[str | None]],
     on_discard_sandbox: Callable[[str], Awaitable[None]],
-    reconcile_state: ReconcileState,
+    submit_warmups: Callable[[int], None],
+    warming_count: int = 0,
 ) -> None:
     pool_name = config.pool_name
     owner_id = str(config.owner_id)
@@ -75,7 +87,7 @@ async def _run_primary_replenish_once(
         state_store, pool_name, now, config.acquire_min_remaining_ttl
     )
     for sandbox_id in discarded_alive:
-        await on_discard_sandbox(sandbox_id)
+        await _discard(on_discard_sandbox, sandbox_id)
     counters = await state_store.snapshot_counters(pool_name)
     excess = max(0, counters.idle_count - config.max_idle)
     to_remove = min(excess, int(config.warmup_concurrency or 1))
@@ -83,125 +95,32 @@ async def _run_primary_replenish_once(
         await _shrink_excess_idle(config, state_store, on_discard_sandbox, to_remove)
         return
 
-    deficit = max(0, config.max_idle - counters.idle_count)
-    to_create = min(deficit, int(config.warmup_concurrency or 1))
-    if to_create == 0 or reconcile_state.is_backoff_active(now):
+    # Aligned with the Kotlin WarmupPlan: idle sandboxes and already-admitted warmups
+    # both count toward the target, and warmup_create_qps caps admissions per tick.
+    # Admission is bounded by the deficit, so queued submissions cannot overshoot.
+    deficit, to_submit = calculate_warmup_plan(
+        idle_count=counters.idle_count,
+        warming_count=warming_count,
+        max_idle=config.max_idle,
+        warmup_create_qps=config.warmup_create_qps,
+    )
+    if to_submit == 0:
         await state_store.renew_primary_lock(pool_name, owner_id, ttl)
+        logger.debug(
+            f"Async reconcile tick: pool_name={pool_name} idle={counters.idle_count} "
+            f"warming={warming_count} deficit={deficit} to_submit=0"
+        )
         return
+
+    logger.debug(
+        f"Async reconcile tick: pool_name={pool_name} idle={counters.idle_count} "
+        f"warming={warming_count} deficit={deficit} create_qps={config.warmup_create_qps} "
+        f"to_submit={to_submit}"
+    )
 
     if not await state_store.renew_primary_lock(pool_name, owner_id, ttl):
         return
-
-    tasks: set[asyncio.Future[str | None]] = {
-        asyncio.ensure_future(create_one()) for _ in range(to_create)
-    }
-    pending = set(tasks)
-    handled_tasks: set[asyncio.Future[str | None]] = set()
-    failure_count = 0
-    last_error: str | None = None
-    created = 0
-    commit_failed = False
-    commit_error: str | None = None
-    accept_commits = True
-    dropped = 0
-    stop_reason: str | None = None
-    try:
-        while pending:
-            done, pending = await asyncio.wait(
-                pending, return_when=asyncio.FIRST_COMPLETED
-            )
-            for task in done:
-                try:
-                    sandbox_id = task.result()
-                except asyncio.CancelledError:
-                    failure_count += 1
-                    last_error = "warmup task cancelled"
-                    handled_tasks.add(task)
-                    continue
-                except Exception as exc:
-                    failure_count += 1
-                    last_error = str(exc)
-                    handled_tasks.add(task)
-                    continue
-                if sandbox_id is None:
-                    failure_count += 1
-                    last_error = None
-                    handled_tasks.add(task)
-                    continue
-
-                if not accept_commits:
-                    await _discard(on_discard_sandbox, sandbox_id)
-                    dropped += 1
-                    handled_tasks.add(task)
-                    continue
-                try:
-                    lock_renewed = await state_store.renew_primary_lock(
-                        pool_name, owner_id, ttl
-                    )
-                except Exception as exc:
-                    lock_renewed = False
-                    commit_failed = True
-                    commit_error = str(exc)
-                    stop_reason = "primary lock renewal failed"
-                if not lock_renewed:
-                    accept_commits = False
-                    stop_reason = stop_reason or "primary lock lost"
-                    await _discard(on_discard_sandbox, sandbox_id)
-                    dropped += 1
-                    handled_tasks.add(task)
-                    continue
-                try:
-                    await state_store.put_idle(pool_name, sandbox_id)
-                    created += 1
-                except Exception as exc:
-                    accept_commits = False
-                    stop_reason = "commit failed"
-                    commit_failed = True
-                    commit_error = str(exc)
-                    try:
-                        await state_store.remove_idle(pool_name, sandbox_id)
-                    except Exception:
-                        pass
-                    await _discard(on_discard_sandbox, sandbox_id)
-                    dropped += 1
-                handled_tasks.add(task)
-    finally:
-        unhandled_tasks = tasks - handled_tasks
-        if unhandled_tasks:
-            cleanup_task = asyncio.create_task(
-                _cleanup_unhandled_tasks(
-                    tasks=unhandled_tasks,
-                    state_store=state_store,
-                    pool_name=pool_name,
-                    on_discard_sandbox=on_discard_sandbox,
-                )
-            )
-            cleanup_cancellation: asyncio.CancelledError | None = None
-            while not cleanup_task.done():
-                try:
-                    await asyncio.shield(cleanup_task)
-                except asyncio.CancelledError as exc:
-                    cleanup_cancellation = cleanup_cancellation or exc
-                    continue
-            cleanup_task.result()
-            if cleanup_cancellation is not None:
-                raise cleanup_cancellation
-
-    reconcile_state.record_failures(failure_count, last_error)
-    if created > 0:
-        reconcile_state.record_success()
-    if commit_failed:
-        reconcile_state.record_failure(commit_error)
-
-    if dropped > 0:
-        error_detail = f" error={commit_error}" if commit_error else ""
-        logger.warning(
-            f"Async reconcile {stop_reason}; dropped {dropped} newly created sandbox(es): pool_name={pool_name}{error_detail}"
-        )
-    if created > 0:
-        logger.debug(
-            f"Async reconcile created {created} sandboxes: pool_name={pool_name}"
-        )
+    submit_warmups(to_submit)
 
 
 async def _shrink_excess_idle(
@@ -230,33 +149,6 @@ async def _shrink_excess_idle(
     logger.debug(
         f"Async reconcile shrunk {removed} idle sandbox(es): pool_name={pool_name}"
     )
-
-
-async def _cleanup_unhandled_tasks(
-    *,
-    tasks: set[asyncio.Future[str | None]],
-    state_store: AsyncPoolStateStore,
-    pool_name: str,
-    on_discard_sandbox: Callable[[str], Awaitable[None]],
-) -> None:
-    for task in tasks:
-        if not task.done():
-            task.cancel()
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    discarded = 0
-    for sandbox_id in results:
-        if isinstance(sandbox_id, BaseException) or sandbox_id is None:
-            continue
-        try:
-            await state_store.remove_idle(pool_name, sandbox_id)
-        except Exception:
-            pass
-        await _discard(on_discard_sandbox, sandbox_id)
-        discarded += 1
-    if discarded > 0:
-        logger.warning(
-            f"Async reconcile interrupted; discarded {discarded} uncommitted sandbox(es): pool_name={pool_name}"
-        )
 
 
 async def _discard(

--- a/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
@@ -13,20 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Sandbox pool reconciliation logic."""
+"""Sandbox pool reconciliation logic.
+
+Aligned with the Kotlin ``PoolReconciler``: one tick only reaps expired idle,
+shrinks excess, computes the admission plan, and submits warmups through the
+caller-provided callback. The tick returns immediately; warmup tasks create,
+validate, renew, and commit their sandbox independently of the tick.
+"""
 
 from __future__ import annotations
 
 import logging
+import threading
 from collections.abc import Callable
-from concurrent.futures import CancelledError, Executor, as_completed
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 
 from opensandbox.pool_types import (
     PoolConfig,
     PoolState,
     PoolStateStore,
+    calculate_warmup_plan,
 )
 from opensandbox.pool_types import (
     reap_expired_idle_with_min_ttl as _reap_expired_idle_with_min_ttl,
@@ -37,22 +44,24 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ReconcileState:
+    """Mutable observation state for the reconcile loop.
+
+    Thread-safe for concurrent updates from warmup workers and reads from
+    ``snapshot()``, mirroring the Kotlin ``@Synchronized`` counterpart.
+    """
+
     degraded_threshold: int
-    backoff_base: timedelta = timedelta(seconds=30)
-    backoff_max: timedelta = timedelta(days=1)
     failure_count: int = 0
     state: PoolState = PoolState.HEALTHY
     last_error: str | None = None
-    backoff_until: datetime | None = None
-    backoff_attempts: int = 0
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
     def record_success(self) -> None:
-        self.failure_count = 0
-        if self.state == PoolState.DEGRADED:
-            self.state = PoolState.HEALTHY
-        self.backoff_until = None
-        self.backoff_attempts = 0
-        self.last_error = None
+        with self._lock:
+            self.failure_count = 0
+            if self.state == PoolState.DEGRADED:
+                self.state = PoolState.HEALTHY
+            self.last_error = None
 
     def record_failure(self, error_message: str | None) -> None:
         self.record_failures(1, error_message)
@@ -60,62 +69,60 @@ class ReconcileState:
     def record_failures(self, count: int, error_message: str | None) -> None:
         if count <= 0:
             return
-        self.failure_count += count
-        self.last_error = error_message
-        if self.failure_count >= self.degraded_threshold:
-            self.state = PoolState.DEGRADED
-            self.backoff_attempts += 1
-            exponent = min(self.backoff_attempts - 1, 30)
-            delay = min(
-                self.backoff_base.total_seconds() * (1 << exponent),
-                self.backoff_max.total_seconds(),
-            )
-            self.backoff_until = datetime.now(timezone.utc) + timedelta(seconds=delay)
+        with self._lock:
+            self.failure_count += count
+            self.last_error = error_message
+            if self.failure_count >= self.degraded_threshold:
+                self.state = PoolState.DEGRADED
 
     def is_backoff_active(self, now: datetime | None = None) -> bool:
-        until = self.backoff_until
-        if until is None:
-            return False
-        return (
-            self.state == PoolState.DEGRADED
-            and (now or datetime.now(timezone.utc)) < until
-        )
+        """Replenish backoff is intentionally disabled; fixed create admission provides
+        pressure control. Aligned with the Kotlin SDK's ``ReconcileState``."""
+        return False
 
 
 def run_reconcile_tick(
     *,
     config: PoolConfig,
     state_store: PoolStateStore,
-    create_one: Callable[[], str | None],
     on_discard_sandbox: Callable[[str], None],
-    reconcile_state: ReconcileState,
-    warmup_executor: Executor,
-) -> None:
+    submit_warmups: Callable[[int], None],
+    warming_count: int = 0,
+) -> bool:
+    """Run one reconcile tick: leader-gated reap / shrink / admission planning.
+
+    Returns whether this node holds the primary lock. Only the lock holder
+    performs idle maintenance writes. Warmup submission is non-blocking: the
+    caller-provided ``submit_warmups`` admits at most ``warmup_create_qps``
+    creates whose in-flight count already participates in the deficit; the tick
+    does not wait for them. The lock is not released at tick end — distributed
+    stores rely on TTL or renew failure.
+    """
     pool_name = config.pool_name
     owner_id = str(config.owner_id)
     ttl = config.primary_lock_ttl
 
     if not state_store.try_acquire_primary_lock(pool_name, owner_id, ttl):
         logger.debug(f"Reconcile skip (not primary): pool_name={pool_name}")
-        return
+        return False
     _run_primary_replenish_once(
         config=config,
         state_store=state_store,
-        create_one=create_one,
         on_discard_sandbox=on_discard_sandbox,
-        reconcile_state=reconcile_state,
-        warmup_executor=warmup_executor,
+        submit_warmups=submit_warmups,
+        warming_count=warming_count,
     )
+    # Do not release primary lock here; leader holds until renew fails or TTL expires.
+    return True
 
 
 def _run_primary_replenish_once(
     *,
     config: PoolConfig,
     state_store: PoolStateStore,
-    create_one: Callable[[], str | None],
     on_discard_sandbox: Callable[[str], None],
-    reconcile_state: ReconcileState,
-    warmup_executor: Executor,
+    submit_warmups: Callable[[int], None],
+    warming_count: int = 0,
 ) -> None:
     pool_name = config.pool_name
     owner_id = str(config.owner_id)
@@ -126,8 +133,8 @@ def _run_primary_replenish_once(
         state_store, pool_name, now, config.acquire_min_remaining_ttl
     )
     for sandbox_id in discarded_alive:
-        # Reaped near-expiry but server-side TTL has not yet elapsed; kill so the live
-        # sandbox does not linger past its pool membership and consume quota.
+        # Reaped near-expiry but server-side TTL has not elapsed; kill so the live sandbox
+        # does not linger past its pool membership and consume quota.
         on_discard_sandbox(sandbox_id)
     counters = state_store.snapshot_counters(pool_name)
     excess = max(0, counters.idle_count - config.max_idle)
@@ -136,85 +143,32 @@ def _run_primary_replenish_once(
         _shrink_excess_idle(config, state_store, on_discard_sandbox, to_remove)
         return
 
-    deficit = max(0, config.max_idle - counters.idle_count)
-    to_create = min(deficit, int(config.warmup_concurrency or 1))
-    if to_create == 0 or reconcile_state.is_backoff_active(now):
+    # Aligned with the Kotlin WarmupPlan: idle sandboxes and already-admitted warmups
+    # both count toward the target, and warmup_create_qps caps admissions per tick.
+    # Admission is bounded by the deficit, so queued submissions cannot overshoot.
+    deficit, to_submit = calculate_warmup_plan(
+        idle_count=counters.idle_count,
+        warming_count=warming_count,
+        max_idle=config.max_idle,
+        warmup_create_qps=config.warmup_create_qps,
+    )
+    if to_submit == 0:
         state_store.renew_primary_lock(pool_name, owner_id, ttl)
+        logger.debug(
+            f"Reconcile tick: pool_name={pool_name} idle={counters.idle_count} "
+            f"warming={warming_count} deficit={deficit} to_submit=0"
+        )
         return
+
+    logger.debug(
+        f"Reconcile tick: pool_name={pool_name} idle={counters.idle_count} "
+        f"warming={warming_count} deficit={deficit} create_qps={config.warmup_create_qps} "
+        f"to_submit={to_submit}"
+    )
 
     if not state_store.renew_primary_lock(pool_name, owner_id, ttl):
         return
-
-    futures = [warmup_executor.submit(create_one) for _ in range(to_create)]
-    failure_count = 0
-    last_error: str | None = None
-    created = 0
-    commit_failed = False
-    commit_error: str | None = None
-    accept_commits = True
-    dropped = 0
-    stop_reason: str | None = None
-    for future in as_completed(futures):
-        try:
-            sandbox_id = future.result()
-            if sandbox_id is None:
-                failure_count += 1
-                last_error = None
-                continue
-        except CancelledError:
-            failure_count += 1
-            last_error = "warmup future cancelled"
-            continue
-        except Exception as exc:
-            failure_count += 1
-            last_error = str(exc)
-            continue
-
-        if not accept_commits:
-            _discard(on_discard_sandbox, sandbox_id)
-            dropped += 1
-            continue
-        try:
-            lock_renewed = state_store.renew_primary_lock(pool_name, owner_id, ttl)
-        except Exception as exc:
-            lock_renewed = False
-            commit_failed = True
-            commit_error = str(exc)
-            stop_reason = "primary lock renewal failed"
-        if not lock_renewed:
-            accept_commits = False
-            stop_reason = stop_reason or "primary lock lost"
-            _discard(on_discard_sandbox, sandbox_id)
-            dropped += 1
-            continue
-        try:
-            state_store.put_idle(pool_name, sandbox_id)
-            created += 1
-        except Exception as exc:
-            accept_commits = False
-            stop_reason = "commit failed"
-            commit_failed = True
-            commit_error = str(exc)
-            try:
-                state_store.remove_idle(pool_name, sandbox_id)
-            except Exception:
-                pass
-            _discard(on_discard_sandbox, sandbox_id)
-            dropped += 1
-
-    reconcile_state.record_failures(failure_count, last_error)
-    if created > 0:
-        reconcile_state.record_success()
-    if commit_failed:
-        reconcile_state.record_failure(commit_error)
-
-    if dropped > 0:
-        error_detail = f" error={commit_error}" if commit_error else ""
-        logger.warning(
-            f"Reconcile {stop_reason}; dropped {dropped} newly created sandbox(es): pool_name={pool_name}{error_detail}"
-        )
-    if created > 0:
-        logger.debug(f"Reconcile created {created} sandboxes: pool_name={pool_name}")
+    submit_warmups(to_submit)
 
 
 def _shrink_excess_idle(
@@ -236,17 +190,13 @@ def _shrink_excess_idle(
         sandbox_id = state_store.try_take_idle(pool_name)
         if sandbox_id is None:
             return
-        _discard(on_discard_sandbox, sandbox_id)
+        try:
+            on_discard_sandbox(sandbox_id)
+        except Exception as exc:
+            logger.warning(
+                f"Reconcile shrink sandbox cleanup failed: pool_name={pool_name} sandbox_id={sandbox_id} error={exc}"
+            )
         removed += 1
 
     state_store.renew_primary_lock(pool_name, owner_id, ttl)
     logger.debug(f"Reconcile shrunk {removed} idle sandbox(es): pool_name={pool_name}")
-
-
-def _discard(on_discard_sandbox: Callable[[str], None], sandbox_id: str) -> None:
-    try:
-        on_discard_sandbox(sandbox_id)
-    except Exception as exc:
-        logger.warning(
-            f"Reconcile sandbox cleanup failed: sandbox_id={sandbox_id} error={exc}"
-        )

--- a/sdks/sandbox/python/src/opensandbox/pool.py
+++ b/sdks/sandbox/python/src/opensandbox/pool.py
@@ -44,6 +44,7 @@ from opensandbox.pool_types import (
     PoolStateStore,
     StoreCounters,
     TakeIdleResult,
+    calculate_warmup_plan,
 )
 from opensandbox.sync.pool import SandboxPoolSync
 
@@ -79,4 +80,5 @@ __all__ = [
     "SandboxPoolSync",
     "StoreCounters",
     "TakeIdleResult",
+    "calculate_warmup_plan",
 ]

--- a/sdks/sandbox/python/src/opensandbox/pool_async.py
+++ b/sdks/sandbox/python/src/opensandbox/pool_async.py
@@ -33,6 +33,7 @@ from opensandbox.exceptions import (
     PoolNotRunningException,
     PoolStateStoreUnavailableException,
 )
+from opensandbox.internal.readiness import ReadinessBudget
 from opensandbox.manager import SandboxManager
 from opensandbox.pool_types import (
     AcquirePolicy,
@@ -86,6 +87,10 @@ class SandboxPoolAsync:
         warmup_health_check: Callable[[Sandbox], Awaitable[bool]] | None = None,
         warmup_sandbox_preparer: Callable[[Sandbox], Awaitable[None]] | None = None,
         warmup_skip_health_check: bool = False,
+        warmup_create_qps: int = 10,
+        warmup_post_prepare_health_check: Callable[[Sandbox], Awaitable[bool]]
+        | None = None,
+        warmup_post_prepare_health_check_timeout: timedelta = timedelta(seconds=30),
         idle_timeout: timedelta = timedelta(hours=24),
         drain_timeout: timedelta = timedelta(seconds=30),
         acquire_min_remaining_ttl: timedelta | None = None,
@@ -116,6 +121,9 @@ class SandboxPoolAsync:
             warmup_health_check=warmup_health_check,
             warmup_sandbox_preparer=warmup_sandbox_preparer,
             warmup_skip_health_check=warmup_skip_health_check,
+            warmup_create_qps=warmup_create_qps,
+            warmup_post_prepare_health_check=warmup_post_prepare_health_check,
+            warmup_post_prepare_health_check_timeout=warmup_post_prepare_health_check_timeout,
             idle_timeout=idle_timeout,
             drain_timeout=drain_timeout,
             acquire_min_remaining_ttl=acquire_min_remaining_ttl,
@@ -136,6 +144,15 @@ class SandboxPoolAsync:
         self._in_flight_condition = asyncio.Condition()
         self._stop_event = asyncio.Event()
         self._scheduler_task: asyncio.Task[None] | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._primary_owned = False
+        self._warming_count = 0
+        # Bounds concurrent warmup work (create + readiness + prepare + renew),
+        # mirroring the Kotlin warmup executor's worker cap. Admission (QPS) is
+        # bounded separately by warmup_create_qps in the reconcile plan.
+        self._warmup_slots = asyncio.Semaphore(
+            max(1, int(self._config.warmup_concurrency or 1))
+        )
         self._sandbox_manager: SandboxManager | None = None
         self._warmup_tasks: set[asyncio.Task[str | None]] = set()
 
@@ -163,6 +180,12 @@ class SandboxPoolAsync:
                 self._scheduler_task = asyncio.create_task(
                     self._run_scheduler(stop_event),
                     name=f"sandbox-pool-reconcile-{self._config.pool_name}",
+                )
+                # Aligned with the Kotlin SDK: renew the primary lease independently of
+                # reconcile work, at an interval no greater than one third of the TTL.
+                self._heartbeat_task = asyncio.create_task(
+                    self._run_primary_heartbeat(stop_event),
+                    name=f"sandbox-pool-heartbeat-{self._config.pool_name}",
                 )
             except Exception:
                 await self._stop_reconcile(wait_for_warmup=True)
@@ -395,9 +418,7 @@ class SandboxPoolAsync:
         if max_workers <= 0:
             raise ValueError("max_workers must be positive")
 
-        cleanup_task = asyncio.create_task(
-            self._release_all_idle_parallel(max_workers)
-        )
+        cleanup_task = asyncio.create_task(self._release_all_idle_parallel(max_workers))
         cancellation: asyncio.CancelledError | None = None
         cleanup_failure: BaseException | None = None
         while not cleanup_task.done():
@@ -560,18 +581,25 @@ class SandboxPoolAsync:
             try:
                 if self._lifecycle_state != PoolLifecycleState.RUNNING:
                     return
-                if await self._state_store.get_destroy_state(
-                    self._config.pool_name
-                ) != PoolDestroyState.ACTIVE:
+                if (
+                    await self._state_store.get_destroy_state(self._config.pool_name)
+                    != PoolDestroyState.ACTIVE
+                ):
                     await self._stop_after_pool_namespace_destroyed()
                     return
-                await run_async_reconcile_tick(
-                    config=self._config.with_max_idle(await self._resolve_max_idle()),
-                    state_store=self._state_store,
-                    create_one=self._create_one_sandbox,
-                    on_discard_sandbox=self._discard_sandbox_callback,
-                    reconcile_state=self._reconcile_state,
-                )
+                try:
+                    self._primary_owned = await run_async_reconcile_tick(
+                        config=self._config.with_max_idle(
+                            await self._resolve_max_idle()
+                        ),
+                        state_store=self._state_store,
+                        on_discard_sandbox=self._discard_sandbox_callback,
+                        submit_warmups=self._submit_warmups,
+                        warming_count=self._warming_count,
+                    )
+                except Exception:
+                    self._primary_owned = False
+                    raise
             except Exception as exc:
                 logger.error(
                     f"Async pool reconcile tick failed unexpectedly: pool_name={self._config.pool_name}",
@@ -580,31 +608,101 @@ class SandboxPoolAsync:
             finally:
                 await self._end_operation()
 
-    async def _create_one_sandbox(self) -> str | None:
-        await self._begin_operation()
-        task = asyncio.current_task()
-        if task is not None:
+    async def _run_primary_heartbeat(self, stop_event: asyncio.Event) -> None:
+        """Renew the primary lock independently of reconcile ticks.
+
+        Aligned with the Kotlin SDK: the interval is ``min(reconcile_interval,
+        primary_lock_ttl / 3)`` so a long reconcile cadence cannot let the lease
+        expire. The heartbeat only renews while this node is the current primary;
+        a failed renewal clears ownership until the next tick re-acquires it.
+        """
+        interval = min(
+            self._config.reconcile_interval.total_seconds(),
+            self._config.primary_lock_ttl.total_seconds() / 3,
+        )
+        while not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval)
+                return
+            except (asyncio.TimeoutError, TimeoutError):
+                pass
+            if not self._primary_owned:
+                continue
+            try:
+                renewed = await self._state_store.renew_primary_lock(
+                    self._config.pool_name,
+                    str(self._config.owner_id),
+                    self._config.primary_lock_ttl,
+                )
+            except Exception as exc:
+                # Keep periodic heartbeats alive after transient store failures.
+                logger.error(
+                    f"Pool primary heartbeat failed: pool_name={self._config.pool_name}",
+                    exc_info=exc,
+                )
+                continue
+            if not renewed:
+                self._primary_owned = False
+                logger.debug(
+                    "Pool primary heartbeat skipped (not current owner): "
+                    f"pool_name={self._config.pool_name} owner_id={self._config.owner_id}"
+                )
+
+    def _submit_warmups(self, count: int) -> None:
+        """Admit ``count`` warmup tasks and return immediately.
+
+        Aligned with the Kotlin SDK's admission model: the reconcile tick only
+        plans and admits; each admitted task then creates, validates, renews, and
+        commits its sandbox independently of the tick. The warming counter is
+        incremented synchronously here (before any task can start) so the next
+        tick's deficit calculation already accounts for these admissions.
+        """
+        if count <= 0:
+            return
+        if self._lifecycle_state != PoolLifecycleState.RUNNING:
+            return
+        for _ in range(count):
+            self._warming_count += 1
+            task = asyncio.create_task(self._run_warmup_task())
             self._warmup_tasks.add(task)  # type: ignore[arg-type]
+            task.add_done_callback(self._on_warmup_task_done)
+
+    def _on_warmup_task_done(self, task: asyncio.Task[str | None]) -> None:
+        self._warming_count -= 1
+        self._warmup_tasks.discard(task)
+
+    async def _run_warmup_task(self) -> str | None:
+        """One admitted warmup: create → validate → renew → commit.
+
+        Runs detached from the reconcile tick. Committing renews the primary
+        lock first (a lost lease drops and kills the sandbox, mirroring the
+        Kotlin leader-epoch fence) and then publishes the ID to the idle store.
+        Failures are recorded on the reconcile state; cancellation is not.
+        """
+        await self._begin_operation()
         try:
             await self._ensure_pool_namespace_active()
             sandbox = await self._build_warmup_sandbox()
             try:
-                if self._config.warmup_sandbox_preparer is not None:
-                    await self._config.warmup_sandbox_preparer(sandbox)
-                if self._lifecycle_state != PoolLifecycleState.RUNNING:
-                    try:
-                        await sandbox.kill()
-                    except Exception:
-                        pass
-                    return None
-                # The server-side TTL has been ticking since sandbox creation;
-                # readiness wait and `warmup_sandbox_preparer` can both consume meaningful time.
-                # Renew right before handing the id back to the reconciler so the store's
-                # stamped expiry actually matches what the server will honor — otherwise
-                # `acquire_min_remaining_ttl` overestimates remaining TTL by the warmup duration.
-                await sandbox.renew(self._config.idle_timeout)
+                async with self._warmup_slots:
+                    if self._config.warmup_sandbox_preparer is not None:
+                        await self._config.warmup_sandbox_preparer(sandbox)
+                    await self._wait_post_prepare_healthy(sandbox)
+                    if self._lifecycle_state != PoolLifecycleState.RUNNING:
+                        try:
+                            await sandbox.kill()
+                        except Exception:
+                            pass
+                        return None
+                    # The server-side TTL has been ticking since sandbox creation;
+                    # readiness wait and `warmup_sandbox_preparer` can both consume
+                    # meaningful time. Renew right before committing so the store's
+                    # stamped expiry actually matches what the server will honor —
+                    # otherwise `acquire_min_remaining_ttl` overestimates remaining
+                    # TTL by the warmup duration.
+                    await sandbox.renew(self._config.idle_timeout)
                 await self._ensure_pool_namespace_active_after_create(sandbox)
-                return sandbox.id
+                return await self._commit_warmup_sandbox(sandbox)
             except BaseException:
                 try:
                     await sandbox.kill()
@@ -613,10 +711,88 @@ class SandboxPoolAsync:
                 raise
             finally:
                 await sandbox.close()
+        except asyncio.CancelledError:
+            # Shutdown cancellation is not a warmup failure.
+            raise
+        except Exception as exc:
+            self._reconcile_state.record_failure(str(exc))
+            return None
         finally:
-            if task is not None:
-                self._warmup_tasks.discard(task)  # type: ignore[arg-type]
             await self._end_operation()
+
+    async def _commit_warmup_sandbox(self, sandbox: Sandbox) -> str | None:
+        """Commit a renewed warmup sandbox to the idle buffer.
+
+        The primary lock is renewed before publishing: if the lease was lost the
+        sandbox is killed instead of committed, mirroring the Kotlin leader-epoch
+        commit fence.
+        """
+        pool_name = self._config.pool_name
+        owner_id = str(self._config.owner_id)
+        ttl = self._config.primary_lock_ttl
+        sandbox_id = sandbox.id
+        try:
+            lock_renewed = await self._state_store.renew_primary_lock(
+                pool_name, owner_id, ttl
+            )
+        except Exception as exc:
+            logger.warning(
+                "Warmup commit dropped (primary lock renewal failed): "
+                f"pool_name={pool_name} sandbox_id={sandbox_id} error={exc}"
+            )
+            lock_renewed = False
+        if not lock_renewed:
+            try:
+                await sandbox.kill()
+            except Exception as exc:
+                logger.warning(
+                    "Best-effort kill after lost primary lock failed: "
+                    f"pool_name={pool_name} sandbox_id={sandbox_id} error={exc}"
+                )
+            self._reconcile_state.record_failure(
+                "primary lock lost during warmup commit"
+            )
+            return None
+        try:
+            await self._state_store.put_idle(pool_name, sandbox_id)
+        except Exception as exc:
+            logger.warning(
+                f"Warmup commit failed; dropped newly created sandbox: "
+                f"pool_name={pool_name} sandbox_id={sandbox_id} error={exc}"
+            )
+            try:
+                await self._state_store.remove_idle(pool_name, sandbox_id)
+            except Exception:
+                pass
+            try:
+                await sandbox.kill()
+            except Exception as kill_exc:
+                logger.warning(
+                    "Best-effort kill after failed commit failed: "
+                    f"pool_name={pool_name} sandbox_id={sandbox_id} error={kill_exc}"
+                )
+            self._reconcile_state.record_failure(f"warmup commit failed: {exc}")
+            return None
+        self._reconcile_state.record_success()
+        return sandbox_id
+
+    async def _wait_post_prepare_healthy(self, sandbox: Sandbox) -> None:
+        """Re-validate readiness after the warmup preparer, if configured.
+
+        Aligned with the Kotlin SDK's ``warmupPostPrepareHealthCheck`` stage: poll the
+        caller-provided check at ``warmup_health_check_polling_interval`` until it
+        returns True or ``warmup_post_prepare_health_check_timeout`` elapses. The
+        preparer is never rerun; a timeout raises :class:`SandboxReadyTimeoutException`
+        so the surrounding warmup failure path kills the sandbox.
+        """
+        check = self._config.warmup_post_prepare_health_check
+        if check is None:
+            return
+        budget = ReadinessBudget(
+            self._config.warmup_post_prepare_health_check_timeout,
+            self._config.warmup_health_check_polling_interval,
+        )
+        await budget.health(lambda: check(sandbox), context="post-prepare health check")
 
     async def _build_warmup_sandbox(self) -> Sandbox:
         if self._config.sandbox_creator is not None:
@@ -677,7 +853,9 @@ class SandboxPoolAsync:
                     finally:
                         await sandbox.close()
                     raise
-            await self._ensure_pool_namespace_active_after_create(sandbox, policy=policy)
+            await self._ensure_pool_namespace_active_after_create(
+                sandbox, policy=policy
+            )
             return sandbox
 
         spec = self._creation_spec
@@ -989,6 +1167,20 @@ class SandboxPoolAsync:
             except (asyncio.TimeoutError, TimeoutError):
                 task.cancel()
             self._scheduler_task = None
+        heartbeat = self._heartbeat_task
+        if heartbeat is not None and heartbeat is not current:
+            heartbeat.cancel()
+            try:
+                await heartbeat
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug(
+                    "Pool primary heartbeat task ended with error: "
+                    f"pool_name={self._config.pool_name}"
+                )
+            self._heartbeat_task = None
+        self._primary_owned = False
         warmup_tasks = list(self._warmup_tasks)
         if wait_for_warmup and warmup_tasks:
             await asyncio.gather(*warmup_tasks, return_exceptions=True)

--- a/sdks/sandbox/python/src/opensandbox/pool_types.py
+++ b/sdks/sandbox/python/src/opensandbox/pool_types.py
@@ -66,9 +66,7 @@ _FALLTHROUGH_POLICIES: frozenset[AcquirePolicy] = frozenset(
 )
 
 
-def effective_max_idle_attempts(
-    policy: AcquirePolicy, max_acquire_retries: int
-) -> int:
+def effective_max_idle_attempts(policy: AcquirePolicy, max_acquire_retries: int) -> int:
     """Return the per-acquire cap on idle candidates for ``policy``.
 
     Single-shot policies always try exactly one; retry policies use the configured budget
@@ -83,6 +81,27 @@ def effective_max_idle_attempts(
 def policy_falls_through_to_direct_create(policy: AcquirePolicy) -> bool:
     """Return whether ``policy``, after exhausting its idle budget, should direct-create."""
     return policy in _FALLTHROUGH_POLICIES
+
+
+def calculate_warmup_plan(
+    idle_count: int, warming_count: int, max_idle: int, warmup_create_qps: int
+) -> tuple[int, int]:
+    """Point-in-time replenish plan shared by the sync and async reconcile ticks.
+
+    Aligned with the Kotlin SDK's ``WarmupPlan``: both idle sandboxes and
+    already-admitted warmups count toward the target, and ``warmup_create_qps``
+    caps new warmup admissions in the current tick. Returns ``(deficit, to_submit)``.
+    """
+    if idle_count < 0:
+        raise ValueError("idle_count must be >= 0")
+    if warming_count < 0:
+        raise ValueError("warming_count must be >= 0")
+    if max_idle < 0:
+        raise ValueError("max_idle must be >= 0")
+    if warmup_create_qps <= 0:
+        raise ValueError("warmup_create_qps must be positive")
+    deficit = max(0, max_idle - idle_count - warming_count)
+    return deficit, min(deficit, warmup_create_qps)
 
 
 class PoolState(Enum):
@@ -349,6 +368,9 @@ class PoolConfig:
     warmup_health_check: Callable[[SandboxSync], bool] | None = None
     warmup_sandbox_preparer: Callable[[SandboxSync], None] | None = None
     warmup_skip_health_check: bool = False
+    warmup_create_qps: int = 10
+    warmup_post_prepare_health_check: Callable[[SandboxSync], bool] | None = None
+    warmup_post_prepare_health_check_timeout: timedelta = timedelta(seconds=30)
     idle_timeout: timedelta = timedelta(hours=24)
     drain_timeout: timedelta = timedelta(seconds=30)
     acquire_min_remaining_ttl: timedelta | None = None
@@ -389,6 +411,12 @@ class PoolConfig:
             self.warmup_health_check_polling_interval,
             "warmup_health_check_polling_interval must be positive",
         )
+        if self.warmup_create_qps <= 0:
+            raise ValueError("warmup_create_qps must be positive")
+        _require_positive(
+            self.warmup_post_prepare_health_check_timeout,
+            "warmup_post_prepare_health_check_timeout must be positive",
+        )
         _require_positive(self.idle_timeout, "idle_timeout must be positive")
         if self.drain_timeout.total_seconds() < 0:
             raise ValueError("drain_timeout must be non-negative")
@@ -427,6 +455,9 @@ class AsyncPoolConfig:
     warmup_health_check: Callable[[Sandbox], Awaitable[bool]] | None = None
     warmup_sandbox_preparer: Callable[[Sandbox], Awaitable[None]] | None = None
     warmup_skip_health_check: bool = False
+    warmup_create_qps: int = 10
+    warmup_post_prepare_health_check: Callable[[Sandbox], Awaitable[bool]] | None = None
+    warmup_post_prepare_health_check_timeout: timedelta = timedelta(seconds=30)
     idle_timeout: timedelta = timedelta(hours=24)
     drain_timeout: timedelta = timedelta(seconds=30)
     acquire_min_remaining_ttl: timedelta | None = None
@@ -466,6 +497,12 @@ class AsyncPoolConfig:
         _require_positive(
             self.warmup_health_check_polling_interval,
             "warmup_health_check_polling_interval must be positive",
+        )
+        if self.warmup_create_qps <= 0:
+            raise ValueError("warmup_create_qps must be positive")
+        _require_positive(
+            self.warmup_post_prepare_health_check_timeout,
+            "warmup_post_prepare_health_check_timeout must be positive",
         )
         _require_positive(self.idle_timeout, "idle_timeout must be positive")
         if self.drain_timeout.total_seconds() < 0:

--- a/sdks/sandbox/python/src/opensandbox/sync/pool.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/pool.py
@@ -33,6 +33,7 @@ from opensandbox.exceptions import (
     PoolNotRunningException,
     PoolStateStoreUnavailableException,
 )
+from opensandbox.internal.readiness import ReadinessBudget
 from opensandbox.pool_types import (
     AcquirePolicy,
     IdleEntry,
@@ -85,6 +86,9 @@ class SandboxPoolSync:
         warmup_health_check: Callable[[SandboxSync], bool] | None = None,
         warmup_sandbox_preparer: Callable[[SandboxSync], None] | None = None,
         warmup_skip_health_check: bool = False,
+        warmup_create_qps: int = 10,
+        warmup_post_prepare_health_check: Callable[[SandboxSync], bool] | None = None,
+        warmup_post_prepare_health_check_timeout: timedelta = timedelta(seconds=30),
         idle_timeout: timedelta = timedelta(hours=24),
         drain_timeout: timedelta = timedelta(seconds=30),
         acquire_min_remaining_ttl: timedelta | None = None,
@@ -115,6 +119,9 @@ class SandboxPoolSync:
             warmup_health_check=warmup_health_check,
             warmup_sandbox_preparer=warmup_sandbox_preparer,
             warmup_skip_health_check=warmup_skip_health_check,
+            warmup_create_qps=warmup_create_qps,
+            warmup_post_prepare_health_check=warmup_post_prepare_health_check,
+            warmup_post_prepare_health_check_timeout=warmup_post_prepare_health_check_timeout,
             idle_timeout=idle_timeout,
             drain_timeout=drain_timeout,
             acquire_min_remaining_ttl=acquire_min_remaining_ttl,
@@ -135,6 +142,10 @@ class SandboxPoolSync:
         self._in_flight_condition = threading.Condition()
         self._stop_event = threading.Event()
         self._scheduler_thread: threading.Thread | None = None
+        self._heartbeat_thread: threading.Thread | None = None
+        self._primary_owned = False
+        self._warming_count = 0
+        self._warming_lock = threading.Lock()
         self._warmup_executor: ThreadPoolExecutor | None = None
         self._sandbox_manager: SandboxManagerSync | None = None
 
@@ -168,8 +179,17 @@ class SandboxPoolSync:
                     name=f"sandbox-pool-reconcile-{self._config.pool_name}",
                     daemon=True,
                 )
+                # Aligned with the Kotlin SDK: renew the primary lease independently of
+                # reconcile work, at an interval no greater than one third of the TTL.
+                self._heartbeat_thread = threading.Thread(
+                    target=self._run_primary_heartbeat,
+                    args=(stop_event,),
+                    name=f"sandbox-pool-heartbeat-{self._config.pool_name}",
+                    daemon=True,
+                )
                 self._lifecycle_state = PoolLifecycleState.RUNNING
                 self._scheduler_thread.start()
+                self._heartbeat_thread.start()
             except Exception:
                 self._stop_reconcile(wait_for_warmup=True)
                 self._close_provider()
@@ -532,17 +552,23 @@ class SandboxPoolSync:
         try:
             if self._lifecycle_state != PoolLifecycleState.RUNNING:
                 return
-            if self._state_store.get_destroy_state(self._config.pool_name) != PoolDestroyState.ACTIVE:
+            if (
+                self._state_store.get_destroy_state(self._config.pool_name)
+                != PoolDestroyState.ACTIVE
+            ):
                 self._stop_after_pool_namespace_destroyed()
                 return
-            run_reconcile_tick(
-                config=self._config.with_max_idle(self._resolve_max_idle()),
-                state_store=self._state_store,
-                create_one=self._create_one_sandbox,
-                on_discard_sandbox=self._discard_sandbox_callback,
-                reconcile_state=self._reconcile_state,
-                warmup_executor=executor,
-            )
+            try:
+                self._primary_owned = run_reconcile_tick(
+                    config=self._config.with_max_idle(self._resolve_max_idle()),
+                    state_store=self._state_store,
+                    on_discard_sandbox=self._discard_sandbox_callback,
+                    submit_warmups=self._submit_warmups,
+                    warming_count=self._warming_count,
+                )
+            except Exception:
+                self._primary_owned = False
+                raise
         except Exception as exc:
             logger.error(
                 f"Pool reconcile tick failed unexpectedly: pool_name={self._config.pool_name}",
@@ -551,7 +577,82 @@ class SandboxPoolSync:
         finally:
             self._end_operation()
 
-    def _create_one_sandbox(self) -> str | None:
+    def _run_primary_heartbeat(self, stop_event: threading.Event) -> None:
+        """Renew the primary lock independently of reconcile ticks.
+
+        Aligned with the Kotlin SDK: the interval is ``min(reconcile_interval,
+        primary_lock_ttl / 3)`` so a long reconcile cadence cannot let the lease
+        expire. The heartbeat only renews while this node is the current primary;
+        a failed renewal clears ownership until the next tick re-acquires it.
+        """
+        interval = min(
+            self._config.reconcile_interval.total_seconds(),
+            self._config.primary_lock_ttl.total_seconds() / 3,
+        )
+        while not stop_event.wait(interval):
+            if not self._primary_owned:
+                continue
+            try:
+                renewed = self._state_store.renew_primary_lock(
+                    self._config.pool_name,
+                    str(self._config.owner_id),
+                    self._config.primary_lock_ttl,
+                )
+            except Exception as exc:
+                # Keep periodic heartbeats alive after transient store failures.
+                logger.error(
+                    f"Pool primary heartbeat failed: pool_name={self._config.pool_name}",
+                    exc_info=exc,
+                )
+                continue
+            if not renewed:
+                self._primary_owned = False
+                logger.debug(
+                    "Pool primary heartbeat skipped (not current owner): "
+                    f"pool_name={self._config.pool_name} owner_id={self._config.owner_id}"
+                )
+
+    def _submit_warmups(self, count: int) -> None:
+        """Admit ``count`` warmup tasks on the warmup executor and return immediately.
+
+        Aligned with the Kotlin SDK's admission model: the reconcile tick only
+        plans and admits; each admitted task then creates, validates, renews, and
+        commits its sandbox independently of the tick. The warming counter is
+        incremented synchronously here (before submission) so the next tick's
+        deficit calculation already accounts for these admissions; queued-but-
+        unstarted tasks also count, which keeps total admissions deficit-bounded.
+        """
+        if count <= 0:
+            return
+        if self._lifecycle_state != PoolLifecycleState.RUNNING:
+            return
+        executor = self._warmup_executor
+        if executor is None:
+            return
+        for _ in range(count):
+            with self._warming_lock:
+                self._warming_count += 1
+            try:
+                future = executor.submit(self._run_warmup_task)
+            except RuntimeError:
+                # Executor is shutting down; stop admitting this tick.
+                with self._warming_lock:
+                    self._warming_count -= 1
+                return
+            future.add_done_callback(self._on_warmup_task_done)
+
+    def _on_warmup_task_done(self, future: object) -> None:
+        with self._warming_lock:
+            self._warming_count -= 1
+
+    def _run_warmup_task(self) -> str | None:
+        """One admitted warmup: create → validate → renew → commit.
+
+        Runs on the warmup executor, detached from the reconcile tick. Committing
+        renews the primary lock first (a lost lease drops and kills the sandbox,
+        mirroring the Kotlin leader-epoch fence) and then publishes the ID to the
+        idle store. Failures are recorded on the reconcile state.
+        """
         self._begin_operation()
         try:
             self._ensure_pool_namespace_active()
@@ -559,6 +660,7 @@ class SandboxPoolSync:
             try:
                 if self._config.warmup_sandbox_preparer is not None:
                     self._config.warmup_sandbox_preparer(sandbox)
+                self._wait_post_prepare_healthy(sandbox)
                 if self._lifecycle_state != PoolLifecycleState.RUNNING:
                     try:
                         sandbox.kill()
@@ -566,14 +668,15 @@ class SandboxPoolSync:
                         pass
                     return None
                 # The server-side TTL has been ticking since sandbox creation;
-                # readiness wait and `warmup_sandbox_preparer` can both consume meaningful time.
-                # Renew right before handing the id back to the reconciler so the store's
-                # stamped expiry actually matches what the server will honor — otherwise
-                # `acquire_min_remaining_ttl` overestimates remaining TTL by the warmup duration.
+                # readiness wait and `warmup_sandbox_preparer` can both consume
+                # meaningful time. Renew right before committing so the store's
+                # stamped expiry actually matches what the server will honor —
+                # otherwise `acquire_min_remaining_ttl` overestimates remaining
+                # TTL by the warmup duration.
                 sandbox.renew(self._config.idle_timeout)
                 self._ensure_pool_namespace_active_after_create(sandbox)
-                return sandbox.id
-            except Exception:
+                return self._commit_warmup_sandbox(sandbox)
+            except BaseException:
                 try:
                     sandbox.kill()
                 except Exception:
@@ -581,8 +684,85 @@ class SandboxPoolSync:
                 raise
             finally:
                 sandbox.close()
+        except Exception as exc:
+            self._reconcile_state.record_failure(str(exc))
+            return None
         finally:
             self._end_operation()
+
+    def _commit_warmup_sandbox(self, sandbox: SandboxSync) -> str | None:
+        """Commit a renewed warmup sandbox to the idle buffer.
+
+        The primary lock is renewed before publishing: if the lease was lost the
+        sandbox is killed instead of committed, mirroring the Kotlin leader-epoch
+        commit fence.
+        """
+        pool_name = self._config.pool_name
+        owner_id = str(self._config.owner_id)
+        ttl = self._config.primary_lock_ttl
+        sandbox_id = sandbox.id
+        try:
+            lock_renewed = self._state_store.renew_primary_lock(
+                pool_name, owner_id, ttl
+            )
+        except Exception as exc:
+            logger.warning(
+                "Warmup commit dropped (primary lock renewal failed): "
+                f"pool_name={pool_name} sandbox_id={sandbox_id} error={exc}"
+            )
+            lock_renewed = False
+        if not lock_renewed:
+            try:
+                sandbox.kill()
+            except Exception as exc:
+                logger.warning(
+                    "Best-effort kill after lost primary lock failed: "
+                    f"pool_name={pool_name} sandbox_id={sandbox_id} error={exc}"
+                )
+            self._reconcile_state.record_failure(
+                "primary lock lost during warmup commit"
+            )
+            return None
+        try:
+            self._state_store.put_idle(pool_name, sandbox_id)
+        except Exception as exc:
+            logger.warning(
+                f"Warmup commit failed; dropped newly created sandbox: "
+                f"pool_name={pool_name} sandbox_id={sandbox_id} error={exc}"
+            )
+            try:
+                self._state_store.remove_idle(pool_name, sandbox_id)
+            except Exception:
+                pass
+            try:
+                sandbox.kill()
+            except Exception as kill_exc:
+                logger.warning(
+                    "Best-effort kill after failed commit failed: "
+                    f"pool_name={pool_name} sandbox_id={sandbox_id} error={kill_exc}"
+                )
+            self._reconcile_state.record_failure(f"warmup commit failed: {exc}")
+            return None
+        self._reconcile_state.record_success()
+        return sandbox_id
+
+    def _wait_post_prepare_healthy(self, sandbox: SandboxSync) -> None:
+        """Re-validate readiness after the warmup preparer, if configured.
+
+        Aligned with the Kotlin SDK's ``warmupPostPrepareHealthCheck`` stage: poll the
+        caller-provided check at ``warmup_health_check_polling_interval`` until it
+        returns True or ``warmup_post_prepare_health_check_timeout`` elapses. The
+        preparer is never rerun; a timeout raises :class:`SandboxReadyTimeoutException`
+        so the surrounding warmup failure path kills the sandbox.
+        """
+        check = self._config.warmup_post_prepare_health_check
+        if check is None:
+            return
+        budget = ReadinessBudget(
+            self._config.warmup_post_prepare_health_check_timeout,
+            self._config.warmup_health_check_polling_interval,
+        )
+        budget.health_sync(lambda: check(sandbox), context="post-prepare health check")
 
     def _build_warmup_sandbox(self) -> SandboxSync:
         if self._config.sandbox_creator is not None:
@@ -941,6 +1121,16 @@ class SandboxPoolSync:
             thread.join(timeout=5)
         if join_scheduler:
             self._scheduler_thread = None
+        heartbeat = self._heartbeat_thread
+        if (
+            join_scheduler
+            and heartbeat is not None
+            and heartbeat is not threading.current_thread()
+        ):
+            heartbeat.join(timeout=5)
+        if join_scheduler:
+            self._heartbeat_thread = None
+        self._primary_owned = False
         executor = self._warmup_executor
         if executor is not None:
             executor.shutdown(wait=False, cancel_futures=True)

--- a/sdks/sandbox/python/tests/test_pool_async.py
+++ b/sdks/sandbox/python/tests/test_pool_async.py
@@ -23,7 +23,6 @@ import httpx
 import pytest
 
 from opensandbox._async_pool_reconciler import run_async_reconcile_tick
-from opensandbox._pool_reconciler import ReconcileState
 from opensandbox.config import ConnectionConfig
 from opensandbox.exceptions import (
     PoolAcquireFailedException,
@@ -39,6 +38,7 @@ from opensandbox.pool import (
     PoolCreationSpec,
     PooledSandboxCreateContext,
     PooledSandboxCreateReason,
+    PoolState,
     SandboxPoolAsync,
 )
 
@@ -184,9 +184,14 @@ async def test_release_all_idle_parallel_finishes_kills_before_cancellation() ->
 
 
 @pytest.mark.asyncio
-async def test_async_reconcile_batch_failures_only_advance_backoff_once() -> None:
+async def test_async_reconcile_batch_failures_track_degraded_without_backoff() -> None:
+    class FailingAsyncSandbox(FakeAsyncSandbox):
+        @classmethod
+        async def create(cls, *args: Any, **kwargs: Any) -> FakeAsyncSandbox:
+            raise RuntimeError("boom")
+
     store = InMemoryAsyncPoolStateStore()
-    config = AsyncPoolConfig(
+    pool = SandboxPoolAsync(
         pool_name="pool",
         owner_id="owner-1",
         max_idle=10,
@@ -194,85 +199,298 @@ async def test_async_reconcile_batch_failures_only_advance_backoff_once() -> Non
         state_store=store,
         connection_config=ConnectionConfig(),
         creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        # One immediate tick only, so exactly one admission batch runs.
+        reconcile_interval=timedelta(seconds=3600),
+        primary_lock_ttl=timedelta(seconds=5),
+        drain_timeout=timedelta(milliseconds=50),
+        sandbox_manager_factory=lambda config: _manager_factory(FakeAsyncManager()),
+        sandbox_factory=FailingAsyncSandbox,  # type: ignore[arg-type]
     )
-    state = ReconcileState(degraded_threshold=3)
+    await pool.start()
+    try:
+        # The tick returns immediately; the 10 admitted warmups fail asynchronously.
+        # Track admission calls: waiting on the warming counter alone can miss the
+        # whole batch (it drops back to zero within one loop turn), and a first-
+        # check-is-true condition would never yield to the event loop at all.
+        submitted: list[int] = []
+        original_submit = pool._submit_warmups
 
-    async def fail_create() -> str:
-        raise RuntimeError("boom")
+        def tracking_submit(count: int) -> None:
+            submitted.append(count)
+            original_submit(count)
 
-    await run_async_reconcile_tick(
+        pool._submit_warmups = tracking_submit
+
+        async def _tick_ran() -> bool:
+            return bool(submitted)
+
+        async def _warmups_done() -> bool:
+            return pool._warming_count == 0
+
+        await _eventually(_tick_ran)
+        await _eventually(_warmups_done)
+
+        assert submitted == [10]
+        assert pool._reconcile_state.failure_count == 10
+        assert pool._reconcile_state.state == PoolState.DEGRADED
+        # Replenish backoff is gone: failures no longer pause the next tick's admissions.
+        assert not pool._reconcile_state.is_backoff_active(datetime.now(timezone.utc))
+    finally:
+        await pool.shutdown(False)
+
+
+@pytest.mark.asyncio
+async def test_async_reconcile_caps_creates_per_tick_at_warmup_create_qps() -> None:
+    store = InMemoryAsyncPoolStateStore()
+    config = AsyncPoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=10,
+        warmup_concurrency=10,
+        warmup_create_qps=3,
+        state_store=store,
+        connection_config=ConnectionConfig(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    )
+    submitted: list[int] = []
+
+    primary_owned = await run_async_reconcile_tick(
         config=config,
         state_store=store,
-        create_one=fail_create,
         on_discard_sandbox=_noop_discard,
-        reconcile_state=state,
+        submit_warmups=submitted.append,
     )
 
-    assert state.failure_count == 10
-    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=29))
-    assert not state.is_backoff_active(
-        datetime.now(timezone.utc) + timedelta(seconds=31)
-    )
+    assert primary_owned is True
+    # The tick only admits; it must not create or commit anything itself.
+    assert submitted == [3]
+    counters = await store.snapshot_counters("pool")
+    assert counters.idle_count == 0
 
 
 @pytest.mark.asyncio
-async def test_async_reconcile_commits_fast_warmup_before_slow_peer_finishes() -> (
-    None
+async def test_async_reconcile_counts_in_flight_warmups_toward_target() -> None:
+    store = InMemoryAsyncPoolStateStore()
+    config = AsyncPoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=4,
+        warmup_concurrency=4,
+        state_store=store,
+        connection_config=ConnectionConfig(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    )
+    submitted: list[int] = []
+
+    primary_owned = await run_async_reconcile_tick(
+        config=config,
+        state_store=store,
+        on_discard_sandbox=_noop_discard,
+        submit_warmups=submitted.append,
+        warming_count=2,
+    )
+
+    # deficit = 4 - 0 idle - 2 warming = 2, so only two more admissions this tick.
+    assert primary_owned is True
+    assert submitted == [2]
+
+
+@pytest.mark.asyncio
+async def test_async_reconcile_returns_false_when_not_primary() -> None:
+    class NotPrimaryStore(InMemoryAsyncPoolStateStore):
+        async def try_acquire_primary_lock(
+            self, pool_name: str, owner_id: str, ttl: timedelta
+        ) -> bool:
+            return False
+
+    store = NotPrimaryStore()
+    config = AsyncPoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=1,
+        state_store=store,
+        connection_config=ConnectionConfig(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    )
+    submitted: list[int] = []
+
+    primary_owned = await run_async_reconcile_tick(
+        config=config,
+        state_store=store,
+        on_discard_sandbox=_noop_discard,
+        submit_warmups=submitted.append,
+    )
+
+    assert primary_owned is False
+    assert submitted == []
+    counters = await store.snapshot_counters("pool")
+    assert counters.idle_count == 0
+
+
+@pytest.mark.asyncio
+async def test_async_warmup_post_prepare_health_check_retries_until_healthy() -> None:
+    FakeAsyncSandbox.reset()
+    store = InMemoryAsyncPoolStateStore()
+    attempts: list[str] = []
+
+    async def post_prepare_check(sandbox: FakeAsyncSandbox) -> bool:
+        attempts.append(sandbox.id)
+        return len(attempts) >= 2
+
+    pool = SandboxPoolAsync(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=1,
+        warmup_concurrency=2,
+        state_store=store,
+        connection_config=ConnectionConfig(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        reconcile_interval=timedelta(milliseconds=20),
+        primary_lock_ttl=timedelta(seconds=5),
+        drain_timeout=timedelta(milliseconds=50),
+        warmup_health_check_polling_interval=timedelta(milliseconds=5),
+        warmup_post_prepare_health_check=post_prepare_check,
+        sandbox_manager_factory=lambda config: _manager_factory(FakeAsyncManager()),
+        sandbox_factory=FakeAsyncSandbox,  # type: ignore[arg-type]
+    )
+    await pool.start()
+    try:
+
+        async def _idle_filled() -> bool:
+            counters = await store.snapshot_counters("pool")
+            return counters.idle_count == 1
+
+        await _eventually(_idle_filled)
+        assert len(attempts) >= 2
+        assert FakeAsyncSandbox.last_created is not None
+        assert FakeAsyncSandbox.last_created.renewed
+    finally:
+        await pool.shutdown(False)
+
+
+@pytest.mark.asyncio
+async def test_async_warmup_post_prepare_health_check_timeout_kills_and_skips_commit() -> (
+    None,
 ):
+    FakeAsyncSandbox.reset()
     store = InMemoryAsyncPoolStateStore()
-    config = AsyncPoolConfig(
+
+    async def post_prepare_check(sandbox: FakeAsyncSandbox) -> bool:
+        return False
+
+    pool = SandboxPoolAsync(
         pool_name="pool",
         owner_id="owner-1",
-        max_idle=2,
+        max_idle=1,
         warmup_concurrency=2,
         state_store=store,
         connection_config=ConnectionConfig(),
         creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        reconcile_interval=timedelta(milliseconds=20),
+        primary_lock_ttl=timedelta(seconds=5),
+        drain_timeout=timedelta(milliseconds=50),
+        warmup_health_check_polling_interval=timedelta(milliseconds=5),
+        warmup_post_prepare_health_check=post_prepare_check,
+        warmup_post_prepare_health_check_timeout=timedelta(milliseconds=30),
+        sandbox_manager_factory=lambda config: _manager_factory(FakeAsyncManager()),
+        sandbox_factory=FakeAsyncSandbox,  # type: ignore[arg-type]
     )
-    state = ReconcileState(degraded_threshold=3)
-    slow_started = asyncio.Event()
-    release_slow = asyncio.Event()
-    calls = 0
-
-    async def create_one() -> str:
-        nonlocal calls
-        calls += 1
-        if calls == 1:
-            slow_started.set()
-            await release_slow.wait()
-            return "slow"
-        await slow_started.wait()
-        return "fast"
-
-    reconcile_task = asyncio.create_task(
-        run_async_reconcile_tick(
-            config=config,
-            state_store=store,
-            create_one=create_one,
-            on_discard_sandbox=_noop_discard,
-            reconcile_state=state,
-        )
-    )
-
-    async def fast_is_idle() -> bool:
-        return (await store.snapshot_counters("pool")).idle_count == 1
-
+    await pool.start()
     try:
-        await asyncio.wait_for(slow_started.wait(), timeout=2)
-        await _eventually(fast_is_idle)
-        assert not reconcile_task.done()
-        assert await store.try_take_idle("pool") == "fast"
-    finally:
-        release_slow.set()
-        await asyncio.wait_for(reconcile_task, timeout=2)
 
-    assert await store.try_take_idle("pool") == "slow"
+        async def _created_killed() -> bool:
+            last = FakeAsyncSandbox.last_created
+            return last is not None and last.killed
+
+        await _eventually(_created_killed)
+        counters = await store.snapshot_counters("pool")
+        assert counters.idle_count == 0
+        assert FakeAsyncSandbox.last_created is not None
+        assert not FakeAsyncSandbox.last_created.renewed
+    finally:
+        await pool.shutdown(False)
 
 
 @pytest.mark.asyncio
-async def test_async_reconcile_cancellation_discards_uncommitted_warmup() -> None:
+async def test_async_primary_heartbeat_renews_independently_and_stops_when_lock_lost() -> (
+    None,
+):
+    class CountingRenewStore(InMemoryAsyncPoolStateStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.renew_calls = 0
+
+        async def renew_primary_lock(
+            self, pool_name: str, owner_id: str, ttl: timedelta
+        ) -> bool:
+            self.renew_calls += 1
+            # First two renewals succeed (the initial tick), then the lease is lost.
+            return self.renew_calls <= 2
+
+    FakeAsyncSandbox.reset()
+    store = CountingRenewStore()
+    pool = SandboxPoolAsync(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=1,
+        warmup_concurrency=2,
+        state_store=store,
+        connection_config=ConnectionConfig(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        # One immediate tick only; the heartbeat interval becomes ttl / 3 = 0.1s.
+        reconcile_interval=timedelta(seconds=3600),
+        primary_lock_ttl=timedelta(milliseconds=300),
+        drain_timeout=timedelta(milliseconds=50),
+        sandbox_manager_factory=lambda config: _manager_factory(FakeAsyncManager()),
+        sandbox_factory=FakeAsyncSandbox,  # type: ignore[arg-type]
+    )
+    await pool.start()
+    try:
+
+        async def _renew_reached() -> bool:
+            return store.renew_calls >= 3
+
+        # Initial tick: plan renew (1) + per-commit renew (2). Heartbeat fires at ~0.1s,
+        # observes the lost lease (renew 3 returns False), and stops renewing.
+        await _eventually(_renew_reached)
+        await asyncio.sleep(0.3)
+        assert store.renew_calls == 3
+    finally:
+        await pool.shutdown(False)
+
+
+@pytest.mark.asyncio
+async def test_async_reconcile_tick_does_not_block_on_slow_warmup() -> None:
+    """Kotlin-aligned admission model: the tick returns after submitting; each warmup
+    commits independently, and in-flight admissions count toward max_idle so the next
+    tick does not overshoot while a slow warmup is still running."""
+
+    class SlowFirstAsyncSandbox(FakeAsyncSandbox):
+        slow_started = asyncio.Event()
+        release_slow = asyncio.Event()
+
+        @classmethod
+        def reset(cls) -> None:
+            super().reset()
+            cls.slow_started = asyncio.Event()
+            cls.release_slow = asyncio.Event()
+
+        @classmethod
+        async def create(cls, *args: Any, **kwargs: Any) -> FakeAsyncSandbox:
+            cls.created_count += 1
+            ordinal = cls.created_count
+            sandbox = cls(f"created-{ordinal}")
+            cls.last_created = sandbox
+            if ordinal == 1:
+                cls.slow_started.set()
+                await cls.release_slow.wait()
+            else:
+                await cls.slow_started.wait()
+            return sandbox
+
+    SlowFirstAsyncSandbox.reset()
     store = InMemoryAsyncPoolStateStore()
-    config = AsyncPoolConfig(
+    pool = SandboxPoolAsync(
         pool_name="pool",
         owner_id="owner-1",
         max_idle=2,
@@ -280,61 +498,85 @@ async def test_async_reconcile_cancellation_discards_uncommitted_warmup() -> Non
         state_store=store,
         connection_config=ConnectionConfig(),
         creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        reconcile_interval=timedelta(milliseconds=20),
+        primary_lock_ttl=timedelta(seconds=5),
+        drain_timeout=timedelta(milliseconds=50),
+        sandbox_manager_factory=lambda config: _manager_factory(FakeAsyncManager()),
+        sandbox_factory=SlowFirstAsyncSandbox,  # type: ignore[arg-type]
     )
-    state = ReconcileState(degraded_threshold=3)
-    slow_started = asyncio.Event()
-    discard_started = asyncio.Event()
-    release_discard = asyncio.Event()
-    discarded: list[str] = []
-    calls = 0
-
-    async def create_one() -> str:
-        nonlocal calls
-        calls += 1
-        if calls == 1:
-            slow_started.set()
-            try:
-                await asyncio.Event().wait()
-            except asyncio.CancelledError:
-                return "late"
-        await slow_started.wait()
-        return "fast"
-
-    async def discard(sandbox_id: str) -> None:
-        discard_started.set()
-        await release_discard.wait()
-        discarded.append(sandbox_id)
-
-    reconcile_task = asyncio.create_task(
-        run_async_reconcile_tick(
-            config=config,
-            state_store=store,
-            create_one=create_one,
-            on_discard_sandbox=discard,
-            reconcile_state=state,
-        )
-    )
-
-    async def fast_is_idle() -> bool:
-        return (await store.snapshot_counters("pool")).idle_count == 1
-
+    await pool.start()
     try:
-        await asyncio.wait_for(slow_started.wait(), timeout=2)
-        await _eventually(fast_is_idle)
-        reconcile_task.cancel()
-        await asyncio.wait_for(discard_started.wait(), timeout=2)
-        reconcile_task.cancel()
-        release_discard.set()
-        with pytest.raises(asyncio.CancelledError):
-            await asyncio.wait_for(reconcile_task, timeout=2)
-    finally:
-        release_discard.set()
-        reconcile_task.cancel()
-        await asyncio.gather(reconcile_task, return_exceptions=True)
+        # The first tick admitted both warmups and returned; the slow one is still
+        # running, yet the fast peer ("created-2") is already committed and acquirable.
+        await asyncio.wait_for(SlowFirstAsyncSandbox.slow_started.wait(), timeout=2)
 
-    assert await store.try_take_idle("pool") == "fast"
-    assert await store.try_take_idle("pool") is None
-    assert discarded == ["late"]
+        async def _fast_committed() -> bool:
+            return await store.try_take_idle("pool") == "created-2"
+
+        await _eventually(_fast_committed)
+        assert not SlowFirstAsyncSandbox.release_slow.is_set()
+        # The slow sandbox commits once released.
+        SlowFirstAsyncSandbox.release_slow.set()
+
+        async def _slow_committed() -> bool:
+            entries = await store.snapshot_idle_entries("pool")
+            return any(entry.sandbox_id == "created-1" for entry in entries)
+
+        await _eventually(_slow_committed)
+    finally:
+        SlowFirstAsyncSandbox.release_slow.set()
+        await pool.shutdown(False)
+
+
+@pytest.mark.asyncio
+async def test_async_warmup_cancelled_during_prepare_kills_sandbox() -> None:
+    """Shutdown cancels in-flight warmup tasks; a sandbox already created by a
+    cancelled task must be killed instead of leaking until its server TTL."""
+
+    class SlowPreparedSandbox(FakeAsyncSandbox):
+        release_prepare = asyncio.Event()
+
+        @classmethod
+        def reset(cls) -> None:
+            super().reset()
+            cls.release_prepare = asyncio.Event()
+
+    async def preparer(sandbox: FakeAsyncSandbox) -> None:
+        await SlowPreparedSandbox.release_prepare.wait()
+
+    SlowPreparedSandbox.reset()
+    store = InMemoryAsyncPoolStateStore()
+    pool = SandboxPoolAsync(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=1,
+        warmup_concurrency=2,
+        state_store=store,
+        connection_config=ConnectionConfig(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        reconcile_interval=timedelta(seconds=3600),
+        primary_lock_ttl=timedelta(seconds=5),
+        drain_timeout=timedelta(milliseconds=50),
+        warmup_sandbox_preparer=preparer,
+        sandbox_manager_factory=lambda config: _manager_factory(FakeAsyncManager()),
+        sandbox_factory=SlowPreparedSandbox,  # type: ignore[arg-type]
+    )
+    await pool.start()
+    try:
+
+        async def _sandbox_created() -> bool:
+            return SlowPreparedSandbox.last_created is not None
+
+        await _eventually(_sandbox_created)
+    finally:
+        # Non-graceful shutdown cancels the warmup task while the preparer is still
+        # parked; the created sandbox must receive a kill before the pool stops.
+        await pool.shutdown(False)
+
+    counters = await store.snapshot_counters("pool")
+    assert counters.idle_count == 0
+    assert SlowPreparedSandbox.last_created is not None
+    assert SlowPreparedSandbox.last_created.killed
 
 
 @pytest.mark.asyncio
@@ -350,6 +592,7 @@ async def test_async_acquire_fail_fast_stale_idle_raises_and_kills_candidate() -
             await pool.acquire(policy=AcquirePolicy.FAIL_FAST)
         assert exc.value.error.code == "POOL_ACQUIRE_FAILED"
         assert (await store.snapshot_counters("pool")).idle_count == 0
+
         # Kill is now fire-and-forget (retry-loop must not block on slow DELETE) so wait for
         # the background task to observe the kill.
         async def _killed_stale_1() -> bool:
@@ -376,7 +619,9 @@ async def test_async_acquire_direct_create_when_empty() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_acquire_does_not_direct_create_when_pool_namespace_is_destroying() -> None:
+async def test_async_acquire_does_not_direct_create_when_pool_namespace_is_destroying() -> (
+    None
+):
     FakeAsyncSandbox.reset()
     store = InMemoryAsyncPoolStateStore()
     pool = _create_pool(max_idle=0, store=store)
@@ -441,7 +686,9 @@ async def test_async_acquire_stopped_destroyed_pool_raises_pool_destroyed() -> N
 
 
 @pytest.mark.asyncio
-async def test_async_acquire_destroy_race_preserves_pool_destroyed_when_cleanup_fails() -> None:
+async def test_async_acquire_destroy_race_preserves_pool_destroyed_when_cleanup_fails() -> (
+    None
+):
     store = InMemoryAsyncPoolStateStore()
     await store.put_idle("pool", "id-1")
 
@@ -784,14 +1031,14 @@ async def test_async_acquire_retry_next_idle_empty_raises_pool_empty() -> None:
         await pool.shutdown(False)
 
 
-async def test_async_acquire_retry_next_idle_all_stale_bounds_retries_and_raises() -> None:
+async def test_async_acquire_retry_next_idle_all_stale_bounds_retries_and_raises() -> (
+    None
+):
     store = InMemoryAsyncPoolStateStore()
     manager = FakeAsyncManager()
     for i in range(5):
         await store.put_idle("pool", f"stale-{i}")
-    pool = _create_pool(
-        max_idle=0, store=store, manager=manager, max_acquire_retries=3
-    )
+    pool = _create_pool(max_idle=0, store=store, manager=manager, max_acquire_retries=3)
     await pool.start()
     try:
         with pytest.raises(PoolAcquireFailedException):
@@ -933,7 +1180,9 @@ async def test_async_acquire_retry_next_idle_renew_failure_kills_remote_without_
         await pool.shutdown(False)
 
 
-async def test_async_acquire_retry_next_idle_does_not_block_on_slow_stale_kill() -> None:
+async def test_async_acquire_retry_next_idle_does_not_block_on_slow_stale_kill() -> (
+    None
+):
     """Async counterpart of the sync slow-kill regression: stale-candidate kill must be
     scheduled as a background task so a slow DELETE does not stall the retry loop.
     """
@@ -950,9 +1199,7 @@ async def test_async_acquire_retry_next_idle_does_not_block_on_slow_stale_kill()
     await store.put_idle("pool", "healthy-x")
 
     manager = SlowKillManager()
-    pool = _create_pool(
-        max_idle=0, store=store, manager=manager, max_acquire_retries=5
-    )
+    pool = _create_pool(max_idle=0, store=store, manager=manager, max_acquire_retries=5)
     await pool.start()
     try:
         start = time.monotonic()

--- a/sdks/sandbox/python/tests/test_pool_config.py
+++ b/sdks/sandbox/python/tests/test_pool_config.py
@@ -234,3 +234,81 @@ def test_async_pool_facade_forwards_acquire_min_remaining_ttl() -> None:
 
     assert pool._config.acquire_min_remaining_ttl == timedelta(seconds=10)
     assert pool._config.idle_timeout == timedelta(seconds=30)
+
+
+def test_warmup_create_qps_defaults_and_validation() -> None:
+    config = PoolConfig(**_sync_kwargs())  # type: ignore[arg-type]
+    assert config.warmup_create_qps == 10
+    assert config.warmup_post_prepare_health_check is None
+    assert config.warmup_post_prepare_health_check_timeout == timedelta(seconds=30)
+
+    with pytest.raises(ValueError, match="warmup_create_qps must be positive"):
+        PoolConfig(**_sync_kwargs(), warmup_create_qps=0)  # type: ignore[arg-type]
+
+
+def test_async_warmup_create_qps_defaults_and_validation() -> None:
+    config = AsyncPoolConfig(**_async_kwargs())  # type: ignore[arg-type]
+    assert config.warmup_create_qps == 10
+    assert config.warmup_post_prepare_health_check is None
+    assert config.warmup_post_prepare_health_check_timeout == timedelta(seconds=30)
+
+    with pytest.raises(ValueError, match="warmup_create_qps must be positive"):
+        AsyncPoolConfig(**_async_kwargs(), warmup_create_qps=-1)  # type: ignore[arg-type]
+
+
+def test_warmup_post_prepare_health_check_timeout_must_be_positive() -> None:
+    with pytest.raises(
+        ValueError, match="warmup_post_prepare_health_check_timeout must be positive"
+    ):
+        PoolConfig(  # type: ignore[arg-type]
+            **_sync_kwargs(),
+            warmup_post_prepare_health_check_timeout=timedelta(0),
+        )
+
+    with pytest.raises(
+        ValueError, match="warmup_post_prepare_health_check_timeout must be positive"
+    ):
+        AsyncPoolConfig(  # type: ignore[arg-type]
+            **_async_kwargs(),
+            warmup_post_prepare_health_check_timeout=timedelta(seconds=-1),
+        )
+
+
+def test_pool_facades_forward_warmup_admission_arguments() -> None:
+    def post_prepare(_sandbox: SandboxSync) -> bool:
+        return True
+
+    async def async_post_prepare(_sandbox: Sandbox) -> bool:
+        return True
+
+    sync_pool = SandboxPoolSync(
+        pool_name="test",
+        max_idle=1,
+        state_store=InMemoryPoolStateStore(),
+        connection_config=ConnectionConfigSync(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        warmup_create_qps=7,
+        warmup_post_prepare_health_check=post_prepare,
+        warmup_post_prepare_health_check_timeout=timedelta(seconds=5),
+    )
+    async_pool = SandboxPoolAsync(
+        pool_name="test",
+        max_idle=1,
+        state_store=InMemoryAsyncPoolStateStore(),
+        connection_config=ConnectionConfig(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        warmup_create_qps=7,
+        warmup_post_prepare_health_check=async_post_prepare,
+        warmup_post_prepare_health_check_timeout=timedelta(seconds=5),
+    )
+
+    assert sync_pool._config.warmup_create_qps == 7
+    assert sync_pool._config.warmup_post_prepare_health_check is post_prepare
+    assert sync_pool._config.warmup_post_prepare_health_check_timeout == timedelta(
+        seconds=5
+    )
+    assert async_pool._config.warmup_create_qps == 7
+    assert async_pool._config.warmup_post_prepare_health_check is async_post_prepare
+    assert async_pool._config.warmup_post_prepare_health_check_timeout == timedelta(
+        seconds=5
+    )

--- a/sdks/sandbox/python/tests/test_pool_kill_discarded.py
+++ b/sdks/sandbox/python/tests/test_pool_kill_discarded.py
@@ -297,7 +297,7 @@ class _RenewTrackingSyncSandbox:
 
 def test_sync_create_one_sandbox_renews_before_returning_id() -> None:
     """Warmup pipeline must renew the sandbox to ``idle_timeout`` after preparer runs and
-    before returning the id to the reconciler. Otherwise the store stamps an expiry the
+    before committing the id to the idle store. Otherwise the store stamps an expiry the
     server-side TTL has already partially elapsed against, and ``acquire_min_remaining_ttl``
     overestimates remaining TTL by the warmup duration.
     """
@@ -310,10 +310,11 @@ def test_sync_create_one_sandbox_renews_before_returning_id() -> None:
         def close(self) -> None:  # pragma: no cover
             return None
 
+    store = InMemoryPoolStateStore()
     pool = SandboxPoolSync(
         pool_name="warm-renew",
         max_idle=1,
-        state_store=InMemoryPoolStateStore(),
+        state_store=store,
         connection_config=ConnectionConfigSync(),
         creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
         idle_timeout=timedelta(minutes=5),
@@ -321,10 +322,11 @@ def test_sync_create_one_sandbox_renews_before_returning_id() -> None:
         sandbox_factory=_RenewTrackingSyncSandbox,  # type: ignore[arg-type]
     )
 
-    # _create_one_sandbox short-circuits unless the pool is running.
+    # _run_warmup_task short-circuits unless the pool is running.
     pool._lifecycle_state = PoolLifecycleState.RUNNING
-    sandbox_id = pool._create_one_sandbox()
+    sandbox_id = pool._run_warmup_task()
     assert sandbox_id == "warm-1"
+    assert store.try_take_idle("warm-renew") == "warm-1"
     assert _RenewTrackingSyncSandbox.last_instance is not None
     assert _RenewTrackingSyncSandbox.last_instance.renewed == [timedelta(minutes=5)], (
         "expected renew([5min]) before putIdle, got "
@@ -371,10 +373,11 @@ async def test_async_create_one_sandbox_renews_before_returning_id() -> None:
     async def _factory(_: Any) -> _AsyncManager:
         return _AsyncManager()
 
+    store = InMemoryAsyncPoolStateStore()
     pool = SandboxPoolAsync(
         pool_name="warm-renew",
         max_idle=1,
-        state_store=InMemoryAsyncPoolStateStore(),
+        state_store=store,
         connection_config=ConnectionConfig(),
         creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
         idle_timeout=timedelta(minutes=5),
@@ -383,8 +386,9 @@ async def test_async_create_one_sandbox_renews_before_returning_id() -> None:
     )
 
     pool._lifecycle_state = PoolLifecycleState.RUNNING
-    sandbox_id = await pool._create_one_sandbox()
+    sandbox_id = await pool._run_warmup_task()
     assert sandbox_id == "warm-1"
+    assert await store.try_take_idle("warm-renew") == "warm-1"
     assert _RenewTrackingAsyncSandbox.last_instance is not None
     assert _RenewTrackingAsyncSandbox.last_instance.renewed == [timedelta(minutes=5)], (
         "expected renew([5min]) before putIdle, got "

--- a/sdks/sandbox/python/tests/test_pool_sync.py
+++ b/sdks/sandbox/python/tests/test_pool_sync.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
@@ -39,35 +38,138 @@ from opensandbox.pool import (
     PoolCreationSpec,
     PooledSandboxCreateContext,
     PooledSandboxCreateReason,
+    PoolState,
+    calculate_warmup_plan,
 )
 from opensandbox.sync.pool import SandboxPoolSync
 
 
-def test_degraded_backoff_caps_at_one_day() -> None:
+def test_replenish_backoff_disabled_degraded_state_tracked() -> None:
+    """Aligned with the Kotlin SDK: fixed create admission replaces replenish backoff,
+    so ``is_backoff_active`` is always False while DEGRADED is still tracked."""
     state = ReconcileState(degraded_threshold=1)
 
     for _ in range(20):
         state.record_failure("boom")
 
     assert state.failure_count == 20
-    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(hours=23))
-    assert not state.is_backoff_active(datetime.now(timezone.utc) + timedelta(hours=25))
+    assert state.state == PoolState.DEGRADED
+    assert state.last_error == "boom"
+    assert not state.is_backoff_active(datetime.now(timezone.utc))
+    assert not state.is_backoff_active(datetime.now(timezone.utc) + timedelta(hours=23))
+
+    state.record_success()
+
+    assert state.state == PoolState.HEALTHY
+    assert state.failure_count == 0
+    assert state.last_error is None
 
 
-def test_degraded_backoff_starts_at_thirty_seconds() -> None:
-    state = ReconcileState(degraded_threshold=1)
+def test_warmup_plan_caps_submissions_at_create_qps() -> None:
+    # Aligned with the Kotlin WarmupPlan: idle + warming both count toward the target.
+    assert calculate_warmup_plan(0, 0, 10, 10) == (10, 10)
+    assert calculate_warmup_plan(0, 4, 10, 10) == (6, 6)
+    assert calculate_warmup_plan(2, 0, 10, 3) == (8, 3)
+    assert calculate_warmup_plan(7, 3, 10, 10) == (0, 0)
+    assert calculate_warmup_plan(12, 0, 10, 10) == (0, 0)
 
-    state.record_failure("boom")
-
-    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=29))
-    assert not state.is_backoff_active(
-        datetime.now(timezone.utc) + timedelta(seconds=31)
-    )
+    with pytest.raises(ValueError, match="warmup_create_qps must be positive"):
+        calculate_warmup_plan(0, 0, 10, 0)
+    with pytest.raises(ValueError, match="warming_count must be >= 0"):
+        calculate_warmup_plan(0, -1, 10, 10)
 
 
-def test_reconcile_batch_failures_only_advance_backoff_once() -> None:
+def test_reconcile_caps_creates_per_tick_at_warmup_create_qps() -> None:
     store = InMemoryPoolStateStore()
     config = PoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=10,
+        warmup_concurrency=10,
+        warmup_create_qps=3,
+        state_store=store,
+        connection_config=ConnectionConfigSync(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    )
+    submitted: list[int] = []
+
+    primary_owned = run_reconcile_tick(
+        config=config,
+        state_store=store,
+        on_discard_sandbox=lambda _sandbox_id: None,
+        submit_warmups=submitted.append,
+    )
+
+    assert primary_owned is True
+    # The tick only admits; it must not create or commit anything itself.
+    assert submitted == [3]
+    assert store.snapshot_counters("pool").idle_count == 0
+
+
+def test_reconcile_counts_in_flight_warmups_toward_target() -> None:
+    store = InMemoryPoolStateStore()
+    config = PoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=4,
+        warmup_concurrency=4,
+        state_store=store,
+        connection_config=ConnectionConfigSync(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    )
+    submitted: list[int] = []
+
+    primary_owned = run_reconcile_tick(
+        config=config,
+        state_store=store,
+        on_discard_sandbox=lambda _sandbox_id: None,
+        submit_warmups=submitted.append,
+        warming_count=2,
+    )
+
+    # deficit = 4 - 0 idle - 2 warming = 2, so only two more admissions this tick.
+    assert primary_owned is True
+    assert submitted == [2]
+
+
+def test_reconcile_returns_false_when_not_primary() -> None:
+    class NotPrimaryStore(InMemoryPoolStateStore):
+        def try_acquire_primary_lock(
+            self, pool_name: str, owner_id: str, ttl: timedelta
+        ) -> bool:
+            return False
+
+    store = NotPrimaryStore()
+    config = PoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=1,
+        state_store=store,
+        connection_config=ConnectionConfigSync(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    )
+    submitted: list[int] = []
+
+    primary_owned = run_reconcile_tick(
+        config=config,
+        state_store=store,
+        on_discard_sandbox=lambda _sandbox_id: None,
+        submit_warmups=submitted.append,
+    )
+
+    assert primary_owned is False
+    assert submitted == []
+    assert store.snapshot_counters("pool").idle_count == 0
+
+
+def test_reconcile_batch_failures_track_degraded_without_backoff() -> None:
+    class FailingSandbox(FakeSandbox):
+        @classmethod
+        def create(cls, *args: Any, **kwargs: Any) -> FailingSandbox:
+            raise RuntimeError("boom")
+
+    store = InMemoryPoolStateStore()
+    pool = SandboxPoolSync(
         pool_name="pool",
         owner_id="owner-1",
         max_idle=10,
@@ -75,32 +177,172 @@ def test_reconcile_batch_failures_only_advance_backoff_once() -> None:
         state_store=store,
         connection_config=ConnectionConfigSync(),
         creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        # One immediate tick only, so exactly one admission batch runs.
+        reconcile_interval=timedelta(seconds=3600),
+        primary_lock_ttl=timedelta(seconds=5),
+        drain_timeout=timedelta(milliseconds=50),
+        sandbox_manager_factory=lambda config: FakeManager(),  # type: ignore[arg-type,return-value]
+        sandbox_factory=FailingSandbox,  # type: ignore[arg-type]
     )
-    state = ReconcileState(degraded_threshold=3)
+    pool.start()
+    try:
+        # The tick returns immediately; the 10 admitted warmups fail asynchronously.
+        _eventually(lambda: pool._warming_count == 0)
 
-    def fail_create() -> str:
-        raise RuntimeError("boom")
-
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        run_reconcile_tick(
-            config=config,
-            state_store=store,
-            create_one=fail_create,
-            on_discard_sandbox=lambda _sandbox_id: None,
-            reconcile_state=state,
-            warmup_executor=executor,
-        )
-
-    assert state.failure_count == 10
-    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=29))
-    assert not state.is_backoff_active(
-        datetime.now(timezone.utc) + timedelta(seconds=31)
-    )
+        assert pool._reconcile_state.failure_count == 10
+        assert pool._reconcile_state.state == PoolState.DEGRADED
+        # Replenish backoff is gone: failures no longer pause the next tick's admissions.
+        assert not pool._reconcile_state.is_backoff_active(datetime.now(timezone.utc))
+    finally:
+        pool.shutdown(False)
 
 
-def test_reconcile_commits_fast_warmup_before_slow_peer_finishes() -> None:
+def test_warmup_post_prepare_health_check_retries_until_healthy() -> None:
+    FakeSandbox.reset()
     store = InMemoryPoolStateStore()
-    config = PoolConfig(
+    attempts: list[str] = []
+
+    def post_prepare_check(sandbox: FakeSandbox) -> bool:
+        attempts.append(sandbox.id)
+        return len(attempts) >= 2
+
+    pool = SandboxPoolSync(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=1,
+        warmup_concurrency=2,
+        state_store=store,
+        connection_config=ConnectionConfigSync(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        reconcile_interval=timedelta(milliseconds=20),
+        primary_lock_ttl=timedelta(seconds=5),
+        drain_timeout=timedelta(milliseconds=50),
+        warmup_health_check_polling_interval=timedelta(milliseconds=5),
+        warmup_post_prepare_health_check=post_prepare_check,
+        sandbox_manager_factory=lambda config: FakeManager(),  # type: ignore[arg-type,return-value]
+        sandbox_factory=FakeSandbox,  # type: ignore[arg-type]
+    )
+    pool.start()
+    try:
+        _eventually(lambda: store.snapshot_counters("pool").idle_count == 1)
+        assert len(attempts) >= 2
+        assert FakeSandbox.last_created is not None
+        assert (
+            FakeSandbox.last_created.renewed
+        )  # reached the renew stage after the check
+    finally:
+        pool.shutdown(False)
+
+
+def test_warmup_post_prepare_health_check_timeout_kills_and_skips_commit() -> None:
+    FakeSandbox.reset()
+    store = InMemoryPoolStateStore()
+
+    def post_prepare_check(sandbox: FakeSandbox) -> bool:
+        return False
+
+    pool = SandboxPoolSync(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=1,
+        warmup_concurrency=2,
+        state_store=store,
+        connection_config=ConnectionConfigSync(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        reconcile_interval=timedelta(milliseconds=20),
+        primary_lock_ttl=timedelta(seconds=5),
+        drain_timeout=timedelta(milliseconds=50),
+        warmup_health_check_polling_interval=timedelta(milliseconds=5),
+        warmup_post_prepare_health_check=post_prepare_check,
+        warmup_post_prepare_health_check_timeout=timedelta(milliseconds=30),
+        sandbox_manager_factory=lambda config: FakeManager(),  # type: ignore[arg-type,return-value]
+        sandbox_factory=FakeSandbox,  # type: ignore[arg-type]
+    )
+    pool.start()
+    try:
+        _eventually(
+            lambda: FakeSandbox.last_created is not None
+            and FakeSandbox.last_created.killed
+        )
+        assert store.snapshot_counters("pool").idle_count == 0
+        assert FakeSandbox.last_created is not None
+        assert not FakeSandbox.last_created.renewed  # timed out before renew stage
+    finally:
+        pool.shutdown(False)
+
+
+def test_primary_heartbeat_renews_independently_and_stops_when_lock_lost() -> None:
+    class CountingRenewStore(InMemoryPoolStateStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.renew_calls = 0
+
+        def renew_primary_lock(
+            self, pool_name: str, owner_id: str, ttl: timedelta
+        ) -> bool:
+            self.renew_calls += 1
+            # First two renewals succeed (the initial tick), then the lease is lost.
+            return self.renew_calls <= 2
+
+    FakeSandbox.reset()
+    store = CountingRenewStore()
+    pool = SandboxPoolSync(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=1,
+        warmup_concurrency=2,
+        state_store=store,
+        connection_config=ConnectionConfigSync(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        # One immediate tick only; the heartbeat interval becomes ttl / 3 = 0.1s.
+        reconcile_interval=timedelta(seconds=3600),
+        primary_lock_ttl=timedelta(milliseconds=300),
+        drain_timeout=timedelta(milliseconds=50),
+        sandbox_manager_factory=lambda config: FakeManager(),  # type: ignore[arg-type,return-value]
+        sandbox_factory=FakeSandbox,  # type: ignore[arg-type]
+    )
+    pool.start()
+    try:
+        # Initial tick: plan renew (1) + per-commit renew (2). Heartbeat fires at ~0.1s,
+        # observes the lost lease (renew 3 returns False), and stops renewing.
+        _eventually(lambda: store.renew_calls >= 3, timeout=2.0)
+        time.sleep(0.3)
+        assert store.renew_calls == 3
+    finally:
+        pool.shutdown(False)
+
+
+def test_reconcile_tick_does_not_block_on_slow_warmup() -> None:
+    """Kotlin-aligned admission model: the tick returns after submitting; each warmup
+    commits independently, and in-flight admissions count toward max_idle so the next
+    tick does not overshoot while a slow warmup is still running."""
+
+    class SlowFirstSandbox(FakeSandbox):
+        slow_started = threading.Event()
+        release_slow = threading.Event()
+
+        @classmethod
+        def reset(cls) -> None:
+            super().reset()
+            cls.slow_started = threading.Event()
+            cls.release_slow = threading.Event()
+
+        @classmethod
+        def create(cls, *args: Any, **kwargs: Any) -> SlowFirstSandbox:
+            cls.created_count += 1
+            ordinal = cls.created_count
+            sandbox = cls(f"created-{ordinal}")
+            cls.last_created = sandbox
+            if ordinal == 1:
+                cls.slow_started.set()
+                assert cls.release_slow.wait(timeout=2), "slow warmup never released"
+            else:
+                assert cls.slow_started.wait(timeout=2), "slow warmup never started"
+            return sandbox
+
+    SlowFirstSandbox.reset()
+    store = InMemoryPoolStateStore()
+    pool = SandboxPoolSync(
         pool_name="pool",
         owner_id="owner-1",
         max_idle=2,
@@ -108,60 +350,28 @@ def test_reconcile_commits_fast_warmup_before_slow_peer_finishes() -> None:
         state_store=store,
         connection_config=ConnectionConfigSync(),
         creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+        reconcile_interval=timedelta(milliseconds=20),
+        primary_lock_ttl=timedelta(seconds=5),
+        drain_timeout=timedelta(milliseconds=50),
+        sandbox_manager_factory=lambda config: FakeManager(),  # type: ignore[arg-type,return-value]
+        sandbox_factory=SlowFirstSandbox,  # type: ignore[arg-type]
     )
-    state = ReconcileState(degraded_threshold=3)
-    slow_started = threading.Event()
-    release_slow = threading.Event()
-    reconcile_finished = threading.Event()
-    reconcile_errors: list[BaseException] = []
-    call_lock = threading.Lock()
-    calls = 0
-
-    def create_one() -> str:
-        nonlocal calls
-        with call_lock:
-            calls += 1
-            call = calls
-        if call == 1:
-            slow_started.set()
-            if not release_slow.wait(timeout=2):
-                raise TimeoutError("slow warmup was never released")
-            return "slow"
-        if not slow_started.wait(timeout=2):
-            raise TimeoutError("slow warmup never started")
-        return "fast"
-
-    def reconcile(warmup_executor: ThreadPoolExecutor) -> None:
-        try:
-            run_reconcile_tick(
-                config=config,
-                state_store=store,
-                create_one=create_one,
-                on_discard_sandbox=lambda _sandbox_id: None,
-                reconcile_state=state,
-                warmup_executor=warmup_executor,
-            )
-        except BaseException as exc:
-            reconcile_errors.append(exc)
-        finally:
-            reconcile_finished.set()
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        reconcile_thread = threading.Thread(target=reconcile, args=(executor,))
-        reconcile_thread.start()
-        try:
-            assert slow_started.wait(timeout=2)
-            _eventually(lambda: store.snapshot_counters("pool").idle_count == 1)
-            assert not reconcile_finished.is_set()
-            assert store.try_take_idle("pool") == "fast"
-        finally:
-            release_slow.set()
-            reconcile_thread.join(timeout=2)
-            assert not reconcile_thread.is_alive()
-
-    assert reconcile_finished.is_set()
-    assert not reconcile_errors, reconcile_errors
-    assert store.try_take_idle("pool") == "slow"
+    pool.start()
+    try:
+        # The first tick admitted both warmups and returned; the slow one is still
+        # running, yet the fast peer ("created-2") is already committed and acquirable.
+        assert SlowFirstSandbox.slow_started.wait(timeout=2)
+        _eventually(lambda: store.try_take_idle("pool") == "created-2")
+        assert not SlowFirstSandbox.release_slow.is_set()
+        # The slow sandbox commits once released.
+        SlowFirstSandbox.release_slow.set()
+        _eventually(
+            lambda: "created-1"
+            in {entry.sandbox_id for entry in store.snapshot_idle_entries("pool")}
+        )
+    finally:
+        SlowFirstSandbox.release_slow.set()
+        pool.shutdown(False)
 
 
 def test_acquire_fail_fast_empty_raises_pool_empty() -> None:


### PR DESCRIPTION
## Summary

Aligns the Python client pool (`SandboxPoolSync` + `SandboxPoolAsync`) with the Kotlin SDK's warmup execution model and cross-SDK behavior:

**Admission model (the core change)** — a reconcile tick now only reaps expired idle, shrinks excess, plans, and admits warmups through a submit callback before returning, mirroring Kotlin's `PoolReconciler`. Each admitted warmup task creates, validates, renews, and commits its sandbox independently of the tick, so a slow warmup no longer delays its peers, the idle buffer, or the next tick (previously the tick blocked on `as_completed` / `FIRST_COMPLETED` loops until the whole batch finished).

**Behavioral alignment**
- `warmup_create_qps` (default `10`) caps admissions per tick; in-flight admissions count toward `max_idle` alongside idle sandboxes, so concurrent replenish cannot overshoot the target.
- `warmup_concurrency` becomes a warmup-worker cap (asyncio semaphore / executor threads), matching the Kotlin warmup executor's role instead of a per-tick submission cap.
- New `warmup_post_prepare_health_check` + `warmup_post_prepare_health_check_timeout` (default `30s`): post-preparer validation polled at `warmup_health_check_polling_interval`; retries never rerun the preparer; timeouts raise `SandboxReadyTimeoutException` and kill instead of committing.
- Warmup commit renews the primary lock first — a lost lease drops and kills the sandbox (Kotlin leader-epoch commit fence).
- Independent primary-lock heartbeat at `min(reconcile_interval, primary_lock_ttl / 3)`; the tick now reports `primaryOwned`.
- Replenish exponential backoff removed (Kotlin design: fixed create admission is the pressure control); `degraded_threshold` still tracks `HEALTHY/DEGRADED`, `snapshot().backoff_active` is always `False`.
- `ReconcileState` is thread-safe for concurrent warmup accounting.

## Tests

- Reconciler tests assert admission counts (`submit_warmups`) instead of blocking on creates.
- Pool-level tests cover: slow warmup does not block fast peer's commit or the tick; in-flight warming prevents overshoot; post-prepare check success/timeout paths; heartbeat renewal and stop-on-lease-loss; shutdown cancels an in-flight warmup and kills its sandbox; config validation for the new knobs.
- Updated backoff-era tests to the aligned semantics.

## Verification

- `uv run ruff check` / `uv run pyright` — clean
- `uv run pytest tests/` — all green
- `cd docs && pnpm docs:build` — zero errors
- Docs updated: `docs/sdks/python.md`, `docs/guides/client-pool.md`

## Not aligned (intentional, follow-ups if wanted)

OTel warmup tracing, Kotlin's `RunContext` restart fencing, shared HTTP connection pool, fixed 1s reconcile cadence (Python keeps the configurable `reconcile_interval`; removing it would be a breaking change).