### PR TITLE
fix(egress): drain webhooks during bounded Docker deletion

### DIFF
--- a/components/egress/main.go
+++ b/components/egress/main.go
@@ -110,8 +110,9 @@ func main() {
 		log.Infof("loaded %d outbound log skip pattern(s) from /var/egress/rules/log_skip.always", len(logSkipPatterns))
 	}
 
+	var blockedBroadcaster *events.Broadcaster
 	if blockWebhookURL := strings.TrimSpace(os.Getenv(constants.EnvBlockedWebhook)); blockWebhookURL != "" {
-		blockedBroadcaster := events.NewBroadcaster(ctx, events.BroadcasterConfig{QueueSize: 256})
+		blockedBroadcaster = events.NewBroadcaster(context.WithoutCancel(ctx), events.BroadcasterConfig{QueueSize: 256})
 		blockedBroadcaster.AddSubscriber(events.NewWebhookSubscriber(blockWebhookURL))
 		proxy.SetBlockedBroadcaster(blockedBroadcaster)
 		defer blockedBroadcaster.Close()
@@ -150,7 +151,7 @@ func main() {
 		log.Errorf("startup hooks (post) error: %v", err)
 	}
 
-	waitForShutdown(ctx, proxy, policySrv, exemptDst, nftMgr, mitm)
+	waitForShutdown(ctx, proxy, policySrv, exemptDst, nftMgr, mitm, blockedBroadcaster)
 }
 
 func withLogger(ctx context.Context) context.Context {

--- a/components/egress/pkg/events/broadcaster.go
+++ b/components/egress/pkg/events/broadcaster.go
@@ -17,7 +17,6 @@ package events
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/alibaba/opensandbox/egress/pkg/log"
@@ -48,7 +47,8 @@ type Broadcaster struct {
 	mu          sync.RWMutex
 	subscribers []chan BlockedEvent
 	queueSize   int
-	closed      atomic.Bool
+	closed      bool
+	workers     sync.WaitGroup
 }
 
 func NewBroadcaster(ctx context.Context, cfg BroadcasterConfig) *Broadcaster {
@@ -70,10 +70,16 @@ func (b *Broadcaster) AddSubscriber(sub Subscriber) {
 	ch := make(chan BlockedEvent, b.queueSize)
 
 	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return
+	}
+	b.workers.Add(1)
 	b.subscribers = append(b.subscribers, ch)
 	b.mu.Unlock()
 
 	safego.Go(func() {
+		defer b.workers.Done()
 		for {
 			select {
 			case <-b.ctx.Done():
@@ -89,12 +95,11 @@ func (b *Broadcaster) AddSubscriber(sub Subscriber) {
 }
 
 func (b *Broadcaster) Publish(event BlockedEvent) {
-	if b.closed.Load() {
-		return
-	}
-
 	b.mu.RLock()
 	defer b.mu.RUnlock()
+	if b.closed {
+		return
+	}
 
 	for _, ch := range b.subscribers {
 		select {
@@ -105,20 +110,37 @@ func (b *Broadcaster) Publish(event BlockedEvent) {
 	}
 }
 
-func (b *Broadcaster) Close() {
-	if b.closed.Load() {
-		return
+// Shutdown seals admission and waits for queued deliveries within ctx's budget.
+func (b *Broadcaster) Shutdown(ctx context.Context) error {
+	b.seal()
+	defer b.cancel()
+	done := make(chan struct{})
+	safego.Go(func() {
+		b.workers.Wait()
+		close(done)
+	})
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
+}
 
+func (b *Broadcaster) Close() {
 	b.cancel()
+	b.seal()
+}
 
+func (b *Broadcaster) seal() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	subs := b.subscribers
-	b.subscribers = nil
-
-	for _, ch := range subs {
+	if b.closed {
+		return
+	}
+	b.closed = true
+	for _, ch := range b.subscribers {
 		close(ch)
 	}
-	b.closed.Store(true)
+	b.subscribers = nil
 }

--- a/components/egress/pkg/events/webhook.go
+++ b/components/egress/pkg/events/webhook.go
@@ -81,6 +81,9 @@ func (w *WebhookSubscriber) HandleBlocked(ctx context.Context, ev BlockedEvent) 
 
 	var lastErr error
 	for attempt := 0; attempt <= w.maxRetries; attempt++ {
+		if ctx.Err() != nil {
+			return
+		}
 		reqCtx := ctx
 		cancel := func() {}
 		if w.timeout > 0 {
@@ -114,7 +117,13 @@ func (w *WebhookSubscriber) HandleBlocked(ctx context.Context, ev BlockedEvent) 
 		cancel()
 		lastErr = err
 		if attempt < w.maxRetries {
-			time.Sleep(w.backoff * time.Duration(1<<attempt))
+			timer := time.NewTimer(w.backoff * time.Duration(1<<attempt))
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
 		}
 	}
 

--- a/components/egress/shutdown.go
+++ b/components/egress/shutdown.go
@@ -23,20 +23,31 @@ import (
 	"time"
 
 	"github.com/alibaba/opensandbox/egress/pkg/dnsproxy"
+	"github.com/alibaba/opensandbox/egress/pkg/events"
 	"github.com/alibaba/opensandbox/egress/pkg/iptables"
 	"github.com/alibaba/opensandbox/egress/pkg/log"
 	"github.com/alibaba/opensandbox/egress/pkg/mitmproxy"
 )
 
 const (
+	defaultWebhookDrainTimeout   = 5 * time.Second
 	defaultPolicyShutdownTimeout = 5 * time.Second
 	defaultNftTeardownTimeout    = 5 * time.Second
 	defaultMitmShutdownTimeout   = 5 * time.Second
 )
 
-func waitForShutdown(ctx context.Context, proxy *dnsproxy.Proxy, policySrv *http.Server, exemptDst []netip.Addr, applier nftApplier, mitm *mitmTransparent) {
+func waitForShutdown(ctx context.Context, proxy *dnsproxy.Proxy, policySrv *http.Server, exemptDst []netip.Addr, applier nftApplier, mitm *mitmTransparent, broadcaster *events.Broadcaster) {
 	<-ctx.Done()
 	log.Infof("received shutdown signal; beginning graceful shutdown")
+
+	// Keep DNS and enforcement alive while accepted notifications finish.
+	if broadcaster != nil {
+		drainCtx, cancel := context.WithTimeout(context.Background(), defaultWebhookDrainTimeout)
+		if err := broadcaster.Shutdown(drainCtx); err != nil {
+			log.Warnf("[webhook] drain timed out; remaining deliveries cancelled: %v", err)
+		}
+		cancel()
+	}
 
 	policyShutdownCtx, policyCancel := context.WithTimeout(context.Background(), defaultPolicyShutdownTimeout)
 	defer policyCancel()

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -179,7 +179,7 @@ On extra ports, mitmproxy still decrypts and logs traffic normally, but the Cred
 
 ::: warning Known issue: large SSE chunks truncated
 mitmproxy can truncate the tail of large streamed bodies (e.g. LLM SSE events > ~1 MB) when the upstream serves over TLS HTTP/1.1 and closes the connection right after the body. See [Egress: SSE Truncation (mitmproxy)](/components/egress-mitmproxy-sse-truncation) for root cause, reproduction, and status.
-::: 
+:::
 
 ### Credential Vault
 
@@ -500,8 +500,14 @@ ENTRYPOINT: supervisor --pre-start=cleanup.sh --name=egress --grace-period=20s -
 
 Egress-specific configuration:
 
-- **`--grace-period=20s`**: Egress needs extra time to drain DNS connections and tear down iptables/nft rules on shutdown (default is 10 s).
+- **`--grace-period=20s`**: Maximum time for worker shutdown before the supervisor sends SIGKILL. The container runtime may enforce a shorter deadline.
 - **Pre-start hook** (`cleanup.sh`): Reaps orphaned `mitmdump` processes from a previous crash and removes stale DNS redirect iptables/native nft state that would otherwise point port 53 at a dead proxy. It does not manage the `inet opensandbox` policy table; the nftables manager deletes and recreates that table when policy enforcement starts.
+
+### Shutdown
+
+On SIGTERM, egress stops accepting webhook events and allows queued and in-flight deliveries up to 5 seconds to finish, keeping DNS and network rules available.
+It then shuts down listeners, removes network rules, and flushes telemetry.
+Delivery is best effort; timeouts or forced termination can drop events and interrupt cleanup. See [Docker deletion](/components/server#docker-deletion) for the Docker stop budget.
 
 ## Troubleshooting
 

--- a/docs/components/server.md
+++ b/docs/components/server.md
@@ -34,6 +34,19 @@ A production-grade, FastAPI-based service for managing the lifecycle of containe
 Metadata keys under the reserved prefix `opensandbox.io/` are system-managed and cannot be supplied by users.
 :::
 
+## Docker deletion
+
+Deletion synchronously removes the application, stops and removes its egress
+sidecar, then cleans up volumes. Docker allows 9 seconds for
+[egress shutdown](/components/egress#shutdown) before forced termination;
+the full deletion request can take longer.
+
+If application removal fails, dependent resources and metadata are kept for
+retry. TTL cleanup retries after 30 seconds without changing the expiration.
+If the application is already absent, DELETE and TTL attempt orphan sidecar
+cleanup; DELETE returns 404. Sidecar cleanup is best effort, so 404 does not
+guarantee that all resources are gone.
+
 ## Requirements
 
 - **Python**: 3.10 or higher

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -364,6 +364,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
             container = self._get_container_by_sandbox_id(sandbox_id)
         except HTTPException as exc:
             if exc.status_code == status.HTTP_404_NOT_FOUND:
+                self._cleanup_egress_sidecar(sandbox_id)
                 self._remove_expiration_tracking(sandbox_id)
                 self._cleanup_windows_oem_volume(sandbox_id, None)
                 if fallback_mount_keys:
@@ -424,6 +425,13 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
             container.remove(force=True)
         except DockerException as exc:
             logger.warning("Failed to remove expired sandbox %s: %s", sandbox_id, exc)
+            # Re-read ownership on retry: a concurrent DELETE may already
+            # have released the mount references captured by this callback.
+            self._schedule_expiration(
+                sandbox_id, datetime.now(timezone.utc) + timedelta(seconds=30),
+                update_expiration=False,
+            )
+            return
 
         managed_volumes_raw = labels.get(SANDBOX_MANAGED_VOLUMES_LABEL, "[]")
         try:
@@ -1130,7 +1138,12 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
         Raises:
             HTTPException: If sandbox not found or deletion fails
         """
-        container = self._get_container_by_sandbox_id(sandbox_id)
+        try:
+            container = self._get_container_by_sandbox_id(sandbox_id)
+        except HTTPException as exc:
+            if exc.status_code == status.HTTP_404_NOT_FOUND:
+                self._cleanup_egress_sidecar(sandbox_id)
+            raise
         labels = container.attrs.get("Config", {}).get("Labels") or {}
         mount_keys_raw = labels.get(SANDBOX_OSSFS_MOUNTS_LABEL, "[]")
         try:
@@ -1160,13 +1173,12 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                     "message": f"Failed to delete sandbox container: {str(exc)}",
                 },
             ) from exc
-        finally:
-            self._remove_expiration_tracking(sandbox_id)
-            self._cleanup_egress_sidecar(sandbox_id)
-            self._cleanup_windows_oem_volume(sandbox_id, labels)
-            self._release_ossfs_mounts(mount_keys)
-            self._cleanup_managed_volumes(sandbox_id, managed_volumes)
-            self._metadata_store.delete(sandbox_id)
+        self._remove_expiration_tracking(sandbox_id)
+        self._cleanup_egress_sidecar(sandbox_id)
+        self._cleanup_windows_oem_volume(sandbox_id, labels)
+        self._release_ossfs_mounts(mount_keys)
+        self._cleanup_managed_volumes(sandbox_id, managed_volumes)
+        self._metadata_store.delete(sandbox_id)
 
     def pause_sandbox(self, sandbox_id: str) -> None:
         """

--- a/server/opensandbox_server/services/docker/networking.py
+++ b/server/opensandbox_server/services/docker/networking.py
@@ -30,6 +30,7 @@ import urllib.error
 import urllib.request
 from typing import Any, Dict, Optional
 
+from requests.exceptions import RequestException
 from docker.errors import DockerException, NotFound as DockerNotFound
 from fastapi import HTTPException, status
 
@@ -412,14 +413,27 @@ class DockerNetworkingMixin:
         for container in containers:
             try:
                 with self._docker_operation("cleanup egress sidecar", sandbox_id):
+                    try:
+                        # Bound Docker deletion independently of the image's supervisor grace.
+                        container.stop(timeout=9)
+                    except DockerNotFound:
+                        continue
+                    except (DockerException, RequestException) as exc:
+                        logger.warning("sandbox=%s | sidecar stop failed; forcing removal: %s", sandbox_id, exc)
                     container.remove(force=True)
-            except DockerException as exc:
+            except DockerNotFound:
+                continue
+            except (DockerException, RequestException) as exc:
                 logger.warning(
                     "sandbox=%s | failed to remove egress sidecar %s: %s",
                     sandbox_id,
                     container.id,
                     exc,
                 )
+
+        # The shared runtime volume can outlive a successfully removed app.
+        # Removal is best effort and still checks the server-managed label.
+        self._cleanup_managed_volumes(sandbox_id, [f"opensandbox-runtime-{sandbox_id}"])
 
     def _start_egress_sidecar(
         self,

--- a/server/tests/test_docker_delete_integration.py
+++ b/server/tests/test_docker_delete_integration.py
@@ -1,0 +1,304 @@
+"""Opt-in regressions through DELETE/TTL against a real egress image.
+
+Run with DOCKER_HOST pointing to the test daemon, OPENSANDBOX_TEST_DOCKER=1
+and OPENSANDBOX_TEST_EGRESS_IMAGE set to an image built from current source.
+Only fixture-owned containers and volumes are changed.
+"""
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+from uuid import uuid4
+
+import docker
+import pytest
+from docker.errors import APIError, NotFound
+from fastapi import HTTPException
+
+from opensandbox_server.config import AppConfig, RuntimeConfig
+from opensandbox_server.services.constants import SANDBOX_ID_LABEL, SANDBOX_MANAGED_VOLUMES_LABEL
+from opensandbox_server.services.docker import DockerSandboxService
+from opensandbox_server.services.docker.metadata import DockerMetadataStore
+from opensandbox_server.services.docker.networking import EGRESS_SIDECAR_LABEL
+
+pytestmark = pytest.mark.skipif(os.environ.get("OPENSANDBOX_TEST_DOCKER") != "1",
+                                reason="requires explicit real Docker opt-in")
+
+
+def read_json(url):
+    with urllib.request.urlopen(url, timeout=1) as response:
+        return json.load(response)
+
+
+def wait_http(url):
+    deadline = time.monotonic() + 15
+    while True:
+        try:
+            with urllib.request.urlopen(url, timeout=1) as response:
+                assert response.status == 200
+                return
+        except (urllib.error.URLError, TimeoutError):
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.05)
+
+
+@pytest.fixture
+def sandbox_pair(tmp_path, request):
+    client = docker.DockerClient.from_env()
+    with patch("docker.from_env", return_value=client), patch.object(client.containers, "list", return_value=[]):
+        service = DockerSandboxService(config=AppConfig(runtime=RuntimeConfig(type="docker", execd_image="unused")))
+    service._metadata_store = DockerMetadataStore(tmp_path / "metadata")
+    sandbox_id = f"delete-regression-{uuid4().hex}"
+    containers = []
+    volume = client.volumes.create(name=f"opensandbox-runtime-{sandbox_id}",
+                                  labels={SANDBOX_MANAGED_VOLUMES_LABEL: "server"})
+    mount = {volume.name: {"bind": "/test-runtime", "mode": "rw"}}
+    mode = getattr(request, "param", 0)
+    delay = mode if isinstance(mode, int) else 0
+    response_status = 500 if mode == "retry" else 200
+    try:
+        collector = client.containers.run("node:24-bookworm-slim", ["node", "-e", f"""
+const events = [];
+require('http').createServer((req, res) => {{
+  if (req.method === 'GET') {{ res.end(JSON.stringify(events)); return; }}
+  let body = '';
+  req.on('data', chunk => body += chunk);
+  req.on('end', () => {{
+    const event = JSON.parse(body); event.acknowledged = false; events.push(event);
+    setTimeout(() => {{ event.acknowledged = true; res.statusCode = {response_status}; res.end('ok'); }}, {delay});
+  }});
+}}).listen(18081, '0.0.0.0');
+"""], detach=True, ports={"18081/tcp": ("127.0.0.1", 0)})
+        containers.append(collector)
+        collector.reload()
+        ip = collector.attrs["NetworkSettings"]["Networks"]["bridge"]["IPAddress"]
+        host_port = collector.attrs["NetworkSettings"]["Ports"]["18081/tcp"][0]["HostPort"]
+        collector_url = f"http://127.0.0.1:{host_port}"
+        wait_http(collector_url)
+        sidecar = client.containers.run(
+            os.environ.get("OPENSANDBOX_TEST_EGRESS_IMAGE", "opensandbox/egress:v1.1.7"),
+            detach=True, cap_add=["NET_ADMIN"], ports={"18080/tcp": ("127.0.0.1", 0)},
+            labels={EGRESS_SIDECAR_LABEL: sandbox_id}, volumes=mount,
+            environment={"OPENSANDBOX_EGRESS_MODE": "dns", "OPENSANDBOX_EGRESS_SANDBOX_ID": sandbox_id,
+                         "OPENSANDBOX_EGRESS_RULES": json.dumps({"defaultAction": "allow", "egress": [
+                             {"action": "deny", "target": "*.blocked.invalid"}]}),
+                         "OPENSANDBOX_EGRESS_DENY_WEBHOOK": f"http://{ip}:18081"},
+        )
+        containers.append(sidecar)
+        sidecar.reload()
+        port = sidecar.attrs["NetworkSettings"]["Ports"]["18080/tcp"][0]["HostPort"]
+        wait_http(f"http://127.0.0.1:{port}/healthz")
+        app = client.containers.run("node:24-bookworm-slim", ["sleep", "600"], detach=True,
+                                    name=f"sandbox-{sandbox_id}", network_mode=f"container:{sidecar.id}",
+                                    volumes=mount, labels={SANDBOX_ID_LABEL: sandbox_id,
+                                    SANDBOX_MANAGED_VOLUMES_LABEL: json.dumps([volume.name])})
+        containers.append(app)
+        yield service, client, sandbox_id, app, sidecar, collector_url, volume
+    finally:
+        for timer in list(service._expiration_timers.values()):
+            timer.cancel()
+        for container in reversed(containers):
+            try:
+                container.remove(force=True)
+            except NotFound:
+                pass
+        try:
+            volume.remove()
+        except NotFound:
+            pass
+        client.close()
+
+
+def emit_blocked(app, count=3):
+    result = app.exec_run(["node", "-e", f"""
+const {{Resolver}} = require('node:dns').promises;
+const resolver = new Resolver({{timeout:1000, tries:1}});
+resolver.setServers(['127.0.0.1:15353']);
+Promise.all(Array.from({{length:{count}}}, (_, i) =>
+  resolver.resolve4(i+'.blocked.invalid').then(() => {{throw Error('not denied')}},
+    e => {{if (e.code !== 'ENOTFOUND') throw e}}))).catch(e=>{{console.error(e);process.exitCode=1}});
+"""])
+    assert result.exit_code == 0, result.output
+
+
+def assert_removed(client, app, sidecar, volume):
+    for container in (app, sidecar):
+        with pytest.raises(NotFound):
+            client.containers.get(container.id)
+    with pytest.raises(NotFound):
+        client.volumes.get(volume.name)
+
+
+@pytest.mark.parametrize("sandbox_pair", [75], indirect=True)
+def test_delete_gives_queued_webhooks_a_short_drain(sandbox_pair):
+    service, client, sandbox_id, app, sidecar, url, volume = sandbox_pair
+    emit_blocked(app)
+    started = time.monotonic()
+    service.delete_sandbox(sandbox_id)
+    elapsed = time.monotonic() - started
+    received = read_json(url)
+    assert len(received) == 3 and all(event["acknowledged"] for event in received)
+    assert elapsed < 2.5
+    assert_removed(client, app, sidecar, volume)
+
+
+@pytest.mark.parametrize("operation", ["kill", "remove_container"])
+def test_delete_failure_preserves_dependencies(sandbox_pair, operation):
+    service, client, sandbox_id, app, sidecar, _, volume = sandbox_pair
+    expiration = datetime.now(timezone.utc) + timedelta(hours=1)
+    service._metadata_store.set_expiration(sandbox_id, expiration)
+    with patch.object(client.api, operation, side_effect=APIError("daemon failure")):
+        with pytest.raises(HTTPException) as error:
+            service.delete_sandbox(sandbox_id)
+    assert error.value.status_code == 500
+    app.reload()
+    sidecar.reload()
+    assert sidecar.status == "running"
+    client.volumes.get(volume.name)
+    assert service._metadata_store.get_expiration(sandbox_id) == expiration.isoformat()
+    service.delete_sandbox(sandbox_id)
+    assert_removed(client, app, sidecar, volume)
+
+
+def test_ttl_remove_failure_retains_resources_and_retries(sandbox_pair):
+    from threading import Timer
+
+    service, client, sandbox_id, app, sidecar, _, volume = sandbox_pair
+    expiration = datetime.now(timezone.utc) - timedelta(seconds=1)
+    service._metadata_store.set_expiration(sandbox_id, expiration)
+    scheduled = []
+
+    def timer_factory(*args, **kwargs):
+        timer = Timer(*args, **kwargs)
+        timer.start = lambda: None
+        scheduled.append(timer)
+        return timer
+
+    original_remove = client.api.remove_container
+
+    def fail_app_remove(container, **kwargs):
+        if container == app.id:
+            raise APIError("application removal failed")
+        return original_remove(container, **kwargs)
+
+    with patch("opensandbox_server.services.docker.docker_service.Timer", side_effect=timer_factory), patch.object(
+        client.api, "remove_container", side_effect=fail_app_remove
+    ):
+        service._expire_sandbox(sandbox_id)
+    assert len(scheduled) == 1
+    sidecar.reload()
+    assert sidecar.status == "running"
+    assert service._metadata_store.get_expiration(sandbox_id) == expiration.isoformat()
+    scheduled[0].function(*scheduled[0].args, **scheduled[0].kwargs)
+    assert_removed(client, app, sidecar, volume)
+
+
+@pytest.mark.parametrize("retry_by", ["delete", "ttl"])
+def test_missing_application_still_allows_sidecar_cleanup(sandbox_pair, retry_by):
+    service, client, sandbox_id, app, sidecar, _, volume = sandbox_pair
+    original_remove = client.api.remove_container
+
+    def fail_sidecar_remove(container, **kwargs):
+        if container == sidecar.id:
+            raise APIError("sidecar removal failed")
+        return original_remove(container, **kwargs)
+
+    with patch.object(client.api, "remove_container", side_effect=fail_sidecar_remove):
+        service.delete_sandbox(sandbox_id)
+    sidecar.reload()
+    assert sidecar.status == "exited"
+    if retry_by == "delete":
+        with pytest.raises(HTTPException) as error:
+            service.delete_sandbox(sandbox_id)
+        assert error.value.status_code == 404
+    else:
+        service._expire_sandbox(sandbox_id)
+    assert_removed(client, app, sidecar, volume)
+
+
+@pytest.mark.parametrize("sandbox_pair", [12000, "retry", "worker_stuck", "supervisor_stuck"], indirect=True)
+def test_slow_or_stuck_egress_cannot_extend_stop_grace(sandbox_pair, request):
+    from threading import Thread
+
+    service, client, sandbox_id, app, sidecar, url, volume = sandbox_pair
+    mode = request.node.callspec.params["sandbox_pair"]
+    stream = sidecar.logs(stream=True, follow=True)
+    logs = []
+    reader = Thread(target=lambda: logs.extend(stream), daemon=True)
+    reader.start()
+    try:
+        if mode == "worker_stuck":
+            result = sidecar.exec_run(["pkill", "-STOP", "-x", "egress"])
+            assert result.exit_code == 0, result.output
+        elif mode == "supervisor_stuck":
+            sidecar.kill(signal="SIGSTOP")
+        else:
+            emit_blocked(app, 1)
+            deadline = time.monotonic() + 2
+            while not read_json(url):
+                assert time.monotonic() < deadline, "webhook was not received"
+                time.sleep(0.01)
+        started = time.monotonic()
+        service.delete_sandbox(sandbox_id)
+        elapsed = time.monotonic() - started
+        print(f"mode={mode} DELETE={elapsed:.3f}s")
+        assert elapsed < 10.5  # Includes daemon/volume overhead beyond the 9s stop grace.
+        assert_removed(client, app, sidecar, volume)
+        reader.join(timeout=2)
+        if mode in (12000, "retry"):
+            assert "drain timed out" in b"".join(logs).decode(errors="replace")
+        else:
+            # Both stalls outlast the Docker stop grace; the supervisor allows 20s.
+            assert elapsed >= 8.5
+    finally:
+        stream.close()
+
+
+def test_stop_transport_error_still_forces_removal(sandbox_pair):
+    from requests.exceptions import ReadTimeout
+
+    service, client, sandbox_id, app, sidecar, _, volume = sandbox_pair
+    with patch.object(client.api, "stop", side_effect=ReadTimeout("lost stop response")):
+        service.delete_sandbox(sandbox_id)
+    assert_removed(client, app, sidecar, volume)
+
+
+@pytest.mark.parametrize("sandbox_pair", [2000], indirect=True)
+def test_repeated_delete_during_stop_preserves_404(sandbox_pair):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event
+
+    service, client, sandbox_id, app, sidecar, _, volume = sandbox_pair
+    emit_blocked(app, 1)
+    stopping = Event()
+    original_stop = client.api.stop
+
+    def observed_stop(*args, **kwargs):
+        stopping.set()
+        return original_stop(*args, **kwargs)
+
+    with patch.object(client.api, "stop", side_effect=observed_stop), ThreadPoolExecutor(2) as executor:
+        first = executor.submit(service.delete_sandbox, sandbox_id)
+        assert stopping.wait(2)
+        second = executor.submit(service.delete_sandbox, sandbox_id)
+        first.result(timeout=5)
+        with pytest.raises(HTTPException) as error:
+            second.result(timeout=5)
+        assert error.value.status_code == 404
+    assert_removed(client, app, sidecar, volume)
+
+
+@pytest.mark.parametrize("sandbox_pair", [200], indirect=True)
+def test_delete_drains_a_small_backlog_before_forcing_exit(sandbox_pair):
+    service, client, sandbox_id, app, sidecar, url, volume = sandbox_pair
+    emit_blocked(app, 20)
+    started = time.monotonic()
+    service.delete_sandbox(sandbox_id)
+    received = read_json(url)
+    assert len(received) == 20 and all(event["acknowledged"] for event in received)
+    assert time.monotonic() - started < 6.5
+    assert_removed(client, app, sidecar, volume)

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -4621,3 +4621,37 @@ async def test_create_sandbox_does_not_retry_on_non_port_error(mock_docker):
     assert attempt_count == 1  # Did NOT retry
     mock_release.assert_called_once_with(bindings)
 
+
+
+@pytest.mark.parametrize("failed_operation", [None, "kill", "remove"])
+def test_delete_preserves_dependencies_until_application_removal(tmp_path, failed_operation):
+    docker_client = MagicMock()
+    docker_client.containers.list.return_value = []
+    with patch("docker.from_env", return_value=docker_client):
+        service = DockerSandboxService(config=_app_config())
+    service._metadata_store = DockerMetadataStore(tmp_path / "metadata")
+    sandbox_id = "short-stop-regression"
+    expiration = datetime.now(timezone.utc) + timedelta(hours=1)
+    service._metadata_store.set_expiration(sandbox_id, expiration)
+    application, sidecar = MagicMock(), MagicMock()
+    application.attrs = {"Config": {"Labels": {SANDBOX_ID_LABEL: sandbox_id}}}
+    docker_client.containers.get.return_value = application
+    docker_client.containers.list.return_value = [sidecar]
+    operations = []
+    application.kill.side_effect = lambda: operations.append("kill app")
+    application.remove.side_effect = lambda **kwargs: operations.append("remove app")
+    sidecar.stop.side_effect = lambda **kwargs: operations.append("stop sidecar")
+    sidecar.remove.side_effect = lambda **kwargs: operations.append("remove sidecar")
+    if failed_operation:
+        getattr(application, failed_operation).side_effect = DockerException("application operation failed")
+        with pytest.raises(HTTPException) as error:
+            service.delete_sandbox(sandbox_id)
+        assert error.value.status_code == 500
+        sidecar.stop.assert_not_called()
+        sidecar.remove.assert_not_called()
+        assert service._metadata_store.get_expiration(sandbox_id) == expiration.isoformat()
+    else:
+        service.delete_sandbox(sandbox_id)
+        assert operations == ["kill app", "remove app", "stop sidecar", "remove sidecar"]
+        sidecar.stop.assert_called_once_with(timeout=9)
+        assert service._metadata_store.get_expiration(sandbox_id) is None


### PR DESCRIPTION
# Summary

Docker deletion currently force-removes the egress sidecar, dropping queued webhook notifications. It also cleans up dependent resources after application deletion fails, while a retry after the application is already gone can leave its sidecar behind.

This change makes cleanup follow application removal and gives egress a bounded opportunity to finish accepted deliveries:

- On SIGTERM, stop accepting webhook events and drain queued/in-flight deliveries for up to **5 seconds** before tearing down DNS and network rules. Cancel outstanding requests and retry backoff when the drain expires.
- After application removal succeeds, stop the sidecar with a **9-second Docker grace**, then remove it and attempt managed runtime-volume cleanup. Keep the image supervisor's existing **20-second grace** unchanged; Docker enforces its own shorter limit.
- Preserve dependent resources and metadata when application deletion fails. Retry failed TTL removal after **30 seconds** without changing the sandbox expiration, re-reading ownership on retry to avoid releasing mount references twice after a concurrent DELETE.
- Attempt orphan sidecar cleanup when the application is already absent, while preserving DELETE's **404** response.

Deletion remains synchronous. These durations are upper bounds, not fixed waits; Docker API calls and other cleanup can extend the full HTTP request. Webhook delivery and sidecar cleanup remain best effort, so neither delivery completion nor complete resource removal is guaranteed after a cleanup failure.

# Testing

- [x] Unit tests
- [x] Integration tests
  - Covers queued delivery, application kill/remove failures, TTL retry, missing applications, slow/failing receivers, frozen worker/supervisor, stop transport failure, and concurrent repeated deletion. Tests inspect actual containers and volumes after cleanup.
- [x] e2e / manual verification
  - Real Docker experiments compared 500ms, 3s, and 5s drain budgets: for 20 events at 200ms per response, they completed 2, 15, and 20 deliveries respectively. This supports 5s as a modest-backlog allowance, not a delivery guarantee.

Real Kubernetes integration was not run. The worker's drain behavior also applies there

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

Public API, SDK and configuration shapes are unchanged. Docker DELETE can now wait for the sidecar stop grace; notifications remain best effort. Deploy the updated egress image to enable draining. The server's 9-second stop limit also applies when using an older image.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
