### PR TITLE
refactor(sdk/kotlin): tidy comments, KDoc, and docs; remove dead code (#1768)

### DIFF
--- a/sdks/sandbox/kotlin/AUDIT-1768.md
+++ b/sdks/sandbox/kotlin/AUDIT-1768.md
@@ -1,0 +1,221 @@
+# Kotlin SDK Audit — issue #1768 (Phase 0 + cleanup pass)
+
+Scope: `sdks/sandbox/kotlin/**` (sandbox, code-interpreter, sandbox-pool-redis).
+This pass intentionally changed **no runtime logic**; it only landed
+documentation/comment/dead-code cleanups. Logic-level findings are listed below
+for triage in follow-up per-issue PRs.
+
+## 1. Completed in this pass (no behavior change)
+
+### Documentation / KDoc
+- `Sandbox.getEndpoint` / `Sandbox.getMetrics` KDoc were copy-pastes of
+  `getInfo`; rewritten to describe their actual behavior.
+- `SandboxUnhealthyException` KDoc was a copy of `SandboxReadyTimeoutException`;
+  corrected.
+- `SandboxState`: added `RESUMING` constant and fixed the transition doc
+  (`Paused → Resuming → Running`) to match the lifecycle spec. Additive only.
+- `SandboxFilter.page` / `PaginationInfo.page` documented as 0-indexed; spec and
+  builder validation are 1-indexed. Fixed. `states` example now points at
+  `SandboxState` constants (values are `Running`, not `RUNNING`).
+- `SetPermissionEntry` KDoc claimed "only specified properties will be changed"
+  while `mode` is always sent (API-required); doc now states this explicitly.
+- `EntryInfo` KDoc: added missing `@property type`.
+- `ExecutionComplete.executionTimeInMillis`: "mills" → milliseconds.
+- `LifecycleHook` / `PeriodicLifecycleHook`: documented server-side defaults
+  (60s) and accepted ranges (1..10800 / 1..300).
+- `IsolatedBackgroundRun` / `IsolatedRunStatus`: documented that `startedAt` is
+  spec-required but parsed as nullable for older execd builds.
+- `PoolCreationSpec`: removed stale "fixed 24h timeout" comment (timeout is
+  `PoolConfig.idleTimeout`, default 24h).
+- `InMemoryPoolStateStore`: KDoc claimed "no external lock" while several
+  operations are `synchronized`; doc now matches implementation.
+- `SandboxPool.warmupConnectionConfig`: added note that both branches produce
+  the same value when a shared pool is set (kept code untouched).
+- `RetryInterceptor`: comment claimed OkHttp `with*Timeout` can only lower a
+  timeout; it actually *replaces* (can raise). Comment corrected.
+- `HttpClientProvider`: removed leftover numbered ("1./2./3.", "Now we can…")
+  revision comments.
+- `ConnectionConfig.getBaseUrl`: comment now distinguishes Python-compatible
+  behavior from the extra normalization Kotlin applies.
+- Code-interpreter KDoc: class example called nonexistent `interpreter.kill()`
+  → `interpreter.sandbox().kill()`; builder example called nonexistent
+  `.connectionConfig(...)` → removed; `CodeContext`/`RunCodeRequest` docs
+  referenced the removed `cwd` field → removed; `context` doc claimed "if null,
+  a temporary context is created" (it is non-null with a default Python context)
+  → rewritten; language list claim ("Java, Kotlin") aligned with
+  `SupportedLanguage` constants.
+- `sandbox-pool-redis/README.md`: "the pool does not silently bypass shared
+  state" contradicted the documented DIRECT_CREATE fallthrough
+  (SandboxPool.kt, OSEP-0005); wording fixed.
+
+### Dead code / duplication
+- Removed unused private `EgressAdapter.optionalIntArray`.
+- Removed `@author/@since` personal tag from `FilesystemConverter`.
+- Removed duplicate instance loggers shadowing identical companion loggers in
+  `Sandbox` and `CodeInterpreter`.
+- `CodeExecutionConverter`: removed redundant `?.` on a non-null field.
+
+## 2. Logic-level findings (NOT changed — need decision / follow-up PRs)
+
+### High
+1. **code-interpreter `run()` does not strip SSE `data:` frame prefixes** —
+   `CodesAdapter.kt:148-159` parses each line as raw JSON. The sandbox SDK's
+   `CommandsAdapter.decodeEventLine` and the Python/JS code-interpreter SDKs
+   all handle standard SSE framing. If a response arrives framed as
+   `data: {...}`, all events are silently dropped (empty `Execution`, no
+   error). Fix: reuse the `decodeEventLine` logic.
+
+### Medium
+2. **`IsolatedFilesystemAdapter.replaceContentsDetailed` swallows HTTP errors**
+   — `IsolatedFilesystemAdapter.kt:314-332`: the `WithHttpInfo` variant returns
+   `ClientError`/`ServerError` wrappers instead of throwing, so 404/5xx map to
+   `emptyList()`. The sibling `replaceContents` correctly throws.
+3. **`callTimeout` caps the whole retry budget** — `HttpClientProvider.kt`
+   `applyStandardTimeouts()` sets OkHttp `callTimeout = requestTimeout` (30s
+   default). `RetryInterceptor` (application interceptor) runs inside that
+   budget, so retries + backoff are truncated to a single request timeout; in
+   Python `request_timeout` is per-attempt and only `overall_deadline` bounds
+   the call. Fix: `callTimeout(0)` when the retry interceptor is installed.
+4. **Per-attempt timeout clamp can raise the client baseline** —
+   `RetryInterceptor.kt` uses `chain.with*Timeout(ms)` directly; OkHttp replaces
+   (not min-merges) the value, so `perAttemptTimeout > clientTimeout` raises
+   the effective timeout. Python clamps with `min()` only. Fix: take
+   `minOf(ms, chain.*TimeoutMillis())`. (Comment corrected this pass.)
+5. **Isolated session URLs interpolate raw ids** — `IsolatedSessionsAdapter`
+   builds `"$execdBaseUrl/.../session/$sessionId"` in 10 places; an id
+   containing `/ ? #` re-routes the request. `CommandsAdapter.runInSession`
+   correctly uses `addPathSegment`. Fix: build URLs via `addPathSegment`.
+6. **code-interpreter run request always serializes `"id": null`** —
+   `CodesAdapter` JSON config lacks `explicitNulls = false` (the sandbox
+   `CommandsAdapter` has it); Python/JS omit the field, spec types `id` as
+   `string`. Fix: align JSON config.
+7. **Blank code throws stdlib `IllegalArgumentException`** —
+   `CodeModels.kt` builder `require(...)`; Python/JS throw SDK
+   `InvalidArgumentException`, so callers cannot `catch (SandboxException)`.
+8. **Pool orphan warmup task race** — `SandboxPool.scheduleAt` vs
+   `retireRun`/`cancelDelayedWarmups`: a task offered to `delayQueue` after the
+   run retired is never consumed; `warmingCount`/`inFlightOperations` leak and
+   an already-created sandbox is never killed. Fix: re-check run liveness after
+   `offer` (or drain queue under the run fence write lock).
+9. **Redis module has zero default CI coverage** — all tests gated on
+   `OPENSANDBOX_TEST_REDIS_URL`; Lua scripts/lock semantics unverified without
+   a Redis. Fix: embedded-redis/testcontainers default.
+
+### Low (selection)
+10. `RetryInterceptor.kt:~100` — `perAttemptMs.toInt()` Long→Int overflow for
+    >24.8-day deadlines (all attempts become 1ms timeouts).
+11. `computePerAttemptTimeoutMs` returns `null` for sub-ms limits, discarding
+    the clamp (attempt falls back to 30s client default).
+12. `EndpointCache.getOrFetch` — `finally` removes `inflight[key]`
+    unconditionally (identity check missing → concurrent invalidate + refetch
+    can double-fetch); leader/follower share one un-cloned mutable
+    `SandboxEndpoint` (`get()` clones).
+13. `ExecutionEventDispatcher` — `eventNode.error!!` NPEs on a malformed error
+    event (event dropped, exit code degrades); `executionCount` unconditionally
+    overwritten (a null clears a previously seen count). Python guards both.
+14. Exit-code inference drift: `CommandsAdapter` doesn't `trim()` error value,
+    `IsolatedSessionsAdapter` does (`"1\n"` → null vs 1).
+15. `runInSession` posts `"cwd":null,"timeout":null` (`run` uses
+    `explicitNulls=false`).
+16. `ReadinessBudget.run()` checks `remaining()` before recording `lastError`,
+    so a deadline-exceeded timeout can lose the cause/message (Python records
+    first).
+17. `renew()` uses local-zone `OffsetDateTime.now()` (spec requires UTC) and
+    computes `now()` twice (log vs payload differ). Server currently
+    normalizes, so cosmetic + robustness.
+18. `LifecycleMetricsReporter` bypasses `ClientIpInterceptor` → metrics
+    requests lack `OPEN-SANDBOX-CLIENT-IP` (Python includes it).
+19. `ConnectionConfig.protocol()` accepts any string (Python validates
+    http/https).
+20. `Connector.connect()`/`Resumer.resume()` reject only `null` sandboxId,
+    blank string proceeds to RPC (Python rejects blank).
+21. `SandboxPool` idle path calls `ensurePoolNamespaceActiveOrDispose(sandbox)`
+    without the acquire policy — under a store outage + DIRECT_CREATE the
+    healthy just-acquired sandbox is killed, while the direct-create path keeps
+    its sandbox. Same acquire, inconsistent semantics.
+22. `ThrowableUtils` cause-chain walk lacks a depth bound (two-node cycle loops
+    forever).
+23. `toCommandTimeoutMillis` catch of `ArithmeticException` is dead code —
+    `toMillis()` silently overflows instead of throwing.
+24. `ClientIpDetector.isPrivateIpv4` misses CGNAT 100.64/10 etc. that Python's
+    `ipaddress.is_private` covers.
+25. Redis `removeIdle` (HDEL then LREM, two round trips) is not atomic vs a
+    concurrent `putIdle`.
+26. Pool reconcile ignores `renewPrimaryLock` failure for up to one heartbeat.
+27. `Retry-After` HTTP-date parsing is strict `RFC_1123_DATE_TIME` (Python's
+    `email.utils` accepts more); old-style dates fall back to computed backoff.
+28. TLS-handshake `SocketTimeoutException("SSL handshake timed out")` lacks
+    "connect" in the message → classified post-send (idempotent-only retry);
+    Python classifies handshake as pre-send.
+29. `WRITE_TIMEOUT` / `UNEXPECTED_EOF` `RetryCause` values are never produced
+    (dead enum values, kept for API compat).
+30. `SandboxCreateResponse` drops spec-required `status`/`createdAt`/
+    `entrypoint` (public model — adding fields needs a compatibility decision).
+31. `SearchEntry.pattern` is forced non-blank; spec allows omitting pattern
+    (defaults `**`).
+32. `EnvPassthroughSpec` defaults `mode="deny"` and the adapter fabricates
+    `"deny"` when the echo omits it.
+33. `RunCodeRequest`/`CodeContext` builders lack `language` blank validation
+    (Python pydantic validates).
+34. `DiagnosticsAdapter` wraps a client + explicit Accept interceptor that the
+    generated `ApiClient` already applies.
+35. Filesystem upload request bodies wrap one-shot `InputStream`s without
+    `isOneShot()`; a transport-level replay would hit an exhausted stream.
+
+## 3. Test coverage gaps (not changed)
+- code-interpreter: no tests for `getContext`/`listContexts`/`deleteContext`,
+  `ping`, SSE `data:` framing, run request body assertions.
+- `SandboxPoolManagerTest` (2 cases): drain timeout → `PoolDestroyIncompleteException`
+  + DESTROYING fence, kill-failure counting, already-destroyed early return.
+- `InMemoryPoolStateStore`: tombstone TTL expiry → ACTIVE fallback;
+  `beginDestroy` on DESTROYED.
+- Idle-path renew-failure dispose; reconciler `reapExpiredIdle` kill loop.
+
+## 4. Visibility hygiene (not changed — decision: leave as-is)
+These public members are module-internal implementation details (undocumented,
+same-module usage only) and could be `internal` in a future major version.
+Tightening them on 1.0.x is binary-breaking for downstream, so they are kept:
+- code-interpreter: `AdapterFactory`, `CodesAdapter` (only used by the internal
+  `CodeInterpreter.create`)
+- sandbox: `ExecutionConverter`, `FilesystemConverter`, `SandboxModelConverter`,
+  `DiagnosticModelConverter`, `EndpointCache`
+- sandbox: `AbstractUnknownPropertiesSerializer` (dead code, zero references)
+
+Must stay public (verified): `HttpClientProvider`, `ExecutionEventDispatcher`,
+`toSandboxException`/`toSandboxApiException` (used cross-module by
+code-interpreter), `InMemoryPoolStateStore` (documented in README), the
+transport config surface (`RetryPolicy`, `RetryInterceptor`, `RetryEvent`,
+`StatusCode`), domain models and service interfaces.
+
+## 5. Deduplication / refactoring opportunities (not changed)
+- `FilesystemAdapter` vs `IsolatedFilesystemAdapter`: ~280 lines duplicated
+  (~90%); extract shared transport/API facade.
+- Endpoint-header interceptor + `"${protocol}://${endpoint.endpoint}"` builder
+  repeated across 6+ adapters → `HttpClientProvider.endpointClient(...)` /
+  `SandboxEndpoint.baseUrl`.
+- SSE read loop + `decodeEventLine` + exit-code inference duplicated between
+  `CommandsAdapter` and `IsolatedSessionsAdapter`.
+- `ConnectionConfig.copyWithoutConnectionPool/copyWithConnectionPool/
+  copyForSingleAttempt/copyForStagedWarmup`: four ~110-line field copies.
+- `SandboxPool`: `releaseAllIdle()` x2; four near-identical reconcile teardown
+  sequences.
+- Build: root `build.gradle.kts` has an unused `buildscript` Jackson classpath;
+  junit jupiter 5.10.1 vs junit-platform-launcher 1.13.4 version lines mixed;
+  `sandbox-bom` does not constrain `jedis`; duplicate POM exclusion logic
+  (GenerateMavenPom regex + vanniktech withXml); module-level `javaParameters`
+  duplicating the root setting.
+
+## 6. Verified as NOT issues (audit false positives)
+- `listSandboxes` metadata filter encoding: Kotlin matches Python exactly —
+  both pass the raw `k=v&k2=v2` string and let the HTTP client encode it once
+  (Python `sandboxes_adapter.py` even comments "similar to Kotlin SDK").
+- Retry defaults (codes {429,502,503}, idempotent-only, decorrelated jitter,
+  Retry-After cap), SSE client exclusion, execd/egress wire field names,
+  millisecond/second units, resource cleanup in adapters: verified aligned
+  with specs and Python.
+
+## 7. Cross-language gaps registered elsewhere (out of Kotlin scope)
+- JavaScript SDK has no HTTP-transport retry at all (Python/Kotlin do).
+- Kotlin typed exception subclasses (507, SANDBOX_NOT_FOUND,
+  BACKEND_CONNECTION_FAILED) and different exception hierarchy for
+  timeout/connection errors vs Python — needs a cross-language decision.

--- a/sdks/sandbox/kotlin/code-interpreter/src/main/kotlin/com/alibaba/opensandbox/codeinterpreter/CodeInterpreter.kt
+++ b/sdks/sandbox/kotlin/code-interpreter/src/main/kotlin/com/alibaba/opensandbox/codeinterpreter/CodeInterpreter.kt
@@ -36,7 +36,8 @@ import java.util.concurrent.TimeUnit
  *
  * ## Key Features
  *
- * - **Multi-language Code Execution**: Support for Python, JavaScript, Bash, Java, Kotlin
+ * - **Multi-language Code Execution**: Support for Python, Java, Go, TypeScript, Bash, JavaScript
+ *   (see [SupportedLanguage])
  * - **Session Management**: Persistent execution contexts with variable state
  * - **Sandbox Integration**: Full access to underlying sandbox file system and command execution
  * - **Streaming Execution**: Real-time code execution with output streaming
@@ -76,7 +77,7 @@ import java.util.concurrent.TimeUnit
  * )
  *
  * // Always clean up resources
- * interpreter.kill()
+ * interpreter.sandbox().kill()
  * interpreter.sandbox().close()
  * ```
  */
@@ -84,8 +85,6 @@ class CodeInterpreter internal constructor(
     private val sandbox: Sandbox,
     private val codeService: Codes,
 ) {
-    private val logger = LoggerFactory.getLogger(CodeInterpreter::class.java)
-
     /**
      * Provides access to the underlying sandbox instance.
      */
@@ -334,7 +333,6 @@ class CodeInterpreter internal constructor(
      * // Then wrap it with code interpreter capabilities
      * val interpreter = CodeInterpreter.builder()
      *     .fromSandbox(sandbox)
-     *     .connectionConfig(customConfig)  // Optional
      *     .build()
      *
      * // Use the interpreter

--- a/sdks/sandbox/kotlin/code-interpreter/src/main/kotlin/com/alibaba/opensandbox/codeinterpreter/domain/models/execd/executions/CodeModels.kt
+++ b/sdks/sandbox/kotlin/code-interpreter/src/main/kotlin/com/alibaba/opensandbox/codeinterpreter/domain/models/execd/executions/CodeModels.kt
@@ -49,7 +49,6 @@ object SupportedLanguage {
  *
  * @property id Unique identifier for this execution context
  * @property language Programming language for this context (e.g., "python", "javascript")
- * @property cwd Current working directory for code execution
  */
 class CodeContext private constructor(
     val id: String?,
@@ -105,7 +104,6 @@ class CodeContext private constructor(
  * val context = CodeContext.builder()
  *     .id("session-123")
  *     .language("python")
- *     .cwd("/workspace")
  *     .build()
  * val request = RunCodeRequest.builder()
  *     .code("import pandas as pd; df = pd.read_csv('data.csv')")
@@ -114,7 +112,8 @@ class CodeContext private constructor(
  * ```
  *
  * @property code The source code to execute
- * @property context Optional execution context. If null, a temporary context will be created
+ * @property context Execution context. Defaults to a Python context; the server
+ * resolves it to the default per-language session, whose state persists across runs
  */
 class RunCodeRequest private constructor(
     val code: String,

--- a/sdks/sandbox/kotlin/code-interpreter/src/main/kotlin/com/alibaba/opensandbox/codeinterpreter/infrastructure/adapters/converter/CodeExecutionConverter.kt
+++ b/sdks/sandbox/kotlin/code-interpreter/src/main/kotlin/com/alibaba/opensandbox/codeinterpreter/infrastructure/adapters/converter/CodeExecutionConverter.kt
@@ -25,7 +25,7 @@ object CodeExecutionConverter {
     fun RunCodeRequest.toApiRunCodeRequest(): ApiRunCodeRequest {
         return ApiRunCodeRequest(
             code = this.code,
-            context = this.context?.toApiCodeContext(),
+            context = this.context.toApiCodeContext(),
         )
     }
 

--- a/sdks/sandbox/kotlin/sandbox-pool-redis/README.md
+++ b/sdks/sandbox/kotlin/sandbox-pool-redis/README.md
@@ -80,7 +80,10 @@ try {
   interval no greater than `primaryLockTtl / 3`. A slow warmup therefore does not block
   lock renewal. Configure the TTL with enough margin for Redis latency, process pauses,
   and scheduling jitter.
-- Redis outages are surfaced as `PoolStateStoreUnavailableException`; the pool does not silently bypass shared state.
+- Store-level Redis failures are surfaced as `PoolStateStoreUnavailableException`. The pool
+  does not silently bypass shared state on the store path; however, under acquire policies
+  that allow fallthrough (`DIRECT_CREATE`, `RETRY_NEXT_IDLE_THEN_CREATE`), a store outage
+  degrades to direct sandbox creation (see OSEP-0005) rather than failing the acquire.
 
 TODO: If production deployments need stronger protection against accidental mixed pool definitions,
 add an optional pool definition version or fingerprint check that fails fast when nodes sharing the

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
@@ -71,7 +71,7 @@ class HttpClientProvider(
             return builder
         }
 
-    // 1. Explicit lazy definition to allow checking initialization status
+    // Lazy so close() can check whether the client was ever initialized
     private val httpClientLazy =
         lazy {
             baseBuilder
@@ -99,7 +99,7 @@ class HttpClientProvider(
 
     internal val singleAttemptClient: OkHttpClient by singleAttemptClientLazy
 
-    // 2. Explicit lazy definition for authenticated client
+    // Lazy so close() can check whether the client was ever initialized
     private val authenticatedClientLazy =
         lazy {
             baseBuilder
@@ -112,7 +112,7 @@ class HttpClientProvider(
 
     val authenticatedClient: OkHttpClient by authenticatedClientLazy
 
-    // 3. Explicit lazy definition for SSE client
+    // Lazy so close() can check whether the client was ever initialized.
     //
     // The SSE client deliberately disables all automatic retries: streaming
     // command POSTs are not safely replayable and could start a command twice
@@ -276,7 +276,6 @@ class HttpClientProvider(
      * Closes the underlying HTTP client and releases resources.
      */
     override fun close() {
-        // Now we can pass the specific backing fields to check initialization
         shutdownClientQuietly(httpClientLazy, "http client")
         shutdownClientQuietly(authenticatedClientLazy, "authenticated client")
         shutdownClientQuietly(sseClientLazy, "sse client")

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
@@ -103,8 +103,6 @@ class Sandbox internal constructor(
     private val httpClientProvider: HttpClientProvider,
     private val diagnosticsService: Diagnostics,
 ) : AutoCloseable {
-    private val logger = LoggerFactory.getLogger(Sandbox::class.java)
-
     /**
      * Provides access to file system operations within the sandbox.
      *
@@ -531,10 +529,11 @@ class Sandbox internal constructor(
     }
 
     /**
-     * Gets the current status of this sandbox.
+     * Gets the externally reachable endpoint for a service port exposed by this sandbox.
      *
-     * @return Current sandbox status including state and metadata
-     * @throws SandboxException if status cannot be retrieved
+     * @param port The port number to get the endpoint for
+     * @return Endpoint information including address and access headers
+     * @throws SandboxException if the endpoint cannot be retrieved
      */
     fun getEndpoint(port: Int): SandboxEndpoint {
         return sandboxService.getSandboxEndpoint(id, port, httpClientProvider.config.useServerProxy)
@@ -555,9 +554,10 @@ class Sandbox internal constructor(
     }
 
     /**
-     * Gets the current status of this sandbox.
+     * Gets current resource usage metrics for this sandbox.
      *
-     * @return Current sandbox status including state and metadata
+     * @return Metrics including CPU and memory usage
+     * @throws SandboxException if metrics cannot be retrieved
      */
     fun getMetrics(): SandboxMetrics {
         return metricsService.getMetrics(id)

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -238,10 +238,10 @@ class ConnectionConfig private constructor(
 
     fun getBaseUrl(): String {
         val currentDomain = getDomain()
-        // Python semantics:
+        // Python-compatible semantics, plus normalization:
         // - If `domain` includes a scheme, treat it as a full base URL (without `/v1`) and append `/v1`.
         // - If `domain` does not include a scheme, build `protocol://domain/v1`.
-        // Also normalize trailing slashes and avoid duplicating `/v1`.
+        // - Beyond Python, trailing slashes are normalized and a duplicated `/v1` is avoided.
         if (currentDomain.startsWith("http://") || currentDomain.startsWith("https://")) {
             val trimmed = currentDomain.removeSuffix("/")
             return if (trimmed.endsWith("/$API_VERSION")) trimmed else "$trimmed/$API_VERSION"

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/exceptions/SandboxException.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/exceptions/SandboxException.kt
@@ -282,7 +282,8 @@ class SandboxConnectionException(
     )
 
 /**
- * Thrown when the operation times out waiting for the sandbox to become ready.
+ * Thrown when the sandbox is determined to be unhealthy, e.g. a custom health
+ * check keeps reporting failure while the sandbox is running.
  */
 class SandboxUnhealthyException(
     message: String? = null,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/ExecutionModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/ExecutionModels.kt
@@ -157,7 +157,7 @@ class ExecutionComplete(
      */
     val timestamp: Long,
     /**
-     * Execution time in mills
+     * Total execution time in milliseconds.
      */
     val executionTimeInMillis: Long,
 )

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/filesystem/FilesystemModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/filesystem/FilesystemModels.kt
@@ -31,6 +31,7 @@ import java.time.OffsetDateTime
  * @property size Size of the file in bytes (0 for directories)
  * @property modifiedAt Timestamp when the entry was last modified
  * @property createdAt Timestamp when the entry was created
+ * @property type Entry type: `file`, `directory`, `symlink`, or `other` (null when the server omits it)
  */
 class EntryInfo(
     val path: String,
@@ -172,7 +173,9 @@ class MoveEntry private constructor(
  * Request to set permissions/ownership of a file or directory.
  *
  * Updates the permissions and/or ownership of an existing file or directory
- * without modifying its content. Only specified properties will be changed.
+ * without modifying its content. Note that `mode` is always sent with the
+ * request (the execd API requires it), so leaving it at the default `755`
+ * also rewrites the file mode. `owner` and `group` are only sent when set.
  *
  * @property path Target path of the file or directory to modify
  * @property owner New owner username (null to keep current owner)

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/isolated/IsolatedModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/isolated/IsolatedModels.kt
@@ -109,6 +109,9 @@ data class IsolatedRunOpts(
 
 /**
  * Handle returned when a run is started with `background: true`.
+ *
+ * [startedAt] is required by the execd spec but parsed as nullable so older
+ * execd builds that omit it do not fail the response.
  */
 data class IsolatedBackgroundRun(
     val sessionId: String,
@@ -118,6 +121,9 @@ data class IsolatedBackgroundRun(
 
 /**
  * Lifecycle state of an isolated background run.
+ *
+ * [startedAt] is required by the execd spec but parsed as nullable so older
+ * execd builds that omit it do not fail the response.
  */
 data class IsolatedRunStatus(
     val sessionId: String,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/LifecycleModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/LifecycleModels.kt
@@ -16,7 +16,13 @@
 
 package com.alibaba.opensandbox.sandbox.domain.models.sandboxes
 
-/** Command executed by execd before the user entrypoint starts. */
+/**
+ * Command executed by execd before the user entrypoint starts.
+ *
+ * [timeoutSeconds] is optional; the server applies its own default (60s) when
+ * omitted. Values outside the server-accepted range (1..10800 for pre-start
+ * hooks) are rejected by the server.
+ */
 class LifecycleHook private constructor(
     val command: List<String>,
     val timeoutSeconds: Int?,
@@ -52,7 +58,13 @@ class LifecycleHook private constructor(
     }
 }
 
-/** Named command scheduled by execd while the sandbox is running. */
+/**
+ * Named command scheduled by execd while the sandbox is running.
+ *
+ * [timeoutSeconds] is optional; the server applies its own default (60s) when
+ * omitted. Values outside the server-accepted range (1..300 for periodic
+ * hooks) are rejected by the server.
+ */
 class PeriodicLifecycleHook private constructor(
     val name: String,
     val schedule: String,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
@@ -26,6 +26,7 @@ import java.time.OffsetDateTime
  * - Running: Sandbox is running and ready to accept requests
  * - Pausing: Sandbox is in the process of pausing
  * - Paused: Sandbox has been paused while retaining its state
+ * - Resuming: Sandbox is in the process of resuming from Paused
  * - Stopping: Sandbox is being terminated
  * - Terminated: Sandbox has been successfully terminated
  * - Failed: Sandbox encountered a critical error
@@ -34,7 +35,8 @@ import java.time.OffsetDateTime
  * - Pending → Running (after creation completes)
  * - Running → Pausing (when pause is requested)
  * - Pausing → Paused (pause operation completes)
- * - Paused → Running (when resume is requested)
+ * - Paused → Resuming (when resume is requested)
+ * - Resuming → Running (resume operation completes)
  * - Running/Paused → Stopping (when kill is requested or TTL expires)
  * - Stopping → Terminated (kill/timeout operation completes)
  * - Pending/Running/Paused → Failed (on error)
@@ -47,6 +49,7 @@ object SandboxState {
     const val RUNNING = "Running"
     const val PAUSING = "Pausing"
     const val PAUSED = "Paused"
+    const val RESUMING = "Resuming"
     const val STOPPING = "Stopping"
     const val TERMINATED = "Terminated"
     const val FAILED = "Failed"
@@ -56,10 +59,10 @@ object SandboxState {
 /**
  * Filter criteria for listing sandboxes.
  *
- * @property states Filter by sandbox states (e.g., RUNNING, PAUSED)
+ * @property states Filter by sandbox states (e.g., [SandboxState.RUNNING], [SandboxState.PAUSED])
  * @property metadata Filter by metadata key-value pairs
  * @property pageSize Number of items per page
- * @property page Page number (0-indexed)
+ * @property page Page number (1-indexed)
  */
 class SandboxFilter private constructor(
     val states: List<String>?,
@@ -930,7 +933,7 @@ class PagedSandboxInfos(
 /**
  * Pagination metadata.
  *
- * @property page Current page number (0-indexed)
+ * @property page Current page number (1-indexed)
  * @property pageSize Number of items per page
  * @property totalItems Total number of items across all pages
  * @property totalPages Total number of pages

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/pool/PoolCreationSpec.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/pool/PoolCreationSpec.kt
@@ -26,8 +26,9 @@ import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Volume
 /**
  * Template for creating sandboxes in the pool (replenish and direct-create).
  *
- * Pool always uses a fixed 24h timeout for created sandboxes; other parameters
- * are taken from this spec. Defaults align with [Sandbox.Builder].
+ * Created sandboxes use the idle timeout configured on the pool
+ * (`PoolConfig.idleTimeout`, default 24h); other parameters are taken from
+ * this spec. Defaults align with [Sandbox.Builder].
  *
  * @property imageSpec Container image specification (required).
  * @property entrypoint Entrypoint command (default: tail -f /dev/null).

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/FilesystemConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/FilesystemConverter.kt
@@ -27,9 +27,6 @@ import com.alibaba.opensandbox.sandbox.api.models.execd.ReplaceFileContentItem a
 
 /**
  * Converter between domain models and API models for filesystem operations.
- *
- * @author ninan
- * @since 2025/12/2
  */
 object FilesystemConverter {
     /**

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/EgressAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/EgressAdapter.kt
@@ -480,7 +480,5 @@ internal class EgressAdapter(
 
     private fun JsonObject.optionalStringArray(name: String): List<String>? = optionalArray(name)?.map { it.requiredStringValue() }
 
-    private fun JsonObject.optionalIntArray(name: String): List<Int>? = optionalArray(name)?.map { it.jsonPrimitive.int }
-
     private fun JsonElement.requiredStringValue(): String = jsonPrimitive.content
 }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/InMemoryPoolStateStore.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/InMemoryPoolStateStore.kt
@@ -30,9 +30,12 @@ import java.util.concurrent.ConcurrentLinkedQueue
 /**
  * In-memory implementation of [PoolStateStore] for single-node use.
  *
- * Concurrency is provided entirely by concurrent data structures:
- * - Per-pool state uses [ConcurrentHashMap] (sandboxId -> [IdleEntry]) and
- *   [ConcurrentLinkedQueue] (FIFO sandboxIds). No external lock.
+ * Concurrency model:
+ * - Per-pool idle state uses [ConcurrentHashMap] (sandboxId -> [IdleEntry]) and
+ *   [ConcurrentLinkedQueue] (FIFO sandboxIds).
+ * - Cross-step sequences (put, take, destroy-state transitions, clear) are
+ *   additionally guarded by a store-wide monitor, so compound operations are
+ *   atomic with respect to each other.
  * - Primary lock is a no-op: single-node mode always treats the caller as leader
  *   ([tryAcquirePrimaryLock]/[renewPrimaryLock] return true, [releasePrimaryLock] is no-op).
  *

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -165,6 +165,10 @@ class SandboxPool internal constructor(
      * thousands of mutually incompatible endpoint routes are not accumulated in one giant pool.
      * An explicitly user-provided connection pool is still honored. Health probes are
      * single-attempt because the DelayQueue owns health retry, interval, and TTL.
+     *
+     * Note: when [sharedConnectionPool] is set, [poolConnectionConfig] equals
+     * [connectionConfig], so both branches below produce the same value; the
+     * conditional is kept to make the sharing intent explicit.
      */
     private val warmupConnectionConfig: ConnectionConfig =
         if (sharedConnectionPool == null) {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptor.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptor.kt
@@ -90,10 +90,11 @@ class RetryInterceptor
                 }
 
                 // Clamp per-attempt timeouts: apply perAttemptTimeout and remaining
-                // overallDeadline, whichever is tighter. OkHttp chain.with*Timeout
-                // returns a new Chain with the timeout lowered (not raised), so
-                // default values from the caller's OkHttpClient are preserved when
-                // these knobs are unset.
+                // overallDeadline, whichever is tighter. Note: OkHttp
+                // chain.with*Timeout *replaces* the previous value (it can
+                // raise as well as lower it), so a policy value larger than
+                // the client baseline raises the effective timeout for this
+                // attempt.
                 var effectiveChain = chain
                 val perAttemptMs = computePerAttemptTimeoutMs(elapsedBefore)
                 if (perAttemptMs != null) {


### PR DESCRIPTION
Kotlin-scope slice of #1768 (systematic SDK audit & cleanup). **No runtime logic, behavior, or visibility changes** — documentation/comment/dead-code cleanup only, plus the Phase 0 audit report.

## Changes (19 source/doc files)
- **KDoc corrections**: `Sandbox.getEndpoint`/`getMetrics` (were copy-pastes of `getInfo`), `SandboxUnhealthyException` (copied doc), `SandboxState` transition doc + additive `RESUMING` constant (spec has `Paused → Resuming → Running`), `SandboxFilter.page`/`PaginationInfo.page` (1-indexed, not 0-indexed), `SetPermissionEntry` (mode is always sent), `EntryInfo.type`, isolated `startedAt` nullability, lifecycle hook timeout ranges
- **Comment governance**: fixed factually wrong `RetryInterceptor` comment (OkHttp `with*Timeout` replaces, not lowers), `InMemoryPoolStateStore` "no external lock" claim, stale `PoolCreationSpec` 24h note, `HttpClientProvider` leftover numbered comments, `ConnectionConfig.getBaseUrl` Python-parity wording, `SandboxPool.warmupConnectionConfig` identical-branches note
- **Dead code / duplication**: removed unused private `EgressAdapter.optionalIntArray`, personal `@author` tag, duplicate instance loggers shadowing companion loggers (`Sandbox`, `CodeInterpreter`), redundant `?.` on non-null field
- **code-interpreter KDoc**: examples calling nonexistent `interpreter.kill()` / `.connectionConfig(...)` / `.cwd(...)`, "temporary context" claim, language list aligned with `SupportedLanguage`
- **README**: `sandbox-pool-redis` wording contradicted the documented `DIRECT_CREATE` store-outage fallthrough (OSEP-0005)

## Audit report
`sdks/sandbox/kotlin/AUDIT-1768.md` records the triaged findings: 1 high + 8 medium logic-level findings intentionally **not** changed here (each with file:line and suggested fix), test-coverage gaps, visibility-hygiene notes, dedup opportunities, and items verified as false positives (e.g. metadata filter encoding matches Python).

## Verification
```
cd sdks/sandbox/kotlin
./gradlew spotlessCheck :sandbox:test :code-interpreter:test :sandbox-pool-redis:test
```
All green (JDK 21 toolchain).