### PR TITLE
fix(execd): skip credential switch for same-identity uid/gid requests

### DIFF
--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -112,11 +112,19 @@ func buildCredential(uid, gid *uint32) (*syscall.Credential, error) {
 	// (even when every id matches), and setgroups requires CAP_SETGID no
 	// matter what values are requested — so same-identity credentials fail
 	// with "fork/exec ...: operation not permitted" inside sandboxes that
-	// drop capabilities (#1802).
+	// drop capabilities (#1802). The fast path applies only when the
+	// credential machinery would be a provable no-op: a uid-only request
+	// still resolves the user entry's primary GID and supplemental groups,
+	// so it skips the switch only when those match the daemon's own groups.
 	currentUID := uint32(os.Getuid())
 	currentGID := uint32(os.Getgid())
 	if (uid == nil || *uid == currentUID) && (gid == nil || *gid == currentGID) {
-		return nil, nil //nolint:nilnil
+		if gid != nil || uid == nil {
+			return nil, nil //nolint:nilnil
+		}
+		if sameProcessGroups(*uid) {
+			return nil, nil //nolint:nilnil
+		}
 	}
 
 	cred := &syscall.Credential{}
@@ -164,9 +172,42 @@ func credentialStartHint(err error, cred *syscall.Credential) error {
 		return err
 	}
 	return fmt.Errorf(
-		"%w (switching to uid=%d gid=%d requires CAP_SETUID/CAP_SETGID; the sandbox may have dropped capabilities — grant them or create the sandbox with bootstrap.execd.isolation=enable)",
+		"%w (switching to uid=%d gid=%d requires CAP_SETUID/CAP_SETGID, which this sandbox may not have — check the server's docker.drop_capabilities configuration; dropping these capabilities makes every identity switch fail)",
 		err, cred.Uid, cred.Gid,
 	)
+}
+
+// sameProcessGroups reports whether the given uid's user entry resolves to
+// the primary GID and supplemental groups the daemon already runs with, i.e.
+// whether building a credential for that uid would be a no-op group-wise.
+func sameProcessGroups(uid uint32) bool {
+	u, err := user.LookupId(strconv.FormatUint(uint64(uid), 10))
+	if err != nil {
+		return false
+	}
+	primaryGid, err := strconv.ParseUint(u.Gid, 10, 32)
+	if err != nil || uint32(primaryGid) != uint32(os.Getgid()) {
+		return false
+	}
+	entryGroups, err := u.GroupIds()
+	if err != nil {
+		return false
+	}
+	processGroups, err := syscall.Getgroups()
+	if err != nil || len(entryGroups) != len(processGroups) {
+		return false
+	}
+	seen := make(map[uint32]bool, len(processGroups))
+	for _, g := range processGroups {
+		seen[uint32(g)] = true
+	}
+	for _, g := range entryGroups {
+		id, err := strconv.ParseUint(g, 10, 32)
+		if err != nil || !seen[uint32(id)] {
+			return false
+		}
+	}
+	return true
 }
 
 // runCommand executes shell commands and streams their output.

--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -106,6 +106,19 @@ func buildCredential(uid, gid *uint32) (*syscall.Credential, error) {
 		return nil, nil //nolint:nilnil
 	}
 
+	// An explicit uid/gid matching the identity execd already runs as needs
+	// no credential switch: return nil so the launch stays on the plain exec
+	// path. A non-nil Credential always makes the child call setgroups
+	// (even when every id matches), and setgroups requires CAP_SETGID no
+	// matter what values are requested — so same-identity credentials fail
+	// with "fork/exec ...: operation not permitted" inside sandboxes that
+	// drop capabilities (#1802).
+	currentUID := uint32(os.Getuid())
+	currentGID := uint32(os.Getgid())
+	if (uid == nil || *uid == currentUID) && (gid == nil || *gid == currentGID) {
+		return nil, nil //nolint:nilnil
+	}
+
 	cred := &syscall.Credential{}
 	if uid != nil {
 		cred.Uid = *uid
@@ -139,6 +152,21 @@ func buildCredential(uid, gid *uint32) (*syscall.Credential, error) {
 	}
 
 	return cred, nil
+}
+
+// credentialStartHint annotates command launch failures that happen while
+// switching identity. With capabilities dropped the kernel rejects the
+// child's setgroups/setgid/setuid calls, and the raw error surfaces as a
+// bare "fork/exec ...: operation not permitted" that gives the caller no
+// way to discover the missing grant (#1802).
+func credentialStartHint(err error, cred *syscall.Credential) error {
+	if cred == nil || !errors.Is(err, os.ErrPermission) {
+		return err
+	}
+	return fmt.Errorf(
+		"%w (switching to uid=%d gid=%d requires CAP_SETUID/CAP_SETGID; the sandbox may have dropped capabilities — grant them or create the sandbox with bootstrap.execd.isolation=enable)",
+		err, cred.Uid, cred.Gid,
+	)
 }
 
 // runCommand executes shell commands and streams their output.
@@ -196,13 +224,14 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	if err != nil {
 		close(done)
 		wg.Wait()
+		startErr := credentialStartHint(err, cred)
 		request.Hooks.OnExecuteInit(session)
 		request.Hooks.OnExecuteError(&execute.ErrorOutput{
 			EName:     "CommandExecError",
-			EValue:    err.Error(),
-			Traceback: []string{err.Error()},
+			EValue:    startErr.Error(),
+			Traceback: []string{startErr.Error()},
 		})
-		log.Error("CommandExecError: error starting commands: %v", err)
+		log.Error("CommandExecError: error starting commands: %v", startErr)
 		return nil
 	}
 
@@ -356,11 +385,12 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	}
 	if err != nil {
 		cancel()
-		log.Error("CommandExecError: error starting commands: %v", err)
+		startErr := credentialStartHint(err, cred)
+		log.Error("CommandExecError: error starting commands: %v", startErr)
 		kernel.running = false
 		c.storeCommandKernel(session, kernel)
-		c.markCommandFinished(session, 255, err.Error())
-		return fmt.Errorf("failed to start commands: %w", err)
+		c.markCommandFinished(session, 255, startErr.Error())
+		return fmt.Errorf("failed to start commands: %w", startErr)
 	}
 
 	// Register the kernel synchronously so that GetCommandStatus callers

--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -108,23 +108,9 @@ func buildCredential(uid, gid *uint32) (*syscall.Credential, error) {
 
 	// An explicit uid/gid matching the identity execd already runs as needs
 	// no credential switch: return nil so the launch stays on the plain exec
-	// path. A non-nil Credential always makes the child call setgroups
-	// (even when every id matches), and setgroups requires CAP_SETGID no
-	// matter what values are requested — so same-identity credentials fail
-	// with "fork/exec ...: operation not permitted" inside sandboxes that
-	// drop capabilities (#1802). The fast path applies only when the
-	// credential machinery would be a provable no-op: a uid-only request
-	// still resolves the user entry's primary GID and supplemental groups,
-	// so it skips the switch only when those match the daemon's own groups.
-	currentUID := uint32(os.Getuid())
-	currentGID := uint32(os.Getgid())
-	if (uid == nil || *uid == currentUID) && (gid == nil || *gid == currentGID) {
-		if gid != nil || uid == nil {
-			return nil, nil //nolint:nilnil
-		}
-		if sameProcessGroups(*uid) {
-			return nil, nil //nolint:nilnil
-		}
+	// path, which is also what the no-uid request already does (#1802).
+	if sameIdentityRequest(uid, gid) {
+		return nil, nil //nolint:nilnil
 	}
 
 	cred := &syscall.Credential{}
@@ -160,6 +146,26 @@ func buildCredential(uid, gid *uint32) (*syscall.Credential, error) {
 	}
 
 	return cred, nil
+}
+
+// sameIdentityRequest reports whether the requested uid/gid matches the
+// identity execd already runs with, making the credential machinery a
+// provable no-op. A non-nil Credential always makes the child call setgroups
+// (even when every id matches), and setgroups requires CAP_SETGID no matter
+// what values are requested — so same-identity credentials fail with
+// "fork/exec ...: operation not permitted" inside sandboxes that drop
+// capabilities (#1802). A uid-only request skips the switch only when the
+// user entry's primary GID and supplemental groups match the daemon's own.
+func sameIdentityRequest(uid, gid *uint32) bool {
+	currentUID := uint32(os.Getuid())
+	currentGID := uint32(os.Getgid())
+	if (uid == nil || *uid == currentUID) && (gid == nil || *gid == currentGID) {
+		if gid != nil || uid == nil {
+			return true
+		}
+		return sameProcessGroups(*uid)
+	}
+	return false
 }
 
 // credentialStartHint annotates command launch failures that happen while

--- a/components/execd/pkg/runtime/command_credential_test.go
+++ b/components/execd/pkg/runtime/command_credential_test.go
@@ -1,0 +1,98 @@
+//go:build !windows
+// +build !windows
+
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCredential_NilIdentityReturnsNil(t *testing.T) {
+	cred, err := buildCredential(nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, cred)
+}
+
+// Explicit ids matching the identity execd already runs as must stay on the
+// plain exec path: a non-nil Credential makes the child call setgroups even
+// when every id matches, and setgroups requires CAP_SETGID regardless of the
+// requested values (#1802).
+func TestBuildCredential_SameIdentityReturnsNil(t *testing.T) {
+	uid := uint32(os.Getuid())
+	gid := uint32(os.Getgid())
+
+	cred, err := buildCredential(&uid, &gid)
+	require.NoError(t, err)
+	assert.Nil(t, cred, "explicit current uid+gid must not produce a credential")
+
+	cred, err = buildCredential(&uid, nil)
+	require.NoError(t, err)
+	assert.Nil(t, cred, "explicit current uid must not produce a credential")
+
+	cred, err = buildCredential(nil, &gid)
+	require.NoError(t, err)
+	assert.Nil(t, cred, "explicit current gid must not produce a credential")
+}
+
+func TestBuildCredential_IdentitySwitchBuildsCredential(t *testing.T) {
+	otherUID := uint32(4294967294) // max-1; not a real login uid in practice
+	if otherUID == uint32(os.Getuid()) {
+		otherUID-- // paranoia: never collide with the real current uid
+	}
+	otherGID := otherUID - 1
+
+	cred, err := buildCredential(&otherUID, &otherGID)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	assert.Equal(t, otherUID, cred.Uid)
+	assert.Equal(t, otherGID, cred.Gid)
+
+	// uid only: credential is built even if the user entry is unknown
+	cred, err = buildCredential(&otherUID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	assert.Equal(t, otherUID, cred.Uid)
+}
+
+func TestCredentialStartHint(t *testing.T) {
+	cred := &syscall.Credential{Uid: 1000, Gid: 1000}
+	permErr := &os.PathError{Op: "fork/exec", Path: "/usr/bin/bash", Err: syscall.EPERM}
+
+	// EPERM with a credential switch in play: annotate with the missing grant.
+	hinted := credentialStartHint(permErr, cred)
+	require.ErrorIs(t, hinted, os.ErrPermission)
+	assert.Contains(t, hinted.Error(), "CAP_SETUID")
+	assert.Contains(t, hinted.Error(), "uid=1000")
+
+	// EPERM without a credential switch: keep the raw error.
+	same := credentialStartHint(permErr, nil)
+	assert.Equal(t, permErr, same)
+
+	// Non-permission errors are not annotated.
+	otherErr := &os.PathError{Op: "fork/exec", Path: "/usr/bin/bash", Err: syscall.ENOENT}
+	assert.Equal(t, otherErr, credentialStartHint(otherErr, cred))
+
+	// nil error stays nil-safe via passthrough.
+	assert.NoError(t, credentialStartHint(nil, cred))
+	assert.True(t, errors.Is(hinted, syscall.EPERM))
+}

--- a/components/execd/pkg/runtime/command_credential_test.go
+++ b/components/execd/pkg/runtime/command_credential_test.go
@@ -45,13 +45,30 @@ func TestBuildCredential_SameIdentityReturnsNil(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, cred, "explicit current uid+gid must not produce a credential")
 
-	cred, err = buildCredential(&uid, nil)
-	require.NoError(t, err)
-	assert.Nil(t, cred, "explicit current uid must not produce a credential")
-
 	cred, err = buildCredential(nil, &gid)
 	require.NoError(t, err)
 	assert.Nil(t, cred, "explicit current gid must not produce a credential")
+
+	// uid-only: the switch is skipped only when the user entry resolves to
+	// the daemon's own groups; otherwise the credential machinery still runs
+	// (the request asks for that user's primary GID and supplemental groups).
+	cred, err = buildCredential(&uid, nil)
+	require.NoError(t, err)
+	if sameProcessGroups(uid) {
+		assert.Nil(t, cred, "uid-only current identity with matching groups must not produce a credential")
+	} else {
+		require.NotNil(t, cred)
+		assert.Equal(t, uid, cred.Uid)
+	}
+}
+
+func TestSameProcessGroupsCurrentUID(t *testing.T) {
+	// The daemon's own uid must resolve to its own primary GID in any sane
+	// environment (root container: root/0/0; dev laptop: the logged-in user).
+	assert.True(t, sameProcessGroups(uint32(os.Getuid())))
+
+	// An unknown uid never matches.
+	assert.False(t, sameProcessGroups(4294967294))
 }
 
 func TestBuildCredential_IdentitySwitchBuildsCredential(t *testing.T) {
@@ -82,6 +99,7 @@ func TestCredentialStartHint(t *testing.T) {
 	hinted := credentialStartHint(permErr, cred)
 	require.ErrorIs(t, hinted, os.ErrPermission)
 	assert.Contains(t, hinted.Error(), "CAP_SETUID")
+	assert.Contains(t, hinted.Error(), "drop_capabilities")
 	assert.Contains(t, hinted.Error(), "uid=1000")
 
 	// EPERM without a credential switch: keep the raw error.


### PR DESCRIPTION
## Summary

Fixes #1802.

Requests like `{"uid":0,"gid":0}` to `/command` failed with `fork/exec /usr/bin/bash: operation not permitted` in sandboxes with dropped capabilities, while the same request without uid/gid worked.

Root cause (one level below the issue's bwrap theory — the plain `/command` path never goes through bwrap): `buildCredential` built a non-nil `syscall.Credential` even when every requested id matched the identity execd already runs as. A non-nil Credential makes the child call `setgroups` before exec — even when all ids match — and `setgroups` requires `CAP_SETGID` regardless of the requested values. With capabilities dropped, that syscall fails and surfaces as the bare `fork/exec ...: operation not permitted` the issue describes.

- Same-identity uid/gid requests now return `nil` and stay on the plain exec path, which is semantically identical (this is also what the no-uid request already did). For uid-only requests the fast path applies only when the user entry's primary GID and supplemental groups match the daemon's own (`sameProcessGroups`), preserving the lookup-based switch otherwise.
- Genuine identity switches that fail due to missing capabilities now produce an actionable error naming the missing grant (`CAP_SETUID`/`CAP_SETGID`, pointing at the server's `docker.drop_capabilities` configuration), instead of a bare EPERM.

## Testing

- [x] `go test ./pkg/runtime/ -run 'TestBuildCredential|TestCredentialStartHint|TestSameProcessGroups'` — 6 new tests, all pass
- [x] `go vet ./pkg/runtime/`, `gofmt` clean, `GOOS=linux go build ./pkg/...`
- [x] Full `go test ./pkg/...` on macOS/arm64 passes except pre-existing PTY tests that require `/dev/ptmx` (also fail on a clean tree in this environment)
- [ ] Full Linux CI + a live sandbox with `drop_capabilities=["ALL"]` repro — not run here

## Breaking Changes

None — same-identity requests previously failed in capability-dropped sandboxes and now execute; all other paths unchanged.
