### PR TITLE
feat(egress): log warn on DNS deny

### DIFF
--- a/components/egress/fastsandbox.go
+++ b/components/egress/fastsandbox.go
@@ -138,17 +138,15 @@ func runFastSandboxProfile(ctx context.Context) {
 	if err != nil {
 		log.Fatalf("failed to init dns proxy: %v", err)
 	}
-	proxy.SetQueryPolicySelector(func(remote netip.Addr) *dnsproxy.QueryPolicy {
+	proxy.SetQueryPolicySelector(func(remote netip.Addr) (*dnsproxy.QueryPolicy, string) {
 		s, ok := reg.Resolve(subject.SubjectKey{SourceIP: remote})
 		if !ok {
 			// Unknown source: deny (fail closed), never a default policy.
-			log.Warnf("[dns] query from unknown source %s denied (fail closed)", remote)
-			return nil
+			return nil, "unknown source"
 		}
 		eff := reg.EffectivePolicy(s)
 		if eff == nil {
-			log.Warnf("[dns] query from subject %s (source %s) denied: no effective policy", s, remote)
-			return nil
+			return nil, "no effective policy for subject " + string(s)
 		}
 		return &dnsproxy.QueryPolicy{
 			Policy: eff,
@@ -159,7 +157,7 @@ func runFastSandboxProfile(ctx context.Context) {
 					log.Warnf("[dns] add resolved IPs to fast-sandbox nft failed for subject %s domain %q: %v", s, domain, err)
 				}
 			},
-		}
+		}, ""
 	})
 	if err := proxy.Start(ctx); err != nil {
 		log.Fatalf("failed to start dns proxy: %v", err)

--- a/components/egress/pkg/dnsproxy/proxy.go
+++ b/components/egress/pkg/dnsproxy/proxy.go
@@ -65,8 +65,10 @@ type Proxy struct {
 	// queryPolicySelector, when set, resolves the per-query policy (and
 	// per-query resolved-IP callback) from the client's source address. This
 	// is the fast-sandbox-profile dispatch seam: one shared listener, N
-	// subject policies. nil keeps the single-policy behavior unchanged.
-	queryPolicySelector func(remoteAddr netip.Addr) *QueryPolicy
+	// subject policies. nil keeps the single-policy behavior unchanged. A nil
+	// result denies the query (fail closed); the returned denyReason carries
+	// the selector's actual reason for the denial log.
+	queryPolicySelector func(remoteAddr netip.Addr) (*QueryPolicy, string)
 
 	// Hosts whose successful outbound DNS log line should be suppressed (audit
 	// errors are still logged). Loaded once at startup; nil means "log all".
@@ -180,11 +182,18 @@ func (p *Proxy) serveDNS(w dns.ResponseWriter, r *dns.Msg) {
 	policyToEval := p.currentPolicy()
 	notifyResolved := p.onResolved
 	if sel := p.queryPolicySelector; sel != nil {
-		qp := sel(requestRemoteAddr(w))
+		qp, denyReason := sel(requestRemoteAddr(w))
 		if qp == nil {
-			// Unknown source: fail closed (NXDOMAIN), never fall back to a
-			// default policy that could open the subject.
+			// Fail closed (NXDOMAIN), never fall back to a default policy
+			// that could open the subject. The selector supplies the actual
+			// denial reason; the denial is logged here only, in a single
+			// layer, so the reason stays accurate and is not duplicated.
+			if denyReason == "" {
+				denyReason = "unknown source"
+			}
 			telemetry.RecordDNSDenied()
+			log.Warnf("[dns] denied query (remote=%s question=%q reason=%s)",
+				requestRemoteAddr(w), host, denyReason)
 			resp := new(dns.Msg)
 			resp.SetRcode(r, dns.RcodeNameError)
 			p.writeReply(w, r, resp, telemetry.DNSReplyStageUnknownSource)
@@ -199,6 +208,8 @@ func (p *Proxy) serveDNS(w dns.ResponseWriter, r *dns.Msg) {
 	if policyToEval != nil && policyToEval.Evaluate(domain) == policy.ActionDeny {
 		telemetry.RecordDNSDenied()
 		p.publishBlocked(domain)
+		log.Warnf("[dns] denied by policy (remote=%s question=%q)",
+			requestRemoteAddr(w), host)
 		resp := new(dns.Msg)
 		resp.SetRcode(r, dns.RcodeNameError)
 		p.writeReply(w, r, resp, telemetry.DNSReplyStageDeny)
@@ -272,8 +283,9 @@ type QueryPolicy struct {
 // SetQueryPolicySelector installs the per-query policy dispatch (fast-sandbox
 // profile). Passing nil restores the single-policy behavior; the selector is
 // invoked on the serveDNS goroutine. A nil *QueryPolicy result denies the
-// query (fail closed).
-func (p *Proxy) SetQueryPolicySelector(sel func(remoteAddr netip.Addr) *QueryPolicy) {
+// query (fail closed); the returned denyReason describes why and is included
+// in the denial log (empty falls back to "unknown source").
+func (p *Proxy) SetQueryPolicySelector(sel func(remoteAddr netip.Addr) (*QueryPolicy, string)) {
 	p.queryPolicySelector = sel
 }
 

--- a/components/egress/pkg/dnsproxy/proxy_test.go
+++ b/components/egress/pkg/dnsproxy/proxy_test.go
@@ -310,7 +310,7 @@ func TestServeDNSReplyWriteFailuresAreSurfaced(t *testing.T) {
 			effectivePolicy: policy.DefaultDenyPolicy(),
 			userPolicy:      policy.DefaultDenyPolicy(),
 		}
-		proxy.SetQueryPolicySelector(func(netip.Addr) *QueryPolicy { return nil })
+		proxy.SetQueryPolicySelector(func(netip.Addr) (*QueryPolicy, string) { return nil, "" })
 		w := newFailingWriter("10.0.0.9")
 		proxy.serveDNS(w, newQuery())
 		require.Equal(t, 1, w.attempts, "fail-closed reply must be attempted exactly once")
@@ -335,8 +335,8 @@ func TestServeDNSReplyWriteFailuresAreSurfaced(t *testing.T) {
 		proxy := selectorProxy(t)
 		allowPol, err := policy.ParsePolicy(`{"defaultAction":"deny","egress":[{"action":"allow","target":"example.com"}]}`)
 		require.NoError(t, err)
-		proxy.SetQueryPolicySelector(func(netip.Addr) *QueryPolicy {
-			return &QueryPolicy{Policy: allowPol}
+		proxy.SetQueryPolicySelector(func(netip.Addr) (*QueryPolicy, string) {
+			return &QueryPolicy{Policy: allowPol}, ""
 		})
 		w := newFailingWriter("10.0.0.9")
 		proxy.serveDNS(w, newQuery())

--- a/components/egress/pkg/dnsproxy/selector_test.go
+++ b/components/egress/pkg/dnsproxy/selector_test.go
@@ -98,14 +98,14 @@ func TestQueryPolicySelectorDispatch(t *testing.T) {
 	allowPol, err := policy.ParsePolicy(`{"defaultAction":"deny","egress":[{"action":"allow","target":"example.com"}]}`)
 	require.NoError(t, err)
 
-	proxy.SetQueryPolicySelector(func(remote netip.Addr) *QueryPolicy {
+	proxy.SetQueryPolicySelector(func(remote netip.Addr) (*QueryPolicy, string) {
 		switch remote.String() {
 		case "10.0.0.5":
-			return &QueryPolicy{Policy: allowPol}
+			return &QueryPolicy{Policy: allowPol}, ""
 		case "10.0.0.6":
-			return &QueryPolicy{Policy: policy.DefaultDenyPolicy()}
+			return &QueryPolicy{Policy: policy.DefaultDenyPolicy()}, ""
 		default:
-			return nil
+			return nil, "unknown source"
 		}
 	})
 
@@ -137,7 +137,7 @@ func TestQueryPolicySelectorPerQueryOnResolved(t *testing.T) {
 		domain string
 		ips    []nftables.ResolvedIP
 	}, 1)
-	proxy.SetQueryPolicySelector(func(remote netip.Addr) *QueryPolicy {
+	proxy.SetQueryPolicySelector(func(remote netip.Addr) (*QueryPolicy, string) {
 		return &QueryPolicy{
 			Policy: allowPol,
 			OnResolved: func(domain string, ips []nftables.ResolvedIP) {
@@ -146,7 +146,7 @@ func TestQueryPolicySelectorPerQueryOnResolved(t *testing.T) {
 					ips    []nftables.ResolvedIP
 				}{domain, ips}
 			},
-		}
+		}, ""
 	})
 
 	w := &fakeRespWriter{remote: addrFromIP("10.0.0.5")}


### PR DESCRIPTION
## Summary
- Add warn logs on both DNS rejection paths in the egress dnsproxy `serveDNS` handler:
  - policy deny (`denied by policy`)
  - unknown-source fail-closed NXDOMAIN (`denied query from unknown source`)
- Both include client remote address and question name for troubleshooting.

## Test plan
- `go build ./...` in `components/egress`
- `go test ./pkg/dnsproxy/` — passes