### PR TITLE
feat(egress): add snapshot revision coordinator for OSEP-0023

### DIFF
--- a/components/egress/pkg/revision/coordinator.go
+++ b/components/egress/pkg/revision/coordinator.go
@@ -1,0 +1,265 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package revision provides the in-memory Go coordinator for OSEP-0023.
+// It has no live Vault, TLS, or IPC wiring. Callers must build and validate the
+// complete policy/Vault snapshot under their mutation barrier, gate reads on
+// Confirmed, and finalize their public store under that same barrier. Transport
+// authentication, receiver/session fencing, restart recovery, and remote teardown
+// remain adapter responsibilities. New is for a fresh generation pair, not a
+// replacement for recovery of an existing receiver.
+package revision
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"math"
+	"sync"
+	"unicode/utf8"
+)
+
+var (
+	ErrInvalid         = errors.New("invalid snapshot or coordinator configuration")
+	ErrBusy            = errors.New("revision operation in progress")
+	ErrClosed          = errors.New("revision coordinator closed")
+	ErrIndeterminate   = errors.New("revision outcome indeterminate")
+	ErrPrepareRejected = errors.New("snapshot prepare rejected and aborted")
+)
+
+// Identity matches the Python receiver's generation/epoch/digest identity.
+// It contains no snapshot payload. Wire encoding belongs to the IPC adapter.
+type Identity struct {
+	ControlGeneration string
+	SubjectGeneration string
+	DecisionEpoch     int64
+	VaultRevision     int64
+	PolicyEpoch       int64
+	Digest            string
+}
+
+// Transport binds one authenticated receiver/session to this coordinator.
+// Errors are conservatively ambiguous, even cancellation: work may have reached
+// the receiver. Methods must honor context cancellation and return owned metadata
+// values. Prepare receives its own byte copy; the caller must not concurrently
+// mutate its input. Late commands must obey the receiver's exact-identity fencing.
+// Transport errors are never propagated, since they may contain credentials.
+type Transport interface {
+	Prepare(context.Context, Identity, []byte) (Identity, error)
+	Commit(context.Context, Identity) (Identity, error)
+	Abort(context.Context, Identity) (Identity, error)
+	Readback(context.Context) (*Identity, error)
+}
+
+// Coordinator serializes one subject's transactions without holding its mutex
+// over transport calls. It retains only confirmed and uncertain metadata, never
+// snapshot payloads. The zero value is not usable; construct it with New.
+type Coordinator struct {
+	mu                       sync.Mutex
+	transport                Transport
+	control, subject         string
+	limit                    int
+	epoch                    int64
+	confirmed, pending       *Identity
+	commitSent, busy, closed bool
+	cancel                   context.CancelFunc
+}
+
+// New starts with unknown state. Even authoritative empty state requires Apply.
+func New(control, subject string, transport Transport, maxSnapshotBytes int) (*Coordinator, error) {
+	valid := func(s string) bool { return utf8.ValidString(s) && len(s) > 0 && utf8.RuneCountInString(s) <= 128 }
+	if !valid(control) || !valid(subject) || transport == nil || maxSnapshotBytes <= 0 {
+		return nil, ErrInvalid
+	}
+	return &Coordinator{transport: transport, control: control, subject: subject, limit: maxSnapshotBytes}, nil
+}
+
+func copyIdentity(r *Identity) *Identity {
+	if r == nil {
+		return nil
+	}
+	copy := *r
+	return &copy
+}
+
+func same(a, b *Identity) bool {
+	return a == nil && b == nil || a != nil && b != nil && *a == *b
+}
+
+func (c *Coordinator) available() error {
+	if c.closed {
+		return ErrClosed
+	}
+	if c.busy {
+		return ErrBusy
+	}
+	return nil
+}
+
+// Confirmed returns a metadata copy, or nil for unknown initial state. It refuses
+// reads during a mutation or uncertainty; it never presents the previous revision
+// as authoritative when the receiver may already have committed a new one.
+func (c *Coordinator) Confirmed() (*Identity, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.available(); err != nil {
+		return nil, err
+	}
+	if c.pending != nil {
+		return nil, ErrIndeterminate
+	}
+	return copyIdentity(c.confirmed), nil
+}
+
+// Apply allocates a monotonically increasing decision epoch and sends exact
+// snapshot bytes. Public Vault revisions may restart after a delete/recreate.
+// A failed prepare is retired by an acknowledged abort. Once commit is sent,
+// only exact commit acknowledgement/readback can publish the candidate; abort
+// must never be used to guess that a commit was rolled back.
+func (c *Coordinator) Apply(ctx context.Context, vaultRevision, policyEpoch int64, payload []byte) (Identity, error) {
+	c.mu.Lock()
+	if err := c.available(); err != nil {
+		c.mu.Unlock()
+		return Identity{}, err
+	}
+	if c.pending != nil {
+		c.mu.Unlock()
+		return Identity{}, ErrIndeterminate
+	}
+	if err := ctx.Err(); err != nil {
+		c.mu.Unlock()
+		return Identity{}, err
+	}
+	if vaultRevision < 0 || policyEpoch < 0 || len(payload) > c.limit || c.epoch == math.MaxInt64 {
+		c.mu.Unlock()
+		return Identity{}, ErrInvalid
+	}
+	data := append([]byte(nil), payload...)
+	digest := sha256.Sum256(data)
+	c.epoch++
+	r := Identity{c.control, c.subject, c.epoch, vaultRevision, policyEpoch, hex.EncodeToString(digest[:])}
+	c.pending, c.commitSent, c.busy = &r, false, true
+	ctx, c.cancel = context.WithCancel(ctx)
+	c.mu.Unlock()
+	ack, err := c.transport.Prepare(ctx, r, data)
+	if err != nil || ack != r {
+		ack, err = c.transport.Abort(ctx, r)
+		if err == nil && ack == r {
+			return Identity{}, c.finish(false, ErrPrepareRejected)
+		}
+		return Identity{}, c.finish(false, ErrIndeterminate)
+	}
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return Identity{}, c.finish(false, ErrClosed)
+	}
+	c.commitSent = true
+	c.mu.Unlock()
+	ack, err = c.transport.Commit(ctx, r)
+	if err != nil || ack != r {
+		return Identity{}, c.finish(false, ErrIndeterminate)
+	}
+	if err := c.finish(true, nil); err != nil {
+		return Identity{}, err
+	}
+	return r, nil
+}
+
+// Reconcile resolves only the outstanding operation, without resending payloads.
+// After a prepare failure it retries exact abort. After a commit attempt it first
+// reads back: an exact candidate confirms success; an exact previous state permits
+// an idempotent commit retry, but does NOT establish rollback. Unknown foreign
+// metadata or unavailable readback leaves all snapshot-affecting work blocked.
+func (c *Coordinator) Reconcile(ctx context.Context) (*Identity, error) {
+	c.mu.Lock()
+	if err := c.available(); err != nil {
+		c.mu.Unlock()
+		return nil, err
+	}
+	if c.pending == nil {
+		r := copyIdentity(c.confirmed)
+		c.mu.Unlock()
+		return r, nil
+	}
+	if err := ctx.Err(); err != nil {
+		c.mu.Unlock()
+		return nil, err
+	}
+	r, sent, previous := *c.pending, c.commitSent, copyIdentity(c.confirmed)
+	c.busy = true
+	ctx, c.cancel = context.WithCancel(ctx)
+	c.mu.Unlock()
+	if !sent {
+		ack, err := c.transport.Abort(ctx, r)
+		if err != nil || ack != r {
+			return nil, c.finish(false, ErrIndeterminate)
+		}
+		if err := c.finish(false, nil); err != nil {
+			return nil, err
+		}
+		return previous, nil
+	}
+	active, err := c.transport.Readback(ctx)
+	if err != nil {
+		return nil, c.finish(false, ErrIndeterminate)
+	}
+	if !same(active, &r) {
+		if !same(active, previous) {
+			return nil, c.finish(false, ErrIndeterminate)
+		}
+		ack, err := c.transport.Commit(ctx, r)
+		if err != nil || ack != r {
+			return nil, c.finish(false, ErrIndeterminate)
+		}
+	}
+	if err := c.finish(true, nil); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func (c *Coordinator) finish(committed bool, err error) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cancel != nil {
+		c.cancel()
+		c.cancel = nil
+	}
+	c.busy = false
+	if c.closed {
+		return ErrClosed
+	}
+	if committed {
+		c.confirmed = copyIdentity(c.pending)
+	}
+	if err != ErrIndeterminate {
+		c.pending = nil
+	}
+	return err
+}
+
+// Close permanently fences local completion and cancels in-flight transport
+// without waiting. The owning adapter must also fence/close the remote receiver
+// and connections; cancellation alone cannot recall a command already delivered.
+func (c *Coordinator) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closed = true
+	c.confirmed, c.pending = nil, nil
+	if c.cancel != nil {
+		c.cancel()
+	}
+}

--- a/components/egress/pkg/revision/coordinator.go
+++ b/components/egress/pkg/revision/coordinator.go
@@ -109,15 +109,16 @@ func (c *Coordinator) available() error {
 }
 
 // Confirmed returns a metadata copy, or nil for unknown initial state. It refuses
-// reads during a mutation or uncertainty; it never presents the previous revision
-// as authoritative when the receiver may already have committed a new one.
+// reads during a mutation or after commit may have reached the receiver. A failed
+// prepare can leave an abort retry pending, but prepare is inert, so the previous
+// confirmed revision remains authoritative while new mutations stay fenced.
 func (c *Coordinator) Confirmed() (*Identity, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if err := c.available(); err != nil {
 		return nil, err
 	}
-	if c.pending != nil {
+	if c.pending != nil && c.commitSent {
 		return nil, ErrIndeterminate
 	}
 	return copyIdentity(c.confirmed), nil

--- a/components/egress/pkg/revision/coordinator_test.go
+++ b/components/egress/pkg/revision/coordinator_test.go
@@ -120,19 +120,28 @@ func TestLostCommitAckRequiresExactReadback(t *testing.T) {
 }
 
 func TestFailedPrepareMustBeAbortedBeforeNextEpoch(t *testing.T) {
-	p := &peer{prepareErr: errors.New("secret"), abortErr: errors.New("lost abort ack")}
+	p := &peer{}
 	c := newTestCoordinator(t, p)
-	_, err := c.Apply(context.Background(), 1, 1, []byte("payload"))
+	previous, err := c.Apply(context.Background(), 1, 1, []byte("active"))
+	require.NoError(t, err)
+	p.prepareErr = errors.New("secret")
+	p.abortErr = errors.New("lost abort ack")
+	_, err = c.Apply(context.Background(), 1, 1, []byte("payload"))
+	require.ErrorIs(t, err, ErrIndeterminate)
+	confirmed, err := c.Confirmed()
+	require.NoError(t, err)
+	require.Equal(t, previous, *confirmed)
+	_, err = c.Apply(context.Background(), 2, 1, []byte("blocked"))
 	require.ErrorIs(t, err, ErrIndeterminate)
 	p.abortErr = nil
 	r, err := c.Reconcile(context.Background())
 	require.NoError(t, err)
-	require.Nil(t, r) // not an authoritative empty snapshot
-	require.Zero(t, p.commits)
+	require.Equal(t, previous, *r)
+	require.Equal(t, 1, p.commits)
 	p.prepareErr = nil
 	next, err := c.Apply(context.Background(), 1, 1, []byte("payload"))
 	require.NoError(t, err)
-	require.Equal(t, int64(2), next.DecisionEpoch)
+	require.Equal(t, int64(3), next.DecisionEpoch)
 }
 
 func TestBadPrepareAckIsAbortedNotCommitted(t *testing.T) {

--- a/components/egress/pkg/revision/coordinator_test.go
+++ b/components/egress/pkg/revision/coordinator_test.go
@@ -1,0 +1,283 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package revision
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type peer struct {
+	badCommitAck, badAbortAck                bool
+	active                                   *Identity
+	prepared                                 Identity
+	prepares, commits, aborts                int
+	prepareErr, commitErr, abortErr, readErr error
+	loseCommitAck, corruptAck                bool
+	onPrepare                                func(context.Context)
+}
+
+func (p *peer) Prepare(ctx context.Context, r Identity, data []byte) (Identity, error) {
+	p.prepares++
+	p.prepared = r
+	if p.onPrepare != nil {
+		p.onPrepare(ctx)
+	}
+	if p.corruptAck {
+		r.PolicyEpoch++
+	}
+	return r, p.prepareErr
+}
+func (p *peer) Commit(_ context.Context, r Identity) (Identity, error) {
+	p.commits++
+	if p.commitErr != nil {
+		return Identity{}, p.commitErr
+	}
+	committed := r
+	p.active = &committed
+	if p.loseCommitAck {
+		return Identity{}, errors.New("secret-bearing transport detail")
+	}
+	if p.badCommitAck {
+		r.Digest = "wrong"
+	}
+	return r, nil
+}
+func (p *peer) Abort(_ context.Context, r Identity) (Identity, error) {
+	p.aborts++
+	if p.badAbortAck {
+		r.DecisionEpoch++
+	}
+	return r, p.abortErr
+}
+func (p *peer) Readback(context.Context) (*Identity, error) { return p.active, p.readErr }
+
+func newTestCoordinator(t *testing.T, p *peer) *Coordinator {
+	t.Helper()
+	c, err := New("control-a", "subject-a", p, 1024)
+	require.NoError(t, err)
+	return c
+}
+
+func TestApplyAcknowledgementAndVaultRecreation(t *testing.T) {
+	p := &peer{}
+	c := newTestCoordinator(t, p)
+	for i, vault := range []int64{0, 1, 0, 1} {
+		r, err := c.Apply(context.Background(), vault, 1, []byte("snapshot"))
+		require.NoError(t, err)
+		require.Equal(t, int64(i+1), r.DecisionEpoch)
+		require.Equal(t, vault, r.VaultRevision)
+		confirmed, err := c.Confirmed()
+		require.NoError(t, err)
+		require.Equal(t, r, *confirmed)
+		confirmed.Digest = "changed"
+		again, err := c.Confirmed()
+		require.NoError(t, err)
+		require.Equal(t, r, *again)
+	}
+	require.Zero(t, p.aborts)
+}
+
+func TestLostCommitAckRequiresExactReadback(t *testing.T) {
+	p := &peer{loseCommitAck: true}
+	c := newTestCoordinator(t, p)
+	_, err := c.Apply(context.Background(), 1, 1, []byte("secret"))
+	require.ErrorIs(t, err, ErrIndeterminate)
+	require.NotContains(t, err.Error(), "secret")
+	_, err = c.Confirmed()
+	require.ErrorIs(t, err, ErrIndeterminate)
+	_, err = c.Apply(context.Background(), 2, 2, []byte("new"))
+	require.ErrorIs(t, err, ErrIndeterminate)
+	p.readErr = errors.New("secret")
+	_, err = c.Reconcile(context.Background())
+	require.ErrorIs(t, err, ErrIndeterminate)
+	p.readErr = nil
+	r, err := c.Reconcile(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, *p.active, *r)
+	require.Equal(t, 1, p.prepares)
+	require.Equal(t, 1, p.commits)
+	require.Zero(t, p.aborts)
+}
+
+func TestFailedPrepareMustBeAbortedBeforeNextEpoch(t *testing.T) {
+	p := &peer{prepareErr: errors.New("secret"), abortErr: errors.New("lost abort ack")}
+	c := newTestCoordinator(t, p)
+	_, err := c.Apply(context.Background(), 1, 1, []byte("payload"))
+	require.ErrorIs(t, err, ErrIndeterminate)
+	p.abortErr = nil
+	r, err := c.Reconcile(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, r) // not an authoritative empty snapshot
+	require.Zero(t, p.commits)
+	p.prepareErr = nil
+	next, err := c.Apply(context.Background(), 1, 1, []byte("payload"))
+	require.NoError(t, err)
+	require.Equal(t, int64(2), next.DecisionEpoch)
+}
+
+func TestBadPrepareAckIsAbortedNotCommitted(t *testing.T) {
+	p := &peer{corruptAck: true}
+	c := newTestCoordinator(t, p)
+	_, err := c.Apply(context.Background(), 1, 1, []byte("payload"))
+	require.ErrorIs(t, err, ErrPrepareRejected)
+	require.Equal(t, 1, p.aborts)
+	require.Zero(t, p.commits)
+}
+
+func TestUnappliedCommitCanBeRetriedWithoutPayload(t *testing.T) {
+	p := &peer{}
+	c := newTestCoordinator(t, p)
+	_, err := c.Apply(context.Background(), 1, 1, []byte("first"))
+	require.NoError(t, err)
+	p.commitErr = errors.New("not delivered")
+	_, err = c.Apply(context.Background(), 2, 1, []byte("next"))
+	require.ErrorIs(t, err, ErrIndeterminate)
+	p.commitErr = nil
+	r, err := c.Reconcile(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(2), r.DecisionEpoch)
+	require.Equal(t, 2, p.prepares)
+	require.Zero(t, p.aborts)
+}
+
+func TestForeignReadbackCannotResolveOrTriggerCommit(t *testing.T) {
+	p := &peer{loseCommitAck: true}
+	c := newTestCoordinator(t, p)
+	_, err := c.Apply(context.Background(), 1, 1, []byte("payload"))
+	require.ErrorIs(t, err, ErrIndeterminate)
+	p.active.SubjectGeneration = "other"
+	_, err = c.Reconcile(context.Background())
+	require.ErrorIs(t, err, ErrIndeterminate)
+	require.Equal(t, 1, p.commits)
+}
+
+func TestCloseDoesNotWaitForTransportAndFencesCompletion(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	p := &peer{onPrepare: func(ctx context.Context) { close(entered); <-release }}
+	c := newTestCoordinator(t, p)
+	done := make(chan error, 1)
+	go func() { _, err := c.Apply(context.Background(), 1, 1, []byte("data")); done <- err }()
+	<-entered
+	_, err := c.Apply(context.Background(), 2, 1, []byte("data"))
+	require.ErrorIs(t, err, ErrBusy)
+	_, err = c.Confirmed()
+	require.ErrorIs(t, err, ErrBusy)
+	c.Close()
+	close(release)
+	require.ErrorIs(t, <-done, ErrClosed)
+	require.Zero(t, p.commits)
+	_, err = c.Reconcile(context.Background())
+	require.ErrorIs(t, err, ErrClosed)
+}
+
+func TestMismatchedAcknowledgementsRemainIndeterminate(t *testing.T) {
+	for _, prepareFails := range []bool{false, true} {
+		p := &peer{badCommitAck: true, badAbortAck: true}
+		if prepareFails {
+			p.prepareErr = errors.New("prepare failed")
+		}
+		c := newTestCoordinator(t, p)
+		_, err := c.Apply(context.Background(), 1, 1, []byte("payload"))
+		require.ErrorIs(t, err, ErrIndeterminate)
+		if prepareFails {
+			_, err = c.Reconcile(context.Background())
+			require.ErrorIs(t, err, ErrIndeterminate)
+			p.badAbortAck = false
+		}
+		_, err = c.Reconcile(context.Background())
+		require.NoError(t, err)
+	}
+}
+
+func TestReadbackConflictsAcrossEveryIdentityField(t *testing.T) {
+	p := &peer{}
+	p.onPrepare = func(context.Context) { p.loseCommitAck = true }
+	c := newTestCoordinator(t, p)
+	_, err := c.Apply(context.Background(), 1, 1, []byte("payload"))
+	require.ErrorIs(t, err, ErrIndeterminate)
+	actual := *p.active
+	for _, mutate := range []func(*Identity){
+		func(r *Identity) { r.ControlGeneration = "foreign" },
+		func(r *Identity) { r.SubjectGeneration = "foreign" },
+		func(r *Identity) { r.DecisionEpoch++ },
+		func(r *Identity) { r.VaultRevision++ },
+		func(r *Identity) { r.PolicyEpoch++ },
+		func(r *Identity) { r.Digest = "wrong" },
+	} {
+		copy := actual
+		mutate(&copy)
+		p.active = &copy
+		_, err = c.Reconcile(context.Background())
+		require.ErrorIs(t, err, ErrIndeterminate)
+	}
+	require.Equal(t, 1, p.commits)
+	p.active = &actual
+	_, err = c.Reconcile(context.Background())
+	require.NoError(t, err)
+}
+
+func TestInitialUnknownAndCancellation(t *testing.T) {
+	p := &peer{}
+	c := newTestCoordinator(t, p)
+	r, err := c.Confirmed()
+	require.NoError(t, err)
+	require.Nil(t, r)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = c.Apply(ctx, 0, 0, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, p.prepares)
+	data := []byte("exact serialized bytes")
+	digest := sha256.Sum256(data)
+	identity, err := c.Apply(context.Background(), 0, 0, data)
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(digest[:]), identity.Digest)
+}
+
+func TestInvalidInputsNeverReachTransport(t *testing.T) {
+	p := &peer{}
+	c := newTestCoordinator(t, p)
+	for _, tc := range []struct {
+		vault, policy int64
+		data          []byte
+	}{
+		{-1, 1, nil}, {1, -1, nil}, {1, 1, make([]byte, 1025)},
+	} {
+		_, err := c.Apply(context.Background(), tc.vault, tc.policy, tc.data)
+		require.ErrorIs(t, err, ErrInvalid)
+	}
+	require.Zero(t, p.prepares)
+	c.epoch = math.MaxInt64
+	_, err := c.Apply(context.Background(), 0, 0, nil)
+	require.ErrorIs(t, err, ErrInvalid)
+	for _, generation := range []string{"", strings.Repeat("x", 129), string([]byte{0xff})} {
+		_, err := New(generation, "subject", p, 1)
+		require.ErrorIs(t, err, ErrInvalid)
+		_, err = New("control", generation, p, 1)
+		require.ErrorIs(t, err, ErrInvalid)
+	}
+	_, err = New("control", "subject", nil, 1)
+	require.ErrorIs(t, err, ErrInvalid)
+	_, err = New("control", "subject", p, 0)
+	require.ErrorIs(t, err, ErrInvalid)
+}

--- a/oseps/0023-credential-bound-tls-interception.md
+++ b/oseps/0023-credential-bound-tls-interception.md
@@ -799,6 +799,15 @@ it does not change traffic.
 
 ### Phased Implementation
 
+The Go transaction coordinator is also an isolated in-memory foundation. It
+allocates decision epochs, checks exact acknowledgements, blocks reads/mutations
+while an outcome is uncertain, and reconciles through metadata-only readback or
+exact commit/abort retries. Its transport is injected; no authenticated IPC or
+public Vault mutation path uses it yet. Local close cancels pending transport and
+fences completion, but the future adapter must also fence the remote session and
+tear down receiver/connections. Startup/recovery and atomic public-store
+finalization under the shared mutation barrier remain integration work.
+
 The proxy-side transaction receiver is an in-memory foundation: it validates
 generation/epoch/digest identities, stages immutable bytes, and implements
 commit, abort, and metadata-only readback. It is not connected to the live addon

--- a/oseps/0023-credential-bound-tls-interception.md
+++ b/oseps/0023-credential-bound-tls-interception.md
@@ -800,10 +800,12 @@ it does not change traffic.
 ### Phased Implementation
 
 The Go transaction coordinator is also an isolated in-memory foundation. It
-allocates decision epochs, checks exact acknowledgements, blocks reads/mutations
-while an outcome is uncertain, and reconciles through metadata-only readback or
-exact commit/abort retries. Its transport is injected; no authenticated IPC or
-public Vault mutation path uses it yet. Local close cancels pending transport and
+allocates decision epochs, checks exact acknowledgements, and blocks mutations
+while an operation is unresolved. A failed prepare remains inert, so the prior
+revision is still readable while abort acknowledgement is retried; reads are
+blocked only after commit may have reached the receiver. Reconciliation uses
+metadata-only readback or exact commit/abort retries. Its transport is injected;
+no authenticated IPC or public Vault mutation path uses it yet. Local close cancels pending transport and
 fences completion, but the future adapter must also fence the remote session and
 tear down receiver/connections. Startup/recovery and atomic public-store
 finalization under the shared mutation barrier remain integration work.


### PR DESCRIPTION
# Summary

Continue the OSEP-0023 revision-transaction phase after #1775, #1777, and #1791 with an isolated Go coordinator. This PR separates coordinator correctness from authenticated IPC and live runtime integration.

- Allocate monotonic decision epochs independently of public Vault revision lifetimes, hashing exact serialized snapshot bytes.
- Serialize one subject's transactions and require the complete generation/epoch/digest identity in acknowledgements.
- Retire failed or ambiguous prepares with an acknowledged abort. Once commit is attempted, never infer rollback or abort the candidate: gate reads and subsequent mutations until exact readback or an idempotent commit retry confirms the outcome.
- Reconcile without resending snapshot payloads. Unexpected/foreign readback identities and transport failures remain indeterminate; transport errors cannot leak credential-bearing details.
- Cancel in-flight transport and fence local completion on close without waiting for the network.

The transport is injected and tested with an in-memory peer. No IPC endpoint, public API, SDK, live addon, or existing Vault/ETag path imports this package. The future adapter must validate complete snapshots, authenticate/fence the receiver session, coordinate policy/Vault preparation and public-store finalization under one mutation barrier, and perform remote teardown. Startup/recovery and selective TLS interception remain subsequent work. The OSEP progress note records these boundaries.

Related: #1713. This is the coordinator portion of the revision-transaction phase, not completion of that phase or the public interception mode.

# Testing

- [x] Unit tests
- [x] Existing local Python/mitmproxy integration regression
- [ ] e2e / manual verification (no live IPC, Linux netns, Docker/Kubernetes, or fleet wiring in this PR)

- New coordinator tests failed before implementation.
- 11 coordinator tests pass, including 10 repeated runs under the race detector: exact acknowledgements/readback, lost ACK, conflicting identity fields, abort reconciliation, commit retry without payload, unknown initial state, delete/recreate epochs, cancellation, invalid inputs, and concurrent close.
- Full egress Go race suite: 394 tests passed. `go vet ./...`, `go build ./...`, gofmt, license checks, and diff checks passed.
- Independent scoped review passed.
- Full Python suite with Python 3.12 and mitmproxy 11.0.2: 104 tests passed. Existing timeout tests still emit BrokenPipe/ResourceWarning diagnostics.
- No published docs-site page changed; the docs-site build was not rerun for the OSEP-only progress note.

# Breaking Changes

- [x] None
- [ ] Yes

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (implementation boundary and OSEP progress)
- [x] Added/updated tests
- [x] Security impact considered
- [x] Backward compatibility considered
