### PR TITLE
fix(sdk): reject negative readiness polling interval in Python and JavaScript

### DIFF
--- a/sdks/sandbox/javascript/src/internal/readiness.ts
+++ b/sdks/sandbox/javascript/src/internal/readiness.ts
@@ -12,7 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { SandboxApiException, SandboxReadyTimeoutException } from "../core/exceptions.js";
+import {
+  InvalidArgumentException,
+  SandboxApiException,
+  SandboxReadyTimeoutException,
+} from "../core/exceptions.js";
+
+export function validatePollingInterval(interval: number): void {
+  // setTimeout() runs a negative delay immediately, which would hammer the
+  // endpoint until the deadline. The Python SDK rejects the same values.
+  if (interval < 0) {
+    throw new InvalidArgumentException({
+      message: `Ready polling interval must not be negative, got: ${interval}`,
+    });
+  }
+}
 
 export class ReadinessBudget {
   private readonly deadline: number;

--- a/sdks/sandbox/javascript/src/sandbox.ts
+++ b/sdks/sandbox/javascript/src/sandbox.ts
@@ -49,7 +49,7 @@ import type {
   SandboxMetadataPatch,
   Volume,
 } from "./models/sandboxes.js";
-import { ReadinessBudget } from "./internal/readiness.js";
+import { ReadinessBudget, validatePollingInterval } from "./internal/readiness.js";
 
 const HOST_PATH_PATTERN = /^([/]|[A-Za-z]:[\\/])/;
 
@@ -358,6 +358,9 @@ export class Sandbox {
     if ((opts.image == null) === (opts.snapshotId == null)) {
       throw new Error("Exactly one of image or snapshotId must be provided");
     }
+    if (!(opts.skipHealthCheck ?? false) && opts.healthCheckPollingInterval !== undefined) {
+      validatePollingInterval(opts.healthCheckPollingInterval);
+    }
 
     // Validate volumes before allocating transport resources.
     if (opts.volumes) {
@@ -547,6 +550,8 @@ export class Sandbox {
 
   static async connect(opts: SandboxConnectOptions): Promise<Sandbox> {
     throwIfAborted(opts.signal);
+    const interval = opts.healthCheckPollingInterval ?? DEFAULT_HEALTH_CHECK_POLLING_INTERVAL_MILLIS;
+    validatePollingInterval(interval);
     const baseConnectionConfig =
       opts.connectionConfig instanceof ConnectionConfig
         ? opts.connectionConfig
@@ -567,7 +572,6 @@ export class Sandbox {
     }
 
     const budget = new ReadinessBudget(opts.readyTimeoutSeconds ?? DEFAULT_READY_TIMEOUT_SECONDS, opts.signal);
-    const interval = opts.healthCheckPollingInterval ?? DEFAULT_HEALTH_CHECK_POLLING_INTERVAL_MILLIS;
     try {
       const endpoint = await budget.endpoint(signal => sandboxes.getSandboxEndpoint(
         opts.sandboxId, DEFAULT_EXECD_PORT, connectionConfig.useServerProxy, signal,
@@ -656,6 +660,9 @@ export class Sandbox {
       healthCheckPollingInterval?: number;
     } = {}
   ): Promise<Sandbox> {
+    if (opts.healthCheckPollingInterval !== undefined) {
+      validatePollingInterval(opts.healthCheckPollingInterval);
+    }
     await this.sandboxes.resumeSandbox(this.id);
     return await Sandbox.connect({
       sandboxId: this.id,
@@ -671,6 +678,9 @@ export class Sandbox {
    * Resume a paused sandbox by id, then connect to its execd endpoint.
    */
   static async resume(opts: SandboxConnectOptions): Promise<Sandbox> {
+    if (opts.healthCheckPollingInterval !== undefined) {
+      validatePollingInterval(opts.healthCheckPollingInterval);
+    }
     const baseConnectionConfig =
       opts.connectionConfig instanceof ConnectionConfig
         ? opts.connectionConfig
@@ -785,6 +795,7 @@ export class Sandbox {
     healthCheck?: (sbx: Sandbox) => boolean | Promise<boolean>;
     signal?: AbortSignal;
   }): Promise<void> {
+    validatePollingInterval(opts.pollingIntervalMillis);
     const budget = new ReadinessBudget(opts.readyTimeoutSeconds, opts.signal);
     await this.checkReadiness(budget, opts.pollingIntervalMillis, opts.healthCheck);
   }

--- a/sdks/sandbox/javascript/tests/sandbox.polling-interval.test.mjs
+++ b/sdks/sandbox/javascript/tests/sandbox.polling-interval.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ConnectionConfig, InvalidArgumentException, Sandbox } from "../dist/index.js";
+
+function createAdapterFactory() {
+  const calls = [];
+  const sandboxes = {
+    async createSandbox() {
+      calls.push("createSandbox");
+      return { id: "sbx-1", expiresAt: null };
+    },
+    async getSandboxEndpoint(sandboxId, port) {
+      calls.push("getSandboxEndpoint");
+      return { endpoint: `sandbox.internal:${port}`, headers: {} };
+    },
+    async resumeSandbox() {
+      calls.push("resumeSandbox");
+    },
+    async getSandbox() {
+      throw new Error("not implemented");
+    },
+    async deleteSandbox() {
+      calls.push("deleteSandbox");
+    },
+  };
+  const adapterFactory = {
+    createLifecycleStack() {
+      return { sandboxes };
+    },
+    createExecdStack() {
+      return {
+        commands: {},
+        files: {},
+        health: {
+          async ping() {
+            calls.push("ping");
+            return false;
+          },
+        },
+        metrics: {},
+      };
+    },
+    createEgressStack() {
+      return { egress: {} };
+    },
+  };
+  return { adapterFactory, calls };
+}
+
+function connectionConfig() {
+  const config = new ConnectionConfig({ domain: "http://127.0.0.1:8080" });
+  config.withTransportIfMissing = () => config;
+  return config;
+}
+
+const operations = {
+  create: (adapterFactory, interval) =>
+    Sandbox.create({
+      adapterFactory,
+      connectionConfig: connectionConfig(),
+      image: "python:3.12",
+      readyTimeoutSeconds: 1,
+      healthCheckPollingInterval: interval,
+    }),
+  connect: (adapterFactory, interval) =>
+    Sandbox.connect({
+      sandboxId: "sbx-1",
+      adapterFactory,
+      connectionConfig: connectionConfig(),
+      readyTimeoutSeconds: 1,
+      healthCheckPollingInterval: interval,
+    }),
+  resume: (adapterFactory, interval) =>
+    Sandbox.resume({
+      sandboxId: "sbx-1",
+      adapterFactory,
+      connectionConfig: connectionConfig(),
+      readyTimeoutSeconds: 1,
+      healthCheckPollingInterval: interval,
+    }),
+};
+
+for (const [name, run] of Object.entries(operations)) {
+  test(`Sandbox.${name} rejects a negative health check polling interval before any request`, async () => {
+    const { adapterFactory, calls } = createAdapterFactory();
+
+    await assert.rejects(run(adapterFactory, -1), InvalidArgumentException);
+    assert.deepEqual(calls, []);
+  });
+}
+
+test("Sandbox.create ignores the polling interval when the health check is skipped", async () => {
+  const { adapterFactory, calls } = createAdapterFactory();
+
+  await Sandbox.create({
+    adapterFactory,
+    connectionConfig: connectionConfig(),
+    image: "python:3.12",
+    skipHealthCheck: true,
+    healthCheckPollingInterval: -1,
+  });
+
+  assert.deepEqual(calls, ["createSandbox", "getSandboxEndpoint", "getSandboxEndpoint"]);
+});

--- a/sdks/sandbox/python/src/opensandbox/internal/readiness.py
+++ b/sdks/sandbox/python/src/opensandbox/internal/readiness.py
@@ -22,7 +22,11 @@ from typing import Any, TypeVar
 
 import httpx
 
-from opensandbox.exceptions import SandboxApiException, SandboxReadyTimeoutException
+from opensandbox.exceptions import (
+    InvalidArgumentException,
+    SandboxApiException,
+    SandboxReadyTimeoutException,
+)
 from opensandbox.transport._deadline_sync import DEADLINE_EXTENSION
 
 T = TypeVar("T")
@@ -56,8 +60,18 @@ def is_readiness_auth_error(error: Exception) -> bool:
     return isinstance(error, SandboxApiException) and error.status_code in (401, 403)
 
 
+def validate_polling_interval(interval: timedelta) -> None:
+    # asyncio.sleep() returns immediately for negative delays (hammering the
+    # health endpoint until the deadline) while time.sleep() raises ValueError.
+    if interval < timedelta(0):
+        raise InvalidArgumentException(
+            f"Ready polling interval must not be negative, got: {interval}"
+        )
+
+
 class ReadinessBudget:
     def __init__(self, timeout: timedelta, interval: timedelta) -> None:
+        validate_polling_interval(interval)
         self.timeout = timeout
         self.context: str | None = None
         self.attempts = 0

--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -33,7 +33,10 @@ from opensandbox.exceptions import (
     SandboxInternalException,
 )
 from opensandbox.internal.lifecycle_metrics import report_sandbox_create_metric
-from opensandbox.internal.readiness import ReadinessBudget
+from opensandbox.internal.readiness import (
+    ReadinessBudget,
+    validate_polling_interval,
+)
 from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import (
     CreateSnapshotRequest,
@@ -526,6 +529,8 @@ class Sandbox:
             raise InvalidArgumentException(
                 "Exactly one of image or snapshot_id must be specified"
             )
+        if not skip_health_check:
+            validate_polling_interval(health_check_polling_interval)
 
         config = (connection_config or ConnectionConfig()).with_transport_if_missing()
         entrypoint = entrypoint or ["tail", "-f", "/dev/null"]
@@ -751,6 +756,7 @@ class Sandbox:
         if not sandbox_id:
             raise InvalidArgumentException("Sandbox ID must be specified")
         sandbox_id = str(sandbox_id)
+        validate_polling_interval(health_check_polling_interval)
 
         config = (connection_config or ConnectionConfig()).with_transport_if_missing()
 

--- a/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
@@ -31,7 +31,10 @@ from opensandbox.exceptions import (
     SandboxInternalException,
 )
 from opensandbox.internal.lifecycle_metrics import report_sandbox_create_metric
-from opensandbox.internal.readiness import ReadinessBudget
+from opensandbox.internal.readiness import (
+    ReadinessBudget,
+    validate_polling_interval,
+)
 from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import (
     CreateSnapshotRequest,
@@ -521,6 +524,8 @@ class SandboxSync:
             raise InvalidArgumentException(
                 "Exactly one of image or snapshot_id must be specified"
             )
+        if not skip_health_check:
+            validate_polling_interval(health_check_polling_interval)
 
         config = (
             connection_config or ConnectionConfigSync()
@@ -738,6 +743,7 @@ class SandboxSync:
             raise InvalidArgumentException("Sandbox ID must be specified")
 
         sandbox_id = str(sandbox_id)
+        validate_polling_interval(health_check_polling_interval)
 
         config = (
             connection_config or ConnectionConfigSync()

--- a/sdks/sandbox/python/tests/test_readiness_polling_interval.py
+++ b/sdks/sandbox/python/tests/test_readiness_polling_interval.py
@@ -1,0 +1,120 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Negative readiness polling intervals are rejected before any request."""
+
+from datetime import timedelta
+
+import httpx
+import pytest
+
+from opensandbox.config import ConnectionConfig
+from opensandbox.config.connection_sync import ConnectionConfigSync
+from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
+from opensandbox.internal.readiness import ReadinessBudget
+from opensandbox.sandbox import Sandbox
+from opensandbox.sync.sandbox import SandboxSync
+
+INTERVALS = [timedelta(milliseconds=-1), timedelta(microseconds=-1)]
+
+
+def _recording_transport(calls: list[str]) -> httpx.MockTransport:
+    def handle(request: httpx.Request) -> httpx.Response:
+        calls.append(f"{request.method} {request.url.path}")
+        if request.url.path == "/ping":
+            return httpx.Response(503)
+        return httpx.Response(
+            200, json={"id": "sb", "endpoint": "localhost:44772", "headers": {}}
+        )
+
+    return httpx.MockTransport(handle)
+
+
+@pytest.mark.parametrize("interval", INTERVALS)
+def test_budget_rejects_negative_interval(interval: timedelta) -> None:
+    with pytest.raises(InvalidArgumentException):
+        ReadinessBudget(timedelta(seconds=1), interval)
+
+
+@pytest.mark.parametrize("interval", INTERVALS)
+@pytest.mark.parametrize("method", ["create", "connect", "resume"])
+@pytest.mark.asyncio
+async def test_async_rejects_negative_interval_before_requests(
+    method: str, interval: timedelta
+) -> None:
+    calls: list[str] = []
+    config = ConnectionConfig(
+        domain="localhost:8080", transport=_recording_transport(calls)
+    )
+    options = {
+        "connection_config": config,
+        "health_check_polling_interval": interval,
+    }
+    with pytest.raises(InvalidArgumentException):
+        if method == "create":
+            await Sandbox.create(
+                "python:3.11", ready_timeout=timedelta(seconds=1), **options
+            )
+        elif method == "connect":
+            await Sandbox.connect(
+                "sb", connect_timeout=timedelta(seconds=1), **options
+            )
+        else:
+            await Sandbox.resume("sb", resume_timeout=timedelta(seconds=1), **options)
+    assert calls == []
+
+
+@pytest.mark.parametrize("interval", INTERVALS)
+@pytest.mark.parametrize("method", ["create", "connect", "resume"])
+def test_sync_rejects_negative_interval_before_requests(
+    method: str, interval: timedelta
+) -> None:
+    calls: list[str] = []
+    config = ConnectionConfigSync(
+        domain="localhost:8080", transport=_recording_transport(calls)
+    )
+    options = {
+        "connection_config": config,
+        "health_check_polling_interval": interval,
+    }
+    with pytest.raises(InvalidArgumentException):
+        if method == "create":
+            SandboxSync.create(
+                "python:3.11", ready_timeout=timedelta(seconds=1), **options
+            )
+        elif method == "connect":
+            SandboxSync.connect("sb", connect_timeout=timedelta(seconds=1), **options)
+        else:
+            SandboxSync.resume("sb", resume_timeout=timedelta(seconds=1), **options)
+    assert calls == []
+
+
+@pytest.mark.parametrize("interval", INTERVALS)
+def test_create_skipping_health_check_does_not_validate_interval(
+    interval: timedelta,
+) -> None:
+    calls: list[str] = []
+    config = ConnectionConfigSync(
+        domain="localhost:8080", transport=_recording_transport(calls)
+    )
+    # The mock create response is not a valid sandbox; reaching the server is enough.
+    with pytest.raises(SandboxApiException):
+        SandboxSync.create(
+            "python:3.11",
+            connection_config=config,
+            health_check_polling_interval=interval,
+            skip_health_check=True,
+        )
+    assert calls[0].startswith("POST ")


### PR DESCRIPTION
# Summary

I noticed that the Kotlin SDK now rejects a non-positive ready polling interval (f4944838) because a no-op sleep turns the health check into a spin, and went looking at the Python SDK. `ReadinessBudget` hands `health_check_polling_interval` straight to the sleep call, with no check.

With a negative interval the two Python flavours fail differently:

- async: `asyncio.sleep()` returns immediately for a negative delay, so `create` / `connect` / `resume` / `check_ready` poll `/ping` in a tight loop until the deadline. Against a mock transport answering 503, a one-second `Sandbox.connect` sent 5 pings with the default 200 ms interval and about 3,500 with `timedelta(milliseconds=-1)`.
- sync: `time.sleep()` raises `ValueError`, which comes out as `SandboxInternalException: Failed to resume sandbox: sleep length must be non-negative`. For `SandboxSync.create` that happens after the sandbox has been provisioned, so it gets killed again because of a client-side argument.

This change raises `InvalidArgumentException` for a negative interval in `ReadinessBudget`, and checks it before any request in `create` (only when the health check is not skipped, since the interval is unused otherwise) and in `resume` (which calls the resume API before building the budget). `connect` and `check_ready` are covered by the budget itself, before any request.

After review I applied the same check to the JavaScript SDK, which passed `healthCheckPollingInterval` straight to `setTimeout`. Node clamps a negative delay to about 1 ms, so a one-second `Sandbox.connect` against a health check returning false made 67 attempts with `-1`. `create` (when the health check is not skipped), `connect`, `resume` and `waitUntilReady` now throw `InvalidArgumentException` before any request. The JS pool options already rejected negative values.

I deliberately left a zero interval allowed: the existing tests call `check_ready(..., polling_interval=timedelta(seconds=0))`, so I only reject values that never worked in sync mode.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

New `tests/test_readiness_polling_interval.py` (16 cases, async and sync, create/connect/resume, asserting no HTTP request is sent). All 14 rejection cases fail on main and pass with the change; the full Python SDK suite passes (625 tests), and `ruff check` and `pyright` on the touched files are clean.

New `tests/sandbox.polling-interval.test.mjs` (create/connect/resume rejections plus a skipped health check case). The three rejection cases fail on main (health check timeout after 67 attempts) and pass with the change. I couldn't run `pnpm install` on my machine, so I ran the JS tests from the TypeScript sources with Node's type stripping and a stub for `openapi-fetch`: the new file plus the create, connect/resume, endpoint-readiness and pool suites give 71 passing tests. ESLint was not run locally.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

A negative interval already crashed the sync SDK; in async it only produced a busy loop. Zero and positive intervals behave as before.

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

AI tools used

