### PR TITLE
feat(egress): add revision Unix transport for OSEP-0023

### DIFF
--- a/components/egress/pkg/revision/coordinator.go
+++ b/components/egress/pkg/revision/coordinator.go
@@ -42,12 +42,12 @@ var (
 // Identity matches the Python receiver's generation/epoch/digest identity.
 // It contains no snapshot payload. Wire encoding belongs to the IPC adapter.
 type Identity struct {
-	ControlGeneration string
-	SubjectGeneration string
-	DecisionEpoch     int64
-	VaultRevision     int64
-	PolicyEpoch       int64
-	Digest            string
+	ControlGeneration string `json:"controlGeneration"`
+	SubjectGeneration string `json:"subjectGeneration"`
+	DecisionEpoch     int64  `json:"decisionEpoch"`
+	VaultRevision     int64  `json:"vaultRevision"`
+	PolicyEpoch       int64  `json:"policyEpoch"`
+	Digest            string `json:"digest"`
 }
 
 // Transport binds one authenticated receiver/session to this coordinator.

--- a/components/egress/pkg/revision/transport_unix.go
+++ b/components/egress/pkg/revision/transport_unix.go
@@ -1,0 +1,272 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package revision
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+)
+
+const maxIPCResponseBytes = 4096
+
+var (
+	ErrInvalidTransport         = errors.New("invalid revision IPC input")
+	ErrTransportUnavailable     = errors.New("revision IPC unavailable")
+	ErrTransportRejected        = errors.New("revision IPC request rejected")
+	ErrInvalidTransportResponse = errors.New("invalid revision IPC response")
+)
+
+type ipcEnvelope struct {
+	Revision Identity `json:"revision"`
+	Payload  []byte   `json:"payload"`
+}
+
+type ipcCommand struct {
+	Revision Identity `json:"revision"`
+}
+
+type ipcResponse struct {
+	Revision *Identity `json:"revision"`
+}
+
+func decodeStrictObject(data []byte, fields map[string]func(*json.Decoder) error) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return ErrInvalidTransportResponse
+	}
+	seen := make(map[string]struct{}, len(fields))
+	for decoder.More() {
+		token, err = decoder.Token()
+		name, ok := token.(string)
+		decode, known := fields[name]
+		if err != nil || !ok || !known {
+			return ErrInvalidTransportResponse
+		}
+		if _, duplicate := seen[name]; duplicate {
+			return ErrInvalidTransportResponse
+		}
+		seen[name] = struct{}{}
+		if err := decode(decoder); err != nil {
+			return ErrInvalidTransportResponse
+		}
+	}
+	if token, err = decoder.Token(); err != nil || token != json.Delim('}') || len(seen) != len(fields) {
+		return ErrInvalidTransportResponse
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return ErrInvalidTransportResponse
+	}
+	return nil
+}
+
+func decodeIPCResponse(data []byte) (*ipcResponse, error) {
+	var raw json.RawMessage
+	if err := decodeStrictObject(data, map[string]func(*json.Decoder) error{
+		"revision": func(decoder *json.Decoder) error { return decoder.Decode(&raw) },
+	}); err != nil {
+		return nil, err
+	}
+	response := &ipcResponse{}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return response, nil
+	}
+	identity := Identity{}
+	if err := decodeStrictObject(raw, map[string]func(*json.Decoder) error{
+		"controlGeneration": func(decoder *json.Decoder) error { return decoder.Decode(&identity.ControlGeneration) },
+		"subjectGeneration": func(decoder *json.Decoder) error { return decoder.Decode(&identity.SubjectGeneration) },
+		"decisionEpoch":     func(decoder *json.Decoder) error { return decoder.Decode(&identity.DecisionEpoch) },
+		"vaultRevision":     func(decoder *json.Decoder) error { return decoder.Decode(&identity.VaultRevision) },
+		"policyEpoch":       func(decoder *json.Decoder) error { return decoder.Decode(&identity.PolicyEpoch) },
+		"digest":            func(decoder *json.Decoder) error { return decoder.Decode(&identity.Digest) },
+	}); err != nil || !validIPCIdentity(identity) {
+		return nil, ErrInvalidTransportResponse
+	}
+	response.Revision = &identity
+	return response, nil
+}
+
+// UnixTransport sends revision transactions over a caller-provisioned private
+// Unix socket. It presents a bearer token for receiver-side client
+// authentication; generation fields provide the independent stale-session
+// fence. It never includes remote response bodies in errors because those
+// bodies are not trusted to be credential-free.
+type UnixTransport struct {
+	client *http.Client
+	token  string
+	limit  int
+}
+
+var _ Transport = (*UnixTransport)(nil)
+
+func (*UnixTransport) String() string { return "revision.UnixTransport" }
+
+func (*UnixTransport) GoString() string { return "revision.UnixTransport{}" }
+
+// NewSessionToken returns 256 bits encoded without padding for one IPC session.
+func NewSessionToken() (string, error) {
+	value := make([]byte, 32)
+	if _, err := rand.Read(value); err != nil {
+		return "", ErrTransportUnavailable
+	}
+	return base64.RawURLEncoding.EncodeToString(value), nil
+}
+
+// NewUnixTransport constructs a transport without dialing. The socket server
+// must use the same token and snapshot byte limit.
+func NewUnixTransport(socketPath, sessionToken string, maxSnapshotBytes int) (*UnixTransport, error) {
+	if !filepath.IsAbs(socketPath) || !validSessionToken(sessionToken) || maxSnapshotBytes <= 0 {
+		return nil, ErrInvalidTransport
+	}
+	dialer := &net.Dialer{}
+	transport := &http.Transport{
+		DisableKeepAlives:      true,
+		MaxResponseHeaderBytes: 8 * 1024,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "unix", socketPath)
+		},
+	}
+	return &UnixTransport{
+		client: &http.Client{
+			Transport: transport,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		token: sessionToken,
+		limit: maxSnapshotBytes,
+	}, nil
+}
+
+func validSessionToken(value string) bool {
+	if len(value) < 32 || len(value) > 256 {
+		return false
+	}
+	for _, c := range value {
+		if !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '-' || c == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+func validIPCIdentity(r Identity) bool {
+	validGeneration := func(value string) bool {
+		return value != "" && utf8.ValidString(value) && utf8.RuneCountInString(value) <= 128
+	}
+	if !validGeneration(r.ControlGeneration) || !validGeneration(r.SubjectGeneration) ||
+		r.DecisionEpoch < 1 || r.VaultRevision < 0 || r.PolicyEpoch < 0 || len(r.Digest) != 64 {
+		return false
+	}
+	decoded, err := hex.DecodeString(r.Digest)
+	return err == nil && len(decoded) == 32 && strings.ToLower(r.Digest) == r.Digest
+}
+
+func (t *UnixTransport) Prepare(ctx context.Context, revision Identity, payload []byte) (Identity, error) {
+	if len(payload) > t.limit {
+		return Identity{}, ErrInvalidTransport
+	}
+	return t.command(ctx, http.MethodPost, "/v1/revisions/prepare", ipcEnvelope{Revision: revision, Payload: payload})
+}
+
+func (t *UnixTransport) Commit(ctx context.Context, revision Identity) (Identity, error) {
+	return t.command(ctx, http.MethodPost, "/v1/revisions/commit", ipcCommand{Revision: revision})
+}
+
+func (t *UnixTransport) Abort(ctx context.Context, revision Identity) (Identity, error) {
+	return t.command(ctx, http.MethodPost, "/v1/revisions/abort", ipcCommand{Revision: revision})
+}
+
+func (t *UnixTransport) Readback(ctx context.Context) (*Identity, error) {
+	response, err := t.do(ctx, http.MethodGet, "/v1/revisions/active", nil)
+	if err != nil {
+		return nil, err
+	}
+	return response.Revision, nil
+}
+
+func (t *UnixTransport) command(ctx context.Context, method, path string, value any) (Identity, error) {
+	var revision Identity
+	switch typed := value.(type) {
+	case ipcEnvelope:
+		revision = typed.Revision
+	case ipcCommand:
+		revision = typed.Revision
+	default:
+		return Identity{}, ErrInvalidTransport
+	}
+	if !validIPCIdentity(revision) {
+		return Identity{}, ErrInvalidTransport
+	}
+	response, err := t.do(ctx, method, path, value)
+	if err != nil {
+		return Identity{}, err
+	}
+	if response.Revision == nil {
+		return Identity{}, ErrInvalidTransportResponse
+	}
+	return *response.Revision, nil
+}
+
+func (t *UnixTransport) do(ctx context.Context, method, path string, value any) (*ipcResponse, error) {
+	if ctx == nil {
+		return nil, ErrInvalidTransport
+	}
+	var body io.Reader
+	if value != nil {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, ErrInvalidTransport
+		}
+		body = bytes.NewReader(encoded)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, "http://revision-ipc"+path, body)
+	if err != nil {
+		return nil, ErrInvalidTransport
+	}
+	request.Header.Set("Authorization", "Bearer "+t.token)
+	request.Header.Set("Content-Type", "application/json")
+	request.Close = true
+	response, err := t.client.Do(request)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, ErrTransportUnavailable
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, ErrTransportRejected
+	}
+	if response.Header.Get("Content-Type") != "application/json" {
+		return nil, ErrInvalidTransportResponse
+	}
+	data, err := io.ReadAll(io.LimitReader(response.Body, maxIPCResponseBytes+1))
+	if err != nil || len(data) > maxIPCResponseBytes {
+		return nil, ErrInvalidTransportResponse
+	}
+	return decodeIPCResponse(data)
+}

--- a/components/egress/pkg/revision/transport_unix.go
+++ b/components/egress/pkg/revision/transport_unix.go
@@ -238,6 +238,9 @@ func (t *UnixTransport) do(ctx context.Context, method, path string, value any) 
 	if ctx == nil {
 		return nil, ErrInvalidTransport
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	var body io.Reader
 	if value != nil {
 		encoded, err := json.Marshal(value)

--- a/components/egress/pkg/revision/transport_unix.go
+++ b/components/egress/pkg/revision/transport_unix.go
@@ -189,6 +189,9 @@ func (t *UnixTransport) Prepare(ctx context.Context, revision Identity, payload 
 	if len(payload) > t.limit {
 		return Identity{}, ErrInvalidTransport
 	}
+	if len(payload) == 0 {
+		payload = []byte{}
+	}
 	return t.command(ctx, http.MethodPost, "/v1/revisions/prepare", ipcEnvelope{Revision: revision, Payload: payload})
 }
 

--- a/components/egress/pkg/revision/transport_unix_test.go
+++ b/components/egress/pkg/revision/transport_unix_test.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package revision
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testSessionToken = "0123456789abcdef0123456789abcdef"
+
+type testEnvelope struct {
+	Revision Identity `json:"revision"`
+	Payload  []byte   `json:"payload"`
+}
+
+func testIdentity() Identity {
+	return Identity{
+		ControlGeneration: "control-a",
+		SubjectGeneration: "subject-a",
+		DecisionEpoch:     1,
+		VaultRevision:     2,
+		PolicyEpoch:       3,
+		Digest:            strings.Repeat("a", 64),
+	}
+}
+
+func startUnixHTTPServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "osri-go-")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(dir)) })
+	path := filepath.Join(dir, "receiver.sock")
+	listener, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	server := &http.Server{Handler: handler}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { require.NoError(t, server.Close()) })
+	return path
+}
+
+func writeTestAck(t *testing.T, w http.ResponseWriter, revision *Identity) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(struct {
+		Revision *Identity `json:"revision"`
+	}{Revision: revision}))
+}
+
+func TestUnixTransportRoundTripContract(t *testing.T) {
+	identity := testIdentity()
+	payload := []byte(`{"revision":2,"secret":"never-log-me"}`)
+	var active *Identity
+	path := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer "+testSessionToken, r.Header.Get("Authorization"))
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.Equal(t, "close", r.Header.Get("Connection"))
+		switch r.URL.Path {
+		case "/v1/revisions/prepare":
+			var request testEnvelope
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+			require.Equal(t, identity, request.Revision)
+			require.Equal(t, payload, request.Payload)
+			writeTestAck(t, w, &identity)
+		case "/v1/revisions/commit":
+			var request struct {
+				Revision Identity `json:"revision"`
+			}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+			active = &request.Revision
+			writeTestAck(t, w, active)
+		case "/v1/revisions/abort":
+			writeTestAck(t, w, &identity)
+		case "/v1/revisions/active":
+			writeTestAck(t, w, active)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	transport, err := NewUnixTransport(path, testSessionToken, 1024)
+	require.NoError(t, err)
+	require.NotContains(t, fmt.Sprintf("%+v", transport), testSessionToken)
+	require.NotContains(t, fmt.Sprintf("%#v", transport), testSessionToken)
+	readback, err := transport.Readback(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, readback)
+
+	ack, err := transport.Prepare(context.Background(), identity, payload)
+	require.NoError(t, err)
+	require.Equal(t, identity, ack)
+	ack, err = transport.Commit(context.Background(), identity)
+	require.NoError(t, err)
+	require.Equal(t, identity, ack)
+	readback, err = transport.Readback(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, identity, *readback)
+	ack, err = transport.Abort(context.Background(), identity)
+	require.NoError(t, err)
+	require.Equal(t, identity, ack)
+}
+
+func TestUnixTransportDoesNotFollowRedirects(t *testing.T) {
+	requests := 0
+	path := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Location", "http://revision-ipc/replayed")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	transport, err := NewUnixTransport(path, testSessionToken, 1024)
+	require.NoError(t, err)
+	_, err = transport.Readback(context.Background())
+	require.ErrorIs(t, err, ErrTransportRejected)
+	require.Equal(t, 1, requests)
+}
+
+func TestUnixTransportRequiresRevisionForCommandAcknowledgement(t *testing.T) {
+	path := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeTestAck(t, w, nil)
+	}))
+	transport, err := NewUnixTransport(path, testSessionToken, 1024)
+	require.NoError(t, err)
+	_, err = transport.Commit(context.Background(), testIdentity())
+	require.ErrorIs(t, err, ErrInvalidTransportResponse)
+}
+
+func TestUnixTransportRejectsUntrustedResponsesWithoutLeakingBody(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+	}{
+		{"remote rejection", http.StatusConflict, "text/plain", "secret-bearing detail"},
+		{"wrong content type", http.StatusOK, "text/plain", `{"revision":null}`},
+		{"unknown field", http.StatusOK, "application/json", `{"revision":null,"extra":1}`},
+		{"duplicate field", http.StatusOK, "application/json", `{"revision":null,"revision":null}`},
+		{"duplicate identity field", http.StatusOK, "application/json", `{"revision":{"controlGeneration":"a","controlGeneration":"b","subjectGeneration":"s","decisionEpoch":1,"vaultRevision":1,"policyEpoch":1,"digest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}`},
+		{"trailing value", http.StatusOK, "application/json", `{"revision":null}{}`},
+		{"invalid identity", http.StatusOK, "application/json", `{"revision":{"controlGeneration":"a","subjectGeneration":"s","decisionEpoch":0,"vaultRevision":1,"policyEpoch":1,"digest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}`},
+		{"oversized", http.StatusOK, "application/json", strings.Repeat("x", 4097)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", tc.contentType)
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			transport, err := NewUnixTransport(path, testSessionToken, 1024)
+			require.NoError(t, err)
+			_, err = transport.Readback(context.Background())
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), "secret-bearing")
+		})
+	}
+}
+
+func TestUnixTransportValidatesConfigurationAndRequests(t *testing.T) {
+	identity := testIdentity()
+	for _, tc := range []struct {
+		path, token string
+		limit       int
+	}{
+		{"relative.sock", testSessionToken, 1},
+		{"/tmp/socket", "short", 1},
+		{"/tmp/socket", testSessionToken, 0},
+	} {
+		_, err := NewUnixTransport(tc.path, tc.token, tc.limit)
+		require.ErrorIs(t, err, ErrInvalidTransport)
+	}
+	path := startUnixHTTPServer(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("invalid request reached transport")
+	}))
+	transport, err := NewUnixTransport(path, testSessionToken, 3)
+	require.NoError(t, err)
+	_, err = transport.Prepare(context.Background(), identity, []byte("four"))
+	require.ErrorIs(t, err, ErrInvalidTransport)
+	identity.Digest = "bad"
+	_, err = transport.Commit(context.Background(), identity)
+	require.ErrorIs(t, err, ErrInvalidTransport)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = transport.Readback(ctx)
+	require.True(t, errors.Is(err, context.Canceled))
+
+	one, err := NewSessionToken()
+	require.NoError(t, err)
+	two, err := NewSessionToken()
+	require.NoError(t, err)
+	require.NotEqual(t, one, two)
+	require.Len(t, one, 43)
+}

--- a/components/egress/pkg/revision/transport_unix_test.go
+++ b/components/egress/pkg/revision/transport_unix_test.go
@@ -37,6 +37,15 @@ type testEnvelope struct {
 	Payload  []byte   `json:"payload"`
 }
 
+type marshalProbe struct {
+	called *bool
+}
+
+func (p marshalProbe) MarshalJSON() ([]byte, error) {
+	*p.called = true
+	return nil, errors.New("marshal should not run")
+}
+
 func testIdentity() Identity {
 	return Identity{
 		ControlGeneration: "control-a",
@@ -228,4 +237,15 @@ func TestUnixTransportValidatesConfigurationAndRequests(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, one, two)
 	require.Len(t, one, 43)
+}
+
+func TestUnixTransportChecksCancellationBeforeEncoding(t *testing.T) {
+	transport, err := NewUnixTransport("/tmp/not-used.sock", testSessionToken, 1)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	called := false
+	_, err = transport.do(ctx, http.MethodPost, "/not-used", marshalProbe{called: &called})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, called)
 }

--- a/components/egress/pkg/revision/transport_unix_test.go
+++ b/components/egress/pkg/revision/transport_unix_test.go
@@ -122,6 +122,22 @@ func TestUnixTransportRoundTripContract(t *testing.T) {
 	require.Equal(t, identity, ack)
 }
 
+func TestUnixTransportEncodesZeroLengthPayloadAsBase64String(t *testing.T) {
+	var encoded json.RawMessage
+	path := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]json.RawMessage
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		encoded = request["payload"]
+		identity := testIdentity()
+		writeTestAck(t, w, &identity)
+	}))
+	transport, err := NewUnixTransport(path, testSessionToken, 1)
+	require.NoError(t, err)
+	_, err = transport.Prepare(context.Background(), testIdentity(), nil)
+	require.NoError(t, err)
+	require.JSONEq(t, `""`, string(encoded))
+}
+
 func TestUnixTransportDoesNotFollowRedirects(t *testing.T) {
 	requests := 0
 	path := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/oseps/0023-credential-bound-tls-interception.md
+++ b/oseps/0023-credential-bound-tls-interception.md
@@ -805,10 +805,15 @@ while an operation is unresolved. A failed prepare remains inert, so the prior
 revision is still readable while abort acknowledgement is retried; reads are
 blocked only after commit may have reached the receiver. Reconciliation uses
 metadata-only readback or exact commit/abort retries. Its transport is injected;
-no authenticated IPC or public Vault mutation path uses it yet. Local close cancels pending transport and
-fences completion, but the future adapter must also fence the remote session and
-tear down receiver/connections. Startup/recovery and atomic public-store
-finalization under the shared mutation barrier remain integration work.
+an unused Go adapter now implements its strict JSON contract over a
+caller-provisioned private Unix socket, presents a high-entropy per-session
+bearer token for receiver-side authentication, and rejects malformed, oversized,
+or credential-bearing error responses. The Python
+receiver endpoint, live token handoff, and public Vault mutation path are not
+wired yet. Local close cancels pending transport and fences completion, but the
+future adapter must also fence the remote session and tear down
+receiver/connections. Startup/recovery and atomic public-store finalization under
+the shared mutation barrier remain integration work.
 
 The proxy-side transaction receiver is an in-memory foundation: it validates
 generation/epoch/digest identities, stages immutable bytes, and implements


### PR DESCRIPTION
# Summary

Continue OSEP-0023 after #1775, #1777, #1791, and #1800 with the Go half of the local revision IPC, kept separate from the proxy endpoint and live lifecycle wiring.

- Implement the coordinator's injected `Transport` over short-lived HTTP/1.1 requests on a caller-provisioned private Unix socket.
- Define the exact camelCase JSON identity and base64 payload envelope for prepare, commit, abort, and metadata-only active readback.
- Generate 256-bit per-session bearer tokens and attach them for receiver-side client authentication; control/subject generations remain the independent stale-session fence.
- Reject invalid inputs, oversized payloads/responses, duplicate or unknown response fields, invalid identities, non-JSON responses, missing command acknowledgements, redirects, and trailing response data.
- Keep remote bodies and bearer tokens out of returned errors and formatted transport values.

This package is not constructed by the running egress component. It does not add the Python receiver endpoint, token handoff, socket provisioning, startup/recovery, Vault mutation integration, or TLS decision changes. The current ETag lookup and interception behavior are unchanged. The next candidate can implement the Python endpoint against this reviewed wire contract before either side is enabled.

Related: #1713. This is one internal prerequisite within the revision-transaction phase, not completion of that phase or the public interception mode.

# Testing

- [x] Unit tests
- [x] Existing local Python/mitmproxy integration regression
- [ ] e2e / manual verification (the Python endpoint and live IPC wiring intentionally remain out of scope)

- New Unix transport tests failed before implementation.
- Revision package race tests: 24 tests passed, covering request/response wire fields, empty and active readback, all transaction operations, session token generation, input limits, malformed/duplicate/oversized response rejection, missing acknowledgement, redirect refusal, context cancellation, and secret redaction.
- Full egress Go race suite: 422 tests passed. `go vet ./...`, `go build ./...`, gofmt, license, and diff checks passed.
- Full Python suite with Python 3.12 and mitmproxy 11.0.2: 104 tests passed. Existing timeout tests still emit BrokenPipe/ResourceWarning diagnostics.
- No published docs-site page changed; the docs-site build was not rerun for the OSEP-only progress note.

# Breaking Changes

- [x] None
- [ ] Yes

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (implementation boundary and OSEP progress)
- [x] Added/updated tests
- [x] Security impact considered
- [x] Backward compatibility considered
