### PR TITLE
test(execd): cover foreground command stream completion

### DIFF
--- a/tests/python/README.md
+++ b/tests/python/README.md
@@ -35,6 +35,36 @@ E2E suite:
 ../../scripts/python-e2e.sh
 ```
 
+### Foreground command stream completion
+
+```bash
+uv run --frozen pytest tests/test_command_stream_e2e.py
+```
+
+This Docker bridge matrix uses direct and server-proxied SDK connections, each
+with and without a `dns+nft` egress sidecar. Configure the lifecycle server with
+an execd image and an egress image, and make its published sandbox endpoints
+reachable from the test runner. On Docker Desktop, one option is to run both
+the lifecycle server and the test runner in Docker, use
+`[docker].host_ip = "host.docker.internal"`, and point the SDK at the server's
+published port on that hostname. Leave `[server].eip` unset for this topology.
+The sandbox image must contain `python3`. Kubernetes runs skip this matrix.
+
+The tests cover empty successful commands and approximately 4 MiB of interleaved
+stdout/stderr with successful and nonzero exits. A delayed SDK callback exercises
+buffering; per-stream line order, Unicode tails without final newlines, accumulated
+logs, exit status, and terminal-event ordering must all be preserved through
+HTTP response completion.
+
+Each case emits a `COMMAND_STREAM_METRIC` JSON record. `total_ms` measures the
+SDK command call; `terminal_to_return_ms` measures the interval from the SDK's
+terminal-event callback to the call returning. These measurements support A/B
+validation of command response latency, including #1277/#1661, without imposing
+machine-speed thresholds on CI. Test sandboxes explicitly use a one-second
+`EXECD_API_GRACE_SHUTDOWN`; compare the same test against baseline and candidate
+execd images. Passing the correctness assertions alone does not establish that
+the fixed tail delay has been removed.
+
 ### Notes about asyncio + shared Sandbox
 
 These tests may reuse a single Sandbox instance across multiple test cases for speed.

--- a/tests/python/tests/test_command_stream_e2e.py
+++ b/tests/python/tests/test_command_stream_e2e.py
@@ -1,0 +1,169 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exercise foreground command stream completion over real sandbox transports."""
+
+import asyncio
+import json
+import logging
+import shlex
+import time
+from datetime import timedelta
+
+import pytest
+from opensandbox import Sandbox
+from opensandbox.models.execd import ExecutionHandlers
+from opensandbox.models.sandboxes import NetworkPolicy
+
+from tests.base_e2e_test import (
+    create_connection_config,
+    create_connection_config_server_proxy,
+    get_e2e_sandbox_resource,
+    get_sandbox_image,
+    is_kubernetes_runtime,
+)
+
+logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.skipif(
+    is_kubernetes_runtime(),
+    reason="This matrix requires Docker bridge endpoints reachable from the test runner.",
+)
+
+
+@pytest.fixture(
+    scope="module",
+    params=[(False, False), (True, False), (False, True), (True, True)],
+    ids=["direct", "server-proxy", "direct-egress", "server-proxy-egress"],
+)
+async def stream_sandbox(request):
+    proxy, egress = request.param
+    config = (
+        create_connection_config_server_proxy() if proxy else create_connection_config()
+    )
+    # Exercise both paths even when the surrounding E2E job defaults to proxying.
+    config.use_server_proxy = proxy
+    sandbox = await Sandbox.create(
+        image=get_sandbox_image(),
+        connection_config=config,
+        resource=get_e2e_sandbox_resource(),
+        timeout=timedelta(minutes=5),
+        env={"EXECD_API_GRACE_SHUTDOWN": "1s"},
+        network_policy=NetworkPolicy(defaultAction="allow") if egress else None,
+        metadata={"tag": "command-stream-e2e"},
+    )
+    try:
+        yield sandbox, proxy, egress
+    finally:
+        try:
+            await sandbox.kill()
+        finally:
+            await sandbox.close()
+
+
+@pytest.mark.parametrize("scenario", ["empty", "burst", "burst-error"])
+async def test_foreground_command_stream_completion(stream_sandbox, scenario):
+    sandbox, proxy, egress = stream_sandbox
+    exit_code = 7 if scenario == "burst-error" else 0
+    expected_stdout = []
+    expected_stderr = []
+    command = "true"
+    if scenario != "empty":
+        # Exceed small HTTP/pipe buffers, keep every line distinguishable, and
+        # finish with unterminated lines to exercise the final output drain.
+        expected_stdout = [f"out-{i:04d}-" + "x" * 4096 for i in range(512)]
+        expected_stderr = [f"err-{i:04d}-" + "y" * 4096 for i in range(512)]
+        expected_stdout.append("stdout-tail-你好")
+        expected_stderr.append("stderr-tail-世界")
+        script = (
+            "import sys\n"
+            "for i in range(512):\n"
+            "    sys.stdout.write(f'out-{i:04d}-' + 'x' * 4096 + '\\n')\n"
+            "    sys.stderr.write(f'err-{i:04d}-' + 'y' * 4096 + '\\n')\n"
+            "sys.stdout.write('stdout-tail-你好')\n"
+            "sys.stderr.write('stderr-tail-世界')\n"
+            f"sys.exit({exit_code})\n"
+        )
+        command = "python3 -c " + shlex.quote(script)
+
+    stdout = []
+    stderr = []
+    events = []
+    terminal_at = None
+
+    async def on_init(_):
+        events.append("init")
+        if scenario != "empty":
+            # Leave a real producer running while the SDK consumer is delayed.
+            await asyncio.sleep(0.1)
+
+    async def on_stdout(message):
+        stdout.append(message.text)
+        events.append("stdout")
+
+    async def on_stderr(message):
+        stderr.append(message.text)
+        events.append("stderr")
+
+    async def on_complete(_):
+        nonlocal terminal_at
+        terminal_at = time.perf_counter()
+        events.append("complete")
+
+    async def on_error(_):
+        nonlocal terminal_at
+        terminal_at = time.perf_counter()
+        events.append("error")
+
+    started = time.perf_counter()
+    execution = await sandbox.commands.run(
+        command,
+        handlers=ExecutionHandlers(
+            on_init=on_init,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+            on_execution_complete=on_complete,
+            on_error=on_error,
+        ),
+    )
+    returned = time.perf_counter()
+
+    assert execution.exit_code == exit_code
+    assert (execution.error is None) == (exit_code == 0)
+    assert stdout == expected_stdout
+    assert stderr == expected_stderr
+    assert [message.text for message in execution.logs.stdout] == expected_stdout
+    assert [message.text for message in execution.logs.stderr] == expected_stderr
+    assert events[0] == "init"
+    assert events.count("init") == 1
+    terminal = "error" if exit_code else "complete"
+    assert events[-1] == terminal
+    assert events.count("complete") + events.count("error") == 1
+    assert terminal_at is not None
+
+    # Keep timing observable for A/B validation without imposing a machine-speed
+    # threshold on normal E2E runs (which may use an older published execd).
+    logger.info(
+        "COMMAND_STREAM_METRIC %s",
+        json.dumps(
+            {
+                "proxy": proxy,
+                "egress": egress,
+                "scenario": scenario,
+                "total_ms": round((returned - started) * 1000, 1),
+                "terminal_to_return_ms": round((returned - terminal_at) * 1000, 1),
+                "stdout_lines": len(stdout),
+                "stderr_lines": len(stderr),
+            }
+        ),
+    )


### PR DESCRIPTION
# Summary

Add a Docker E2E matrix for foreground command stream completion through the Python SDK: direct and server-proxied connections, each with and without a `dns+nft` egress sidecar. The 12 cases cover empty commands, approximately 4 MiB of stdout/stderr, nonzero exits, and a delayed SDK consumer. They assert exact per-stream output/order, Unicode tails without final newlines, accumulated logs, exit status, and exactly one terminal event after the output.

Each case logs total call time and terminal-callback-to-return time for reproducible latency comparisons. Correctness is asserted in CI; latency is reported without a machine-speed threshold. Existing Python E2E discovery includes this file automatically. The README documents prerequisites and the Docker Desktop network topology.

This complements the runtime completion fix in #1281 and the user reports in #1277 / #1661. It adds coverage and measurements without copying the runtime fix into another PR.

# Testing

- [x] Real Docker E2E: **12/12 pass on main `4ba17adf`**, **12/12 pass with the #1281 production change applied to that same main**.
- [x] `uv run --frozen ruff check tests/test_command_stream_e2e.py`
- [x] `uv run --frozen ruff format --check tests/test_command_stream_e2e.py`
- [x] `uv run --frozen pyright tests/test_command_stream_e2e.py` (zero errors)
- [x] Kubernetes selection check: all 12 cases skip before sandbox creation when `OPENSANDBOX_E2E_RUNTIME=kubernetes`.
- [ ] Full cross-language E2E suite and Kubernetes runtime validation: not run; this change targets the Docker command transport matrix.

## Local A/B observations

The SDK's empty `true` command returned in:

| Path | Main `4ba17adf` | Main + #1281 completion change |
| --- | --- | --- |
| Direct | 1011.9 ms | 4.9 ms |
| Server proxy | 1016.4 ms | 12.9 ms |
| Direct + egress | 1008.1 ms | 10.2 ms |
| Server proxy + egress | 1013.4 ms | 11.0 ms |

Across all 12 cases, the interval from the SDK terminal-event callback to `commands.run` returning was **913.7–1005.3 ms** on baseline versus **0.3–0.8 ms** on the candidate. Every output assertion passed in both variants. Passing these correctness tests alone does not prove the latency fix; the separately reported measurements provide that evidence for this local run.

Environment: Docker Desktop on macOS ARM64, Docker engine 29.4.1 Linux/ARM64, Python client 3.10.21, Go build toolchain 1.26.4, `python:3.12-slim` sandboxes, egress v1.1.4. Server and Python SDK source use `4ba17adf` with locked dependencies. Both execd binaries use that same source/toolchain/runtime image; the candidate removes the trailing sleep and unused import via a Go overlay, matching the production change reviewed in #1281 at `e6dbf6b7`. This is an isolated-change comparison on current main, not a claim that the entire older PR branch was tested. Only shell command paths were exercised.

Run the same `uv run --frozen pytest tests/test_command_stream_e2e.py` against baseline and candidate execd images using the documented E2E connection settings. The matrix uses real HTTP, Docker sandboxes, and sidecars, with no mocked adapters. All test sandboxes, sidecars, temporary servers, and test-client containers were removed.

# Breaking Changes

- [x] None: test coverage and test-runner documentation only.
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs
- [x] Added/updated tests
- [x] Security impact considered
- [x] Backward compatibility considered
