### PR TITLE
docs(install): use code-group tabs for pip/uv install commands

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -19,19 +19,21 @@ It uses the OpenSandbox Python SDK under the hood and is intended to be the shor
 
 ## Install
 
-Choose one:
+::: code-group
 
-```bash
+```bash [pip]
 pip install opensandbox-cli
 ```
 
-```bash
+```bash [uv]
 uv tool install opensandbox-cli
 ```
 
-```bash
+```bash [pipx]
 pipx install opensandbox-cli
 ```
+
+:::
 
 Confirm the install:
 

--- a/docs/components/server.md
+++ b/docs/components/server.md
@@ -49,9 +49,17 @@ Metadata keys under the reserved prefix `opensandbox.io/` are system-managed and
 
 Install from PyPI. For local development, clone the repo and run `uv sync` in `server/`.
 
-```bash
+::: code-group
+
+```bash [pip]
+pip install opensandbox-server
+```
+
+```bash [uv]
 uv pip install opensandbox-server
 ```
+
+:::
 
 ### Configuration
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,13 +9,17 @@ description: Install OpenSandbox server, SDKs, CLI, and MCP server across all su
 
 The OpenSandbox server is a FastAPI-based service that manages sandbox lifecycles. It supports Docker and Kubernetes runtimes.
 
-```bash
-# Install from PyPI
-uv pip install opensandbox-server
+::: code-group
 
-# Or with pip
+```bash [pip]
 pip install opensandbox-server
 ```
+
+```bash [uv]
+uv pip install opensandbox-server
+```
+
+:::
 
 **Requirements:**
 - Python 3.10+
@@ -99,11 +103,17 @@ dotnet add package Alibaba.OpenSandbox.CodeInterpreter
 
 The `osb` CLI provides terminal-based sandbox management.
 
-```bash
+::: code-group
+
+```bash [pip]
 pip install opensandbox-cli
-# or
+```
+
+```bash [uv]
 uv tool install opensandbox-cli
 ```
+
+:::
 
 See the [CLI reference](/cli/) for the full command set.
 
@@ -111,8 +121,19 @@ See the [CLI reference](/cli/) for the full command set.
 
 The MCP server exposes sandbox operations to MCP-capable clients like Claude Code and Cursor.
 
-```bash
+::: code-group
+
+```bash [pip]
 pip install opensandbox-mcp
+```
+
+```bash [uv]
+uv pip install opensandbox-mcp
+```
+
+:::
+
+```bash
 opensandbox-mcp --domain localhost:8080 --protocol http
 ```
 


### PR DESCRIPTION
## Summary

Installation docs mixed plain code blocks and `::: code-group` tabs for pip/uv commands, inconsistent with the tabbed style already used for SDK language choices on the same page. This aligns all pip/uv/pipx install snippets to the same tabbed pattern.

- `docs/getting-started/installation.md`: Server, CLI, and MCP Server sections now use `::: code-group` with `[pip]` / `[uv]` tabs instead of comment-separated or run-on code blocks.
- `docs/cli/index.md`: the "Choose one:" list of three loose `pip` / `uv` / `pipx` blocks converted to a single `code-group` with matching tabs.
- `docs/components/server.md`: added a missing `pip` tab alongside the existing `uv pip install` command (page text already said "uv (recommended) or pip" but only showed the uv command).

## Not changed

- `docs/examples/docker-ossfs-volume-mount.md`, `docs/examples/host-volume-mount.md`: pip/uv lines there serve a different purpose (PyPI install vs. from-source/venv fallback), not a package-manager choice — left as-is.
- Other `docs/examples/*.md` tutorial pages use `uv` only in combined install+run scripts, no pip alternative offered — out of scope.

## Test plan

- [x] Render docs site locally and confirm tabs display correctly on all three edited pages
- [x] Click through pip/uv (and pipx) tabs to confirm commands are correct per tab
