### PR TITLE
fix(cli): preserve local files when downloads fail

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -220,6 +220,9 @@ osb file replace <sandbox-id> /workspace/app.py --old old --new new -o json
 osb file chmod <sandbox-id> /workspace/script.sh --mode 755 -o json
 ```
 
+Downloads replace the local file only on success; a failed or interrupted
+download preserves any existing file. See the [CLI guide](../docs/cli/index.md#work-with-files).
+
 ### Manage runtime egress policy
 
 Inspect current policy:

--- a/cli/src/opensandbox_cli/commands/file.py
+++ b/cli/src/opensandbox_cli/commands/file.py
@@ -16,8 +16,11 @@
 
 from __future__ import annotations
 
+import os
+import stat
 import sys
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import click
 
@@ -159,15 +162,31 @@ def file_download(
     local_path: str,
     output_format: str | None,
 ) -> None:
-    """Download a file from the sandbox to local disk."""
+    """Download to local disk, preserving existing files on failure."""
     prepare_output(obj, output_format, allowed=("table", "json", "yaml"), fallback="table")
     sandbox = obj.connect_sandbox(sandbox_id)
     try:
         destination = Path(local_path)
         destination.parent.mkdir(parents=True, exist_ok=True)
-        with destination.open("wb") as out:
-            for chunk in sandbox.files.read_bytes_stream(remote_path):
-                out.write(chunk)
+        destination = destination.resolve()
+        try:
+            destination_mode = destination.stat().st_mode
+        except FileNotFoundError:
+            destination_mode = None
+        if destination_mode is not None:
+            if not stat.S_ISREG(destination_mode):
+                raise click.ClickException("Download destination must be a regular file.")
+            # Check write permission without truncating the existing file.
+            os.close(os.open(destination, os.O_WRONLY))
+
+        with TemporaryDirectory(prefix=".osb-download-", dir=destination.parent) as temp_dir:
+            staged = Path(temp_dir) / "download"
+            with staged.open("wb") as out:
+                for chunk in sandbox.files.read_bytes_stream(remote_path):
+                    out.write(chunk)
+            if destination_mode is not None:
+                staged.chmod(destination_mode & 0o777)
+            staged.replace(destination)
         obj.output.success(f"Downloaded: {remote_path} → {local_path}")
     finally:
         sandbox.close()

--- a/cli/src/opensandbox_cli/skills/opensandbox-file-operations.md
+++ b/cli/src/opensandbox_cli/skills/opensandbox-file-operations.md
@@ -119,6 +119,7 @@ Rules:
 
 - use `upload` when the source file is on the host
 - use `download` when the destination should be written to the host filesystem
+- downloads replace the destination only on success; failures and interruptions preserve the existing file
 - use `write` and `cat` only when the operation stays entirely inside the sandbox
 
 ## Metadata and Permissions

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -21,12 +21,15 @@ so the root ``cli`` callback creates our mock instead of a real SDK client.
 from __future__ import annotations
 
 import json
+import os
+import stat
 from datetime import timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
+from opensandbox.exceptions import SandboxApiException
 from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import SandboxImageSpec
 
@@ -834,6 +837,182 @@ class TestFileTransfer:
         assert result.exit_code == 0
         assert local_path.read_bytes() == b"hello"
         mock_sb.files.read_bytes_stream.assert_called_once_with("/tmp/download.txt")
+
+    @pytest.mark.parametrize("existing", [False, True])
+    @pytest.mark.parametrize("failure", ["not_found", "disconnect", "interrupt"])
+    def test_failed_download_preserves_destination(
+        self, runner: CliRunner, tmp_path: Path, existing: bool, failure: str
+    ) -> None:
+        local_path = tmp_path / "result.json"
+        original = b"previous successful result"
+        if existing:
+            local_path.write_bytes(original)
+        mock_sb = MagicMock()
+        if failure == "not_found":
+            mock_sb.files.read_bytes_stream.side_effect = SandboxApiException(
+                "File not found", status_code=404
+            )
+        else:
+            def broken_stream():
+                yield b"partial download"
+                if failure == "interrupt":
+                    raise KeyboardInterrupt
+                raise ConnectionError("Download disconnected")
+
+            mock_sb.files.read_bytes_stream.return_value = broken_stream()
+
+        result = _invoke(
+            runner,
+            ["file", "download", "sb-1", "/workspace/result.json", str(local_path)],
+            sandbox=mock_sb,
+        )
+
+        assert result.exit_code != 0
+        assert "Downloaded:" not in result.output
+        if existing:
+            assert local_path.read_bytes() == original
+        else:
+            assert not local_path.exists()
+        assert set(tmp_path.iterdir()) == ({local_path} if existing else set())
+        mock_sb.close.assert_called_once()
+
+    @pytest.mark.parametrize("chunks", [[], [b"new ", b"result"]])
+    def test_download_replaces_destination_after_stream_completes(
+        self, runner: CliRunner, tmp_path: Path, chunks: list[bytes]
+    ) -> None:
+        local_path = tmp_path / "result.json"
+        original = b"previous successful result"
+        local_path.write_bytes(original)
+
+        def stream():
+            for chunk in chunks:
+                assert local_path.read_bytes() == original
+                yield chunk
+            assert local_path.read_bytes() == original
+
+        mock_sb = MagicMock()
+        mock_sb.files.read_bytes_stream.return_value = stream()
+        result = _invoke(
+            runner,
+            ["file", "download", "sb-1", "/workspace/result.json", str(local_path)],
+            sandbox=mock_sb,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert local_path.read_bytes() == b"".join(chunks)
+        assert set(tmp_path.iterdir()) == {local_path}
+        mock_sb.close.assert_called_once()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file permissions")
+    @pytest.mark.parametrize("existing", [False, True])
+    def test_download_preserves_permissions_and_respects_umask(
+        self, runner: CliRunner, tmp_path: Path, existing: bool
+    ) -> None:
+        local_path = tmp_path / "script.sh"
+        if existing:
+            local_path.write_bytes(b"old script")
+            local_path.chmod(0o754)
+        mock_sb = MagicMock()
+        mock_sb.files.read_bytes_stream.return_value = iter([b"new script"])
+
+        previous_umask = os.umask(0o077)
+        try:
+            result = _invoke(
+                runner,
+                ["file", "download", "sb-1", "/workspace/script.sh", str(local_path)],
+                sandbox=mock_sb,
+            )
+        finally:
+            os.umask(previous_umask)
+
+        assert result.exit_code == 0, result.output
+        assert local_path.read_bytes() == b"new script"
+        assert stat.S_IMODE(local_path.stat().st_mode) == (0o754 if existing else 0o600)
+
+    @pytest.mark.skipif(os.name == "nt", reason="Creating symlinks may require privileges")
+    @pytest.mark.parametrize("existing", [False, True])
+    def test_download_follows_destination_symlink(
+        self, runner: CliRunner, tmp_path: Path, existing: bool
+    ) -> None:
+        target = tmp_path / "target.json"
+        if existing:
+            target.write_bytes(b"old result")
+        link = tmp_path / "link.json"
+        link.symlink_to(target.name)
+        mock_sb = MagicMock()
+        mock_sb.files.read_bytes_stream.return_value = iter([b"new result"])
+
+        result = _invoke(
+            runner,
+            ["file", "download", "sb-1", "/workspace/result.json", str(link)],
+            sandbox=mock_sb,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert link.is_symlink()
+        assert target.read_bytes() == b"new result"
+        assert set(tmp_path.iterdir()) == {link, target}
+
+    @pytest.mark.skipif(
+        os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+        reason="Requires POSIX write permission enforcement",
+    )
+    def test_download_does_not_overwrite_read_only_file(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        local_path = tmp_path / "readonly.json"
+        local_path.write_bytes(b"original")
+        local_path.chmod(0o444)
+        mock_sb = MagicMock()
+
+        result = _invoke(
+            runner,
+            ["file", "download", "sb-1", "/workspace/result.json", str(local_path)],
+            sandbox=mock_sb,
+        )
+
+        assert result.exit_code != 0
+        assert local_path.read_bytes() == b"original"
+        assert set(tmp_path.iterdir()) == {local_path}
+        mock_sb.files.read_bytes_stream.assert_not_called()
+        mock_sb.close.assert_called_once()
+
+    def test_download_rejects_directory_destination(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        mock_sb = MagicMock()
+        result = _invoke(
+            runner,
+            ["file", "download", "sb-1", "/workspace/result.json", str(tmp_path)],
+            sandbox=mock_sb,
+        )
+
+        assert result.exit_code != 0
+        assert tmp_path.is_dir()
+        assert list(tmp_path.iterdir()) == []
+        mock_sb.files.read_bytes_stream.assert_not_called()
+        mock_sb.close.assert_called_once()
+
+    def test_download_preserves_destination_when_replace_fails(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        local_path = tmp_path / "result.json"
+        local_path.write_bytes(b"original")
+        mock_sb = MagicMock()
+        mock_sb.files.read_bytes_stream.return_value = iter([b"complete download"])
+
+        with patch("os.replace", side_effect=PermissionError("Cannot replace file")):
+            result = _invoke(
+                runner,
+                ["file", "download", "sb-1", "/workspace/result.json", str(local_path)],
+                sandbox=mock_sb,
+            )
+
+        assert result.exit_code != 0
+        assert "Downloaded:" not in result.output
+        assert local_path.read_bytes() == b"original"
+        assert set(tmp_path.iterdir()) == {local_path}
+        mock_sb.close.assert_called_once()
 
 
 class TestFileRm:

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -214,6 +214,11 @@ osb file replace <sandbox-id> /workspace/app.py --old old --new new -o json
 osb file chmod <sandbox-id> /workspace/script.sh --mode 755 -o json
 ```
 
+`file download` replaces the local destination only after the entire download
+succeeds. If the download fails or you interrupt it, an existing file stays
+unchanged and temporary download files are removed. The destination directory
+must be writable so the CLI can stage the download before replacing the file.
+
 ### Manage runtime egress policy
 
 Inspect current policy:


### PR DESCRIPTION
# Summary

`osb file download` currently opens the local destination with `wb` before requesting the remote file. A 404 therefore truncates an existing local file, and a dropped connection or Ctrl+C replaces its contents with a partial download.

Stage downloads in a private temporary directory on the destination filesystem and replace the destination only after the stream and output file close successfully. Failures, interruptions, and replacement errors clean up staging and preserve the previous file; a failed download to a new path leaves no destination file.

Preserve ordinary permission bits for existing files, honor umask for new files, follow destination symlinks, and retain the existing write-permission check. Update CLI help, the guide, the package README, and the bundled file-operations skill.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests: `cd cli && uv run --frozen pytest tests/ -q` — 221 passed, including 15 new download cases. The eight core preservation/atomic-visibility cases failed against the original implementation before the fix.
- [x] Integration tests: 20 local HTTP fault-injection cases using independent CLI processes and the real Python SDK, ten each before/after the fix. Covered HTTP 404, truncated Content-Length responses, SIGINT after 256 KiB had been written, a 2 MiB binary download, and empty files, each with an existing/new destination. The original implementation reproduced the data loss; the fixed implementation preserved destinations on all failures, removed staging, and produced identical successful-download hashes.
- [ ] e2e / manual verification with a real sandbox runtime

Also passed `uv run --frozen ruff check`, `uv run --frozen pyright`, `cd docs && pnpm docs:build`, and `git diff --check`. Validation ran on macOS with Python 3.12. Kubernetes and Windows were not exercised; this change is in local CLI file handling.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

The command and flags are unchanged. Atomic replacement requires write access to the destination directory; this requirement is documented.

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
