### PR TITLE
fix(execd): remove command completion delay and align SDK stream handling

### DIFF
--- a/components/execd/pkg/flag/flags.go
+++ b/components/execd/pkg/flag/flags.go
@@ -32,7 +32,7 @@ var (
 	// ServerAccessToken guards API entrypoints when set.
 	ServerAccessToken string
 
-	// ApiGracefulShutdownTimeout waits before tearing down SSE streams.
+	// ApiGracefulShutdownTimeout bounds the fallback wait for execution callbacks.
 	ApiGracefulShutdownTimeout time.Duration
 
 	// JupyterIdlePollInterval controls how often ExecuteCodeStream checks for

--- a/components/execd/pkg/web/controller/command.go
+++ b/components/execd/pkg/web/controller/command.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alibaba/opensandbox/execd/pkg/flag"
 	"github.com/alibaba/opensandbox/execd/pkg/jupyter/execute"
 	"github.com/alibaba/opensandbox/execd/pkg/runtime"
 	"github.com/alibaba/opensandbox/execd/pkg/telemetry"
@@ -113,12 +112,6 @@ func (c *CodeInterpretingController) RunCommand() {
 	}
 
 	waitForExecutionComplete(ctx, completeCh)
-
-	// Keep the SSE connection alive briefly so clients can read all
-	// buffered events and downstream components (e.g. egress sidecar)
-	// have time to synchronise state changes that were triggered
-	// during command execution.
-	time.Sleep(flag.ApiGracefulShutdownTimeout)
 }
 
 // InterruptCommand stops a running shell command session.

--- a/components/execd/pkg/web/controller/command_test.go
+++ b/components/execd/pkg/web/controller/command_test.go
@@ -15,16 +15,138 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	goruntime "runtime"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/alibaba/opensandbox/execd/pkg/flag"
 	"github.com/alibaba/opensandbox/execd/pkg/runtime"
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRunBackgroundCommandClosesHTTPStream(t *testing.T) {
+	previousRunner, previousTimeout := codeRunner, flag.ApiGracefulShutdownTimeout
+	t.Cleanup(func() {
+		codeRunner, flag.ApiGracefulShutdownTimeout = previousRunner, previousTimeout
+	})
+	flag.ApiGracefulShutdownTimeout = 2 * time.Second
+	codeRunner = &fakeCodeRunner{execute: func(request *runtime.ExecuteCodeRequest) error {
+		request.Hooks.OnExecuteInit("exec-test")
+		request.Hooks.OnExecuteComplete(time.Millisecond)
+		return nil
+	}}
+	router := gin.New()
+	router.POST("/command", func(ctx *gin.Context) { NewCodeInterpretingController(ctx).RunCommand() })
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := server.Client()
+	client.Timeout = time.Second // EOF must precede the old fixed sleep.
+	response, err := client.Post(server.URL+"/command", "application/json",
+		strings.NewReader(`{"command":"echo test","background":true}`))
+	require.NoError(t, err)
+	defer response.Body.Close()
+	data, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.Contains(t, string(data), "execution_complete")
+}
+
+func TestRunCommandReturnsPromptlyWhenCanceledAfterExecute(t *testing.T) {
+	previousRunner, previousTimeout := codeRunner, flag.ApiGracefulShutdownTimeout
+	t.Cleanup(func() {
+		codeRunner, flag.ApiGracefulShutdownTimeout = previousRunner, previousTimeout
+	})
+	flag.ApiGracefulShutdownTimeout = 2 * time.Second
+	requestCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	codeRunner = &fakeCodeRunner{execute: func(_ *runtime.ExecuteCodeRequest) error {
+		cancel()
+		return nil
+	}}
+	ctx, _ := newTestContext(http.MethodPost, "/command", []byte(`{"command":"echo test"}`))
+	ctx.Request = ctx.Request.WithContext(requestCtx)
+	start := time.Now()
+	NewCodeInterpretingController(ctx).RunCommand()
+	require.Less(t, time.Since(start), time.Second)
+}
+
+func TestRunCommandRealProcessDrainsOutputBeforeEOF(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+	previousRunner, previousTimeout := codeRunner, flag.ApiGracefulShutdownTimeout
+	t.Cleanup(func() {
+		codeRunner, flag.ApiGracefulShutdownTimeout = previousRunner, previousTimeout
+	})
+	codeRunner = runtime.NewController("", "")
+	flag.ApiGracefulShutdownTimeout = 5 * time.Second
+	router := gin.New()
+	router.POST("/command", func(ctx *gin.Context) { NewCodeInterpretingController(ctx).RunCommand() })
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := server.Client()
+	client.Timeout = 4 * time.Second
+
+	for _, exitCode := range []int{0, 7} {
+		t.Run(fmt.Sprintf("exit-%d", exitCode), func(t *testing.T) {
+			// More than 2 MiB across both streams, followed by unterminated UTF-8
+			// tails. This exercises the real process, log readers and HTTP framing.
+			command := `i=0; while [ "$i" -lt 512 ]; do printf 'out-%04d-%02048d\n' "$i" 0; printf 'err-%04d-%02048d\n' "$i" 0 >&2; i=$((i+1)); done; printf 'stdout-tail-你好'; printf 'stderr-tail-世界' >&2; exit ` + fmt.Sprint(exitCode)
+			body, err := json.Marshal(model.RunCommandRequest{Command: command, Cwd: t.TempDir()})
+			require.NoError(t, err)
+			response, err := client.Post(server.URL+"/command", "application/json", strings.NewReader(string(body)))
+			require.NoError(t, err)
+			defer response.Body.Close()
+			// Delay reading so output can accumulate before the client drains it.
+			time.Sleep(100 * time.Millisecond)
+			data, err := io.ReadAll(response.Body)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, response.StatusCode)
+			var stdout, stderr []string
+			terminalCount := 0
+			for _, frame := range strings.Split(strings.TrimSpace(string(data)), "\n\n") {
+				var event model.ServerStreamEvent
+				require.NoError(t, json.Unmarshal([]byte(frame), &event))
+				switch event.Type {
+				case model.StreamEventTypeStdout, model.StreamEventTypeStderr:
+					require.Zero(t, terminalCount, "output must precede terminal event")
+					if event.Type == model.StreamEventTypeStdout {
+						stdout = append(stdout, event.Text)
+					} else {
+						stderr = append(stderr, event.Text)
+					}
+				case model.StreamEventTypeComplete:
+					require.Zero(t, exitCode)
+					terminalCount++
+				case model.StreamEventTypeError:
+					require.Equal(t, 7, exitCode)
+					require.NotNil(t, event.Error)
+					require.Equal(t, "7", event.Error.EValue)
+					terminalCount++
+				}
+			}
+			require.Equal(t, 1, terminalCount)
+			require.Len(t, stdout, 513)
+			require.Len(t, stderr, 513)
+			for i := 0; i < 512; i++ {
+				require.Equal(t, fmt.Sprintf("out-%04d-%02048d", i, 0), stdout[i])
+				require.Equal(t, fmt.Sprintf("err-%04d-%02048d", i, 0), stderr[i])
+			}
+			require.Equal(t, "stdout-tail-你好", stdout[512])
+			require.Equal(t, "stderr-tail-世界", stderr[512])
+		})
+	}
+}
 
 func TestBuildExecuteCommandRequestForwardsEnvs(t *testing.T) {
 	ctrl := &CodeInterpretingController{}

--- a/docs/components/execd.md
+++ b/docs/components/execd.md
@@ -102,6 +102,12 @@ Windows encoding. Batch files require a shell; use absolute paths instead of
 drive-relative paths such as `C:tool.exe`. See the [OpenAPI reference](/api/)
 for field constraints and executable lookup details.
 
+Command responses close without a fixed grace-period delay. Foreground SDK calls
+read to EOF, preserving trailing output from older servers. For background commands,
+`execution_complete` acknowledges startup; SDK methods that collect command results
+return on this event and close the stream without inferring a process exit code.
+Command completion does not imply asynchronous application readiness or audit delivery.
+
 ### Command output retention
 
 Foreground command output is streamed over SSE and its temporary stdout and
@@ -236,7 +242,7 @@ override it.
 | `--port` | `44772` | HTTP listen port. |
 | `--log-level` | `6` | Log level (0=Emergency, 7=Debug). |
 | `--access-token` | `""` | Optional shared API access token. |
-| `--graceful-shutdown-timeout` | `1s` | SSE tail-drain wait window before closing. |
+| `--graceful-shutdown-timeout` | `1s` | Maximum fallback wait for an execution completion callback before closing SSE. |
 | `--jupyter-idle-poll-interval` | `100ms` | Poll interval after Jupyter reports idle. |
 | `--isolation-config` | `""` | Path to the isolation TOML config (see below). |
 | `--init` | `false` | Run as the sandbox init (OSEP-0018): reap children, forward signals, own the container lifecycle. Set together with `EXECD_INIT`; see [Init mode](#init-mode). |

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/CommandsAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/CommandsAdapter.cs
@@ -98,7 +98,7 @@ internal sealed class CommandsAdapter : IExecdCommands
     {
         return ConsumeExecutionAsync(
             RunStreamAsync(argv, options, cancellationToken), handlers,
-            inferExitCode: !(options?.Background ?? false), cancellationToken);
+            isBackground: options?.Background ?? false, cancellationToken);
     }
 
     public async Task<Execution> RunAsync(
@@ -111,7 +111,7 @@ internal sealed class CommandsAdapter : IExecdCommands
         return await ConsumeExecutionAsync(
             RunStreamAsync(command, options, cancellationToken),
             handlers,
-            inferExitCode: !(options?.Background ?? false),
+            isBackground: options?.Background ?? false,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -185,7 +185,7 @@ internal sealed class CommandsAdapter : IExecdCommands
         return await ConsumeExecutionAsync(
             RunInSessionStreamAsync(sessionId, command, options, cancellationToken),
             handlers,
-            inferExitCode: true,
+            isBackground: false,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -342,7 +342,7 @@ internal sealed class CommandsAdapter : IExecdCommands
     private async Task<Execution> ConsumeExecutionAsync(
         IAsyncEnumerable<ServerStreamEvent> stream,
         ExecutionHandlers? handlers,
-        bool inferExitCode,
+        bool isBackground,
         CancellationToken cancellationToken)
     {
         var execution = new Execution();
@@ -352,9 +352,11 @@ internal sealed class CommandsAdapter : IExecdCommands
         {
             PreserveLegacyInitId(ev, execution);
             await dispatcher.DispatchAsync(ev).ConfigureAwait(false);
+            if (isBackground && ev.Type == ServerStreamEventTypes.ExecutionComplete)
+                break;
         }
 
-        if (inferExitCode)
+        if (!isBackground)
         {
             execution.ExitCode = InferForegroundExitCode(execution);
         }

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/CommandsAdapterTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/CommandsAdapterTests.cs
@@ -29,6 +29,69 @@ namespace OpenSandbox.Tests;
 
 public class CommandsAdapterTests
 {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task BackgroundCommand_StopsAtCompleteAndDisposesStream(bool argv)
+    {
+        using var stream = new CommandEventStream("data: {\"type\":\"execution_complete\"}\n\n", failAtEnd: true);
+        var adapter = CreateAdapter(new StubHttpMessageHandler((_, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream) })));
+        var options = new RunCommandOptions { Background = true };
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var execution = argv
+            ? await adapter.RunAsync(new[] { "sleep", "30" }, options, cancellationToken: timeout.Token)
+            : await adapter.RunAsync("sleep 30", options, cancellationToken: timeout.Token);
+        execution.Complete.Should().NotBeNull();
+        execution.ExitCode.Should().BeNull();
+        stream.Disposed.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ForegroundCommand_DrainsAndDisposesStream(bool failure, bool lateOutput)
+    {
+        var terminal = failure
+            ? "data: {\"type\":\"error\",\"error\":{\"ename\":\"CommandExecError\",\"evalue\":\"7\"}}\n\n"
+            : "data: {\"type\":\"execution_complete\"}\n\n";
+        var output = "data: {\"type\":\"stdout\",\"text\":\"tail\"}\n\ndata: {\"type\":\"stderr\",\"text\":\"error-tail\"}\n\n";
+        using var stream = new CommandEventStream(lateOutput ? terminal + output : output + terminal);
+        var adapter = CreateAdapter(new StubHttpMessageHandler((_, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream) })));
+        var execution = await adapter.RunAsync("echo test");
+        execution.Logs.Stdout.Should().ContainSingle().Which.Text.Should().Be("tail");
+        execution.Logs.Stderr.Should().ContainSingle().Which.Text.Should().Be("error-tail");
+        execution.ExitCode.Should().Be(failure ? 7 : 0);
+        stream.Exhausted.Should().BeTrue();
+        stream.Disposed.Should().BeTrue();
+    }
+
+    private sealed class CommandEventStream(string text, bool failAtEnd = false)
+        : MemoryStream(Encoding.UTF8.GetBytes(text))
+    {
+        public bool Disposed { get; private set; }
+        public bool Exhausted { get; private set; }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (Position == Length)
+            {
+                if (failAtEnd) throw new IOException("Stream interrupted after terminal event");
+                Exhausted = true;
+            }
+            return base.ReadAsync(buffer[..Math.Min(buffer.Length, 7)], cancellationToken);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
     [Fact]
     public async Task NativeArgv_ShouldRejectInvalidInputsBeforeSending()
     {

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -132,7 +132,25 @@ func (e *ExecdClient) DeleteSession(ctx context.Context, sessionID string) error
 
 // RunCommand executes a shell command and streams output events via SSE.
 func (e *ExecdClient) RunCommand(ctx context.Context, req RunCommandRequest, handler EventHandler) error {
-	return e.client.doStreamRequest(ctx, http.MethodPost, "/command", req, handler)
+	if !req.Background {
+		return e.client.doStreamRequest(ctx, http.MethodPost, "/command", req, handler)
+	}
+	// Returning a private sentinel closes the response without masking callback errors.
+	complete := fmt.Errorf("background command started")
+	err := e.client.doStreamRequest(ctx, http.MethodPost, "/command", req, func(event StreamEvent) error {
+		if err := handler(event); err != nil {
+			return err
+		}
+		var payload struct{ Type string }
+		if json.Unmarshal([]byte(event.Data), &payload) == nil && payload.Type == "execution_complete" {
+			return complete
+		}
+		return nil
+	})
+	if err == complete {
+		return nil
+	}
+	return err
 }
 
 // InterruptCommand interrupts the currently running command execution.

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -2667,3 +2667,90 @@ func TestCreateSandbox_WithVolumes(t *testing.T) {
 	})
 	require.NoErrorf(t, err, "CreateSandbox with Volumes")
 }
+
+func TestRunCommandBackgroundStopsAtComplete(t *testing.T) {
+	for _, callbackFails := range []bool{false, true} {
+		t.Run(fmt.Sprint(callbackFails), func(t *testing.T) {
+			closed := make(chan struct{})
+			release := make(chan struct{})
+			defer close(release)
+			_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
+				io.Copy(io.Discard, r.Body)
+				fmt.Fprint(w, "data: {\"type\":\"execution_complete\"}\n\n")
+				w.(http.Flusher).Flush()
+				select { // No EOF: the client must close the response.
+				case <-r.Context().Done():
+					close(closed)
+				case <-release:
+				}
+			})
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			callbackErr := fmt.Errorf("callback failed")
+			calls := 0
+			err := client.RunCommand(ctx, RunCommandRequest{Command: "sleep 30", Background: true}, func(StreamEvent) error {
+				calls++
+				if callbackFails {
+					return callbackErr
+				}
+				return nil
+			})
+			if callbackFails {
+				require.ErrorIs(t, err, callbackErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, 1, calls)
+			select {
+			case <-closed:
+			case <-time.After(time.Second):
+				t.Fatal("response was not closed")
+			}
+		})
+	}
+}
+
+func TestRunCommandForegroundDrainsTerminalStream(t *testing.T) {
+	for _, failure := range []bool{false, true} {
+		for _, late := range []bool{false, true} {
+			t.Run(fmt.Sprintf("failure=%v/late=%v", failure, late), func(t *testing.T) {
+				terminal := `{"type":"execution_complete"}`
+				if failure {
+					terminal = `{"type":"error","error":{"ename":"CommandExecError","evalue":"7"}}`
+				}
+				output := []string{`{"type":"stdout","text":"tail"}`, `{"type":"stderr","text":"error-tail"}`}
+				frames := append(append([]string{}, output...), terminal)
+				if late {
+					frames = append([]string{terminal}, output...)
+				}
+				_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
+					for _, frame := range frames {
+						fmt.Fprint(w, "data: "+frame[:7])
+						w.(http.Flusher).Flush()
+						fmt.Fprint(w, frame[7:]+"\n\n")
+						w.(http.Flusher).Flush()
+					}
+				})
+				var got []string
+				err := client.RunCommand(context.Background(), RunCommandRequest{Command: "echo test"}, func(event StreamEvent) error {
+					got = append(got, event.Data)
+					return nil
+				})
+				require.NoError(t, err)
+				require.Equal(t, frames, got)
+			})
+		}
+	}
+}
+
+func TestSandboxBackgroundResultAcknowledgesStartup(t *testing.T) {
+	_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "{\"type\":\"init\",\"text\":\"background-id\"}\n\n{\"type\":\"execution_complete\"}\n\n")
+	})
+	sandbox := &Sandbox{execd: client}
+	result, err := sandbox.RunCommandWithOpts(context.Background(), RunCommandRequest{Command: "sleep 30", Background: true}, nil)
+	require.NoError(t, err)
+	require.Equal(t, "background-id", result.ID)
+	require.NotNil(t, result.Complete)
+	require.True(t, result.ExitCode == nil, "startup does not establish a process exit code")
+}

--- a/sdks/sandbox/go/sandbox_exec.go
+++ b/sdks/sandbox/go/sandbox_exec.go
@@ -34,10 +34,11 @@ func (s *Sandbox) RunCommandWithOpts(ctx context.Context, req RunCommandRequest,
 	err := s.execd.RunCommand(ctx, req, func(event StreamEvent) error {
 		return processStreamEvent(exec, event, handlers)
 	})
-	if err != nil {
-		return exec, err
+	if req.Background {
+		// Completion acknowledges startup, not the background process exit.
+		exec.ExitCode = nil
 	}
-	return exec, nil
+	return exec, err
 }
 
 // ExecuteCode executes code in a context and streams output via SSE.

--- a/sdks/sandbox/javascript/src/adapters/commandsAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/commandsAdapter.ts
@@ -219,8 +219,8 @@ export class CommandsAdapter implements ExecdCommands {
       await dispatcher.dispatch(ev as any);
       if (isBackground && ev.type === "execution_complete") {
         // Background commands are done once execution_complete arrives; do
-        // not wait for the chunked terminator, which execd sends only after
-        // a graceful-shutdown sleep and can be lost if the connection is
+        // not wait for the chunked terminator, which older execd versions
+        // delay with a grace-period sleep and can be lost if the connection is
         // closed early (#1528).
         break;
       }

--- a/sdks/sandbox/javascript/src/adapters/sse.ts
+++ b/sdks/sandbox/javascript/src/adapters/sse.ts
@@ -101,5 +101,6 @@ export async function* parseJsonEventStream<T>(
     // instead of staying locked and holding the transport connection
     // open (#1528, #1532).
     await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
   }
 }

--- a/sdks/sandbox/javascript/tests/commands.run.test.mjs
+++ b/sdks/sandbox/javascript/tests/commands.run.test.mjs
@@ -288,3 +288,32 @@ test("native argv rejects invalid inputs before transport", async () => {
   }
   assert.equal(requests, 0);
 });
+
+for (const failure of [false, true]) {
+  for (const lateOutput of [false, true]) {
+    test(`foreground drains and releases stream: failure=${failure}, lateOutput=${lateOutput}`, async () => {
+      const terminal = failure
+        ? {type: "error", error: {ename: "CommandExecError", evalue: "7", traceback: []}}
+        : {type: "execution_complete", execution_time: 1};
+      const output = [{type: "stdout", text: "tail"}, {type: "stderr", text: "error-tail"}];
+      const events = lateOutput ? [terminal, ...output] : [...output, terminal];
+      const chunks = events.flatMap((event) => {
+        const frame = new TextEncoder().encode(`data: ${JSON.stringify({...event, timestamp: 1})}\n\n`);
+        return [frame.slice(0, 7), frame.slice(7)];
+      });
+      let exhausted = false;
+      const stream = new ReadableStream({
+        pull(controller) {
+          if (chunks.length) controller.enqueue(chunks.shift());
+          else { exhausted = true; controller.close(); }
+        },
+      });
+      const execution = await createAdapter(stream).run("echo test");
+      assert.deepEqual(execution.logs.stdout.map((item) => item.text), ["tail"]);
+      assert.deepEqual(execution.logs.stderr.map((item) => item.text), ["error-tail"]);
+      assert.equal(execution.exitCode, failure ? 7 : 0);
+      assert.equal(exhausted, true);
+      assert.equal(stream.locked, false);
+    });
+  }
+}

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapter.kt
@@ -101,7 +101,7 @@ internal class CommandsAdapter(
             return executeStreamingRequest(
                 httpRequest = httpRequest,
                 handlers = request.handlers,
-                inferExitCode = !request.background,
+                isBackground = request.background,
                 failureMessage = { statusCode, errorBody ->
                     "Failed to run commands. Status code: $statusCode, Body: $errorBody"
                 },
@@ -219,7 +219,7 @@ internal class CommandsAdapter(
             return executeStreamingRequest(
                 httpRequest = httpRequest,
                 handlers = request.handlers,
-                inferExitCode = true,
+                isBackground = false,
                 failureMessage = { statusCode, errorBody ->
                     "run_in_session failed. Status: $statusCode, Body: $errorBody"
                 },
@@ -245,7 +245,7 @@ internal class CommandsAdapter(
     private fun executeStreamingRequest(
         httpRequest: Request,
         handlers: ExecutionHandlers?,
-        inferExitCode: Boolean,
+        isBackground: Boolean,
         failureMessage: (Int, String?) -> String,
     ): Execution {
         val execution = Execution()
@@ -255,19 +255,19 @@ internal class CommandsAdapter(
 
             response.body?.byteStream()?.bufferedReader(Charsets.UTF_8)?.use { reader ->
                 val dispatcher = ExecutionEventDispatcher(execution, handlers)
-                reader.lineSequence().forEach { line ->
-                    decodeEventLine(line)?.let { eventNode ->
-                        try {
-                            dispatcher.dispatch(eventNode)
-                        } catch (e: Exception) {
-                            logger.error("Failed to dispatch SSE event: {}", eventNode, e)
-                        }
+                for (line in reader.lineSequence()) {
+                    val eventNode = decodeEventLine(line) ?: continue
+                    try {
+                        dispatcher.dispatch(eventNode)
+                    } catch (e: Exception) {
+                        logger.error("Failed to dispatch SSE event: {}", eventNode, e)
                     }
+                    if (isBackground && eventNode.type == "execution_complete") break
                 }
             }
         }
 
-        if (inferExitCode) {
+        if (!isBackground) {
             execution.exitCode = inferForegroundExitCode(execution)
         }
         return execution

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapterTest.kt
@@ -40,6 +40,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -78,6 +79,51 @@ class CommandsAdapterTest {
     fun tearDown() {
         mockWebServer.shutdown()
         httpClientProvider.close()
+    }
+
+    @Test
+    fun `background returns before EOF for shell and argv commands`() {
+        val complete = """data: {"timestamp":1,"type":"execution_complete","execution_time":1}""" + "\n\n"
+        for (argv in listOf(false, true)) {
+            mockWebServer.enqueue(
+                MockResponse().setBody(complete + "unread tail")
+                    .throttleBody(complete.toByteArray().size.toLong(), 3, TimeUnit.SECONDS),
+            )
+            val request = RunCommandRequest.builder().background(true)
+            if (argv) request.argv(listOf("sleep", "30")) else request.command("sleep 30")
+            assertTimeoutPreemptively(Duration.ofSeconds(2)) {
+                val result = commandsAdapter.run(request.build())
+                assertTrue(result.complete != null)
+                assertEquals(null, result.exitCode)
+            }
+            val pool = httpClientProvider.sseClient.connectionPool
+            assertEquals(pool.idleConnectionCount(), pool.connectionCount(), "response still holds a connection")
+        }
+    }
+
+    @Test
+    fun `foreground drains immediate EOF and output after terminal`() {
+        for (failure in listOf(false, true)) {
+            for (late in listOf(false, true)) {
+                val terminal =
+                    if (failure) {
+                        """data: {"timestamp":1,"type":"error","error":{"ename":"CommandExecError","evalue":"7"}}"""
+                    } else {
+                        """data: {"timestamp":1,"type":"execution_complete","execution_time":1}"""
+                    }
+                val output =
+                    listOf(
+                        """data: {"timestamp":1,"type":"stdout","text":"tail"}""",
+                        """data: {"timestamp":1,"type":"stderr","text":"error-tail"}""",
+                    )
+                val frames = if (late) listOf(terminal) + output else output + terminal
+                mockWebServer.enqueue(MockResponse().setChunkedBody(frames.joinToString("\n\n") + "\n\n", 7))
+                val result = commandsAdapter.run(RunCommandRequest.builder().command("echo test").build())
+                assertEquals(listOf("tail"), result.logs.stdout.map { it.text })
+                assertEquals(listOf("error-tail"), result.logs.stderr.map { it.text })
+                assertEquals(if (failure) 7 else 0, result.exitCode)
+            }
+        }
     }
 
     @Test

--- a/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
@@ -232,10 +232,12 @@ class CommandsAdapter(Commands):
                 if event_node is None:
                     continue
                 await dispatcher.dispatch(event_node)
+                # Foreground responses drain to EOF: older servers may emit
+                # trailing output after the completion event.
                 if is_background and event_node.type == "execution_complete":
                     # Background commands are done once execution_complete
                     # arrives; do not wait for the chunked terminator, which
-                    # execd sends only after a graceful-shutdown sleep and can
+                    # older execd versions delay with a grace-period sleep and can
                     # be lost if the connection is closed early (#1528).
                     break
 

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
@@ -201,10 +201,12 @@ class CommandsAdapterSync(CommandsSync):
                 if event_node is None:
                     continue
                 dispatcher.dispatch(event_node)
+                # Foreground responses drain to EOF: older servers may emit
+                # trailing output after the completion event.
                 if is_background and event_node.type == "execution_complete":
                     # Background commands are done once execution_complete
                     # arrives; do not wait for the chunked terminator, which
-                    # execd sends only after a graceful-shutdown sleep and can
+                    # older execd versions delay with a grace-period sleep and can
                     # be lost if the connection is closed early (#1528).
                     break
 

--- a/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator
 from datetime import timedelta
 
 import httpx
@@ -374,3 +375,56 @@ async def test_run_rejects_unsupported_command_types(command) -> None:
 
     with pytest.raises(InvalidArgumentException, match="shell text or an argv list"):
         await adapter.run(command)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [False, True])
+@pytest.mark.parametrize("late_output", [False, True])
+async def test_foreground_drains_terminal_response_and_closes_stream(
+    failure: bool, late_output: bool
+) -> None:
+    """Handle immediate EOF from fixed execd and trailing output from older execd."""
+    terminal = (
+        {"type": "error", "error": {"ename": "CommandExecError", "evalue": "7", "traceback": []}}
+        if failure else
+        {"type": "execution_complete", "execution_time": 5}
+    )
+    output = [
+        {"type": "stdout", "text": "last stdout"},
+        {"type": "stderr", "text": "last stderr"},
+    ]
+    events = [terminal, *output] if late_output else [*output, terminal]
+
+    class Stream(httpx.AsyncByteStream):
+        closed = False
+        exhausted = False
+
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            for timestamp, event in enumerate(events, start=1):
+                frame = f"data: {json.dumps({'timestamp': timestamp, **event})}\n\n".encode()
+                # Split frames across reads to exercise incremental SSE decoding.
+                yield frame[:7]
+                yield frame[7:]
+            self.exhausted = True
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    stream = Stream()
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200, headers={"Content-Type": "text/event-stream"}, stream=stream
+        )
+    )
+    cfg = ConnectionConfig(protocol="http", transport=transport)
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+    adapter = CommandsAdapter(cfg, endpoint)
+
+    execution = await adapter.run("echo test")
+
+    assert [item.text for item in execution.logs.stdout] == ["last stdout"]
+    assert [item.text for item in execution.logs.stderr] == ["last stderr"]
+    assert execution.exit_code == (7 if failure else 0)
+    assert (execution.complete is None) == failure
+    assert stream.exhausted
+    assert stream.closed

--- a/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from datetime import timedelta
 
 import httpx
@@ -317,3 +318,55 @@ def test_run_rejects_unsupported_command_types(command) -> None:
 
     with pytest.raises(InvalidArgumentException, match="shell text or an argv list"):
         adapter.run(command)
+
+
+@pytest.mark.parametrize("failure", [False, True])
+@pytest.mark.parametrize("late_output", [False, True])
+def test_foreground_drains_terminal_response_and_closes_stream(
+    failure: bool, late_output: bool
+) -> None:
+    """Handle immediate EOF from fixed execd and trailing output from older execd."""
+    terminal = (
+        {"type": "error", "error": {"ename": "CommandExecError", "evalue": "7", "traceback": []}}
+        if failure else
+        {"type": "execution_complete", "execution_time": 5}
+    )
+    output = [
+        {"type": "stdout", "text": "last stdout"},
+        {"type": "stderr", "text": "last stderr"},
+    ]
+    events = [terminal, *output] if late_output else [*output, terminal]
+
+    class Stream(httpx.SyncByteStream):
+        closed = False
+        exhausted = False
+
+        def __iter__(self) -> Iterator[bytes]:
+            for timestamp, event in enumerate(events, start=1):
+                frame = f"data: {json.dumps({'timestamp': timestamp, **event})}\n\n".encode()
+                # Split frames across reads to exercise incremental SSE decoding.
+                yield frame[:7]
+                yield frame[7:]
+            self.exhausted = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    stream = Stream()
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200, headers={"Content-Type": "text/event-stream"}, stream=stream
+        )
+    )
+    cfg = ConnectionConfigSync(protocol="http", transport=transport)
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+    adapter = CommandsAdapterSync(cfg, endpoint)
+
+    execution = adapter.run("echo test")
+
+    assert [item.text for item in execution.logs.stdout] == ["last stdout"]
+    assert [item.text for item in execution.logs.stderr] == ["last stderr"]
+    assert execution.exit_code == (7 if failure else 0)
+    assert (execution.complete is None) == failure
+    assert stream.exhausted
+    assert stream.closed


### PR DESCRIPTION
# Summary

Every command response currently waits an extra second after execution completes. Remove this fixed delay while retaining output flushing and heartbeat cleanup. Foreground SDK calls continue reading to EOF so trailing output from older servers is preserved; background result collection returns on startup acknowledgement and releases the stream consistently across Python, JavaScript, Go, Kotlin, and C#, without treating startup as process exit.

Add regression coverage for foreground output, background startup acknowledgement, and response cleanup. Document command completion semantics.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
  - Real process tests cover stdout/stderr delivery, successful and failed execution, and handler completion; SDK tests cover trailing events and background streams whose EOF is delayed.
- [x] e2e / manual verification
  - Local Docker: OpenCode and pi completed real inference tasks through direct, lifecycle-proxy, and proxy-plus-egress paths. Large stdout/stderr, UTF-8 tails, nonzero exits, and concurrent commands passed.
  - Local A/B command samples reduced median terminal-event-to-return latency from 1001.82 ms to 0.45 ms (three samples per version).

Kubernetes and Windows were not tested. Real agent inference preceded the final SDK alignment; subsequent Go/JavaScript Docker smoke tests covered the aligned behavior without repeating inference.

# Breaking Changes

- [ ] None
- [x] Yes (describe impact and migration path)

Public API/SDK signatures and SSE event schemas are unchanged. Background result collection in Go, Kotlin, and C# now returns on startup acknowledgement, matching Python and JavaScript; it no longer waits for EOF or infers exit code 0. Callers must query command status for the eventual process outcome instead of treating startup completion as successful process exit.

Commands no longer include a fixed one-second delay. Callers that rely on asynchronous application readiness must explicitly wait for it. Foreground calls still read to EOF for compatibility with older servers.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
