### PR TITLE
fix(controller): stop attributing failures of deleting pods (PauseResume e2e on K8s >= 1.27)

### DIFF
--- a/docs/guides/pause-resume.md
+++ b/docs/guides/pause-resume.md
@@ -62,6 +62,13 @@ The sandbox transitions through both stable and intermediate states:
 
 The Lifecycle API exposes only the coarse-grained sandbox states above. For detailed snapshot progress, inspect the internal `SandboxSnapshot` resource:
 
+Pod termination can continue after the controller reports `Paused`. A resume request
+can be submitted during this interval; the controller waits for the old Pod to be
+removed before recreating its replacement. Pods with a deletion timestamp do not
+contribute new runtime failure conditions, including terminal exit statuses reported
+by Kubernetes during deletion. Failures already recorded on the sandbox remain
+terminal, and failures of replacement Pods are still reported normally.
+
 - `Pending`: snapshot request accepted, waiting to resolve source Pod / create commit Job
 - `Committing`: commit Job is running and pushing snapshot images
 - `Succeed`: snapshot is ready and can be used for the next resume

--- a/kubernetes/internal/controller/batchsandbox_status.go
+++ b/kubernetes/internal/controller/batchsandbox_status.go
@@ -114,6 +114,10 @@ func applyBatchSandboxPhaseConditions(status *sandboxv1alpha1.BatchSandboxStatus
 }
 
 func getPodFailureReasonAndMessage(pod *corev1.Pod) (string, string, bool) {
+	// Deleting pods no longer contribute new runtime failures, including waiting states.
+	if pod.DeletionTimestamp != nil {
+		return "", "", false
+	}
 	if reason, message, failed := getTerminalPodFailureReasonAndMessage(pod); failed {
 		return reason, message, true
 	}
@@ -130,6 +134,11 @@ func getPodFailureReasonAndMessage(pod *corev1.Pod) (string, string, bool) {
 }
 
 func getTerminalPodFailureReasonAndMessage(pod *corev1.Pod) (string, string, bool) {
+	// Kubernetes may publish a terminal failure while deleting an old runtime pod.
+	// Ignore it for new failure attribution; already recorded sandbox failures remain terminal.
+	if pod.DeletionTimestamp != nil {
+		return "", "", false
+	}
 	if pod.Status.Phase != corev1.PodFailed {
 		return "", "", false
 	}

--- a/kubernetes/internal/controller/batchsandbox_status_test.go
+++ b/kubernetes/internal/controller/batchsandbox_status_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	sandboxv1alpha1 "github.com/alibaba/OpenSandbox/sandbox-k8s/apis/sandbox/v1alpha1"
+	"github.com/alibaba/OpenSandbox/sandbox-k8s/internal/utils/expectations"
+	"github.com/alibaba/OpenSandbox/sandbox-k8s/internal/utils/fieldindex"
+)
+
+func TestDeletingPodFailureAttribution(t *testing.T) {
+	for _, phase := range []sandboxv1alpha1.BatchSandboxPhase{
+		sandboxv1alpha1.BatchSandboxPhasePending,
+		sandboxv1alpha1.BatchSandboxPhaseResuming,
+		sandboxv1alpha1.BatchSandboxPhaseSucceed,
+	} {
+		for _, deleting := range []bool{false, true} {
+			t.Run(string(phase)+map[bool]string{false: "/active", true: "/deleting"}[deleting], func(t *testing.T) {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "sandbox-0"},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+						ContainerStatuses: []corev1.ContainerStatus{{Name: "main", State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"},
+						}}},
+					},
+				}
+				if deleting {
+					now := metav1.Now()
+					pod.DeletionTimestamp = &now
+				}
+				bs := &sandboxv1alpha1.BatchSandbox{Status: sandboxv1alpha1.BatchSandboxStatus{Phase: phase}}
+				view := buildRuntimeView(bs, []*corev1.Pod{pod})
+				if deleting {
+					assert.NotEqual(t, sandboxv1alpha1.BatchSandboxPhaseFailed, view.status.Phase)
+					assert.False(t, hasTrueBatchSandboxCondition(view.status.Conditions, sandboxv1alpha1.BatchSandboxConditionPodFailed))
+					assert.False(t, hasTrueBatchSandboxCondition(view.status.Conditions, sandboxv1alpha1.BatchSandboxConditionResumeFailed))
+				} else {
+					assert.Equal(t, sandboxv1alpha1.BatchSandboxPhaseFailed, view.status.Phase)
+					assert.True(t, hasTrueBatchSandboxCondition(view.status.Conditions, sandboxv1alpha1.BatchSandboxConditionPodFailed))
+				}
+			})
+		}
+	}
+}
+
+func TestDeletingPodWaitingFailure(t *testing.T) {
+	for _, reason := range []string{"CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull", "CreateContainerConfigError"} {
+		t.Run(reason, func(t *testing.T) {
+			pod := &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: reason}},
+			}}}}
+			_, _, failed := getPodFailureReasonAndMessage(pod)
+			assert.True(t, failed)
+			now := metav1.Now()
+			pod.DeletionTimestamp = &now
+			_, _, failed = getPodFailureReasonAndMessage(pod)
+			assert.False(t, failed)
+		})
+	}
+}
+
+// Run the real reconciler against an API server, but drive reconciles explicitly
+// so both orders of failure/deletion observation are deterministic. No kubelet
+// runs in envtest; the test publishes its terminal Pod status and releases its finalizer.
+func TestReconcileDeletingPod(t *testing.T) {
+	testEnvironment := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: getFirstFoundEnvTestBinaryDir(),
+	}
+	config, err := testEnvironment.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testEnvironment.Stop()) })
+	testContext, stop := context.WithCancel(context.Background())
+	manager, err := ctrl.NewManager(config, ctrl.Options{Scheme: testscheme, Metrics: metricsserver.Options{BindAddress: "0"}})
+	require.NoError(t, err)
+	require.NoError(t, fieldindex.RegisterFieldIndexes(manager.GetCache()))
+	managerDone := make(chan error, 1)
+	go func() { managerDone <- manager.Start(testContext) }()
+	t.Cleanup(func() { stop(); require.NoError(t, <-managerDone) })
+	require.True(t, manager.GetCache().WaitForCacheSync(testContext))
+	apiClient, err := client.New(config, client.Options{Scheme: testscheme})
+	require.NoError(t, err)
+
+	for _, failureBeforeDeletion := range []bool{false, true} {
+		name := "resume-deleting"
+		if failureBeforeDeletion {
+			name = "resume-real-failure"
+		}
+		t.Run(name, func(t *testing.T) {
+			bs := &sandboxv1alpha1.BatchSandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				Spec: sandboxv1alpha1.BatchSandboxSpec{Replicas: ptr.To(int32(1)), Pause: ptr.To(false),
+					Template: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "snapshot:test"}}}},
+				},
+			}
+			require.NoError(t, apiClient.Create(testContext, bs))
+			bs.Status.Phase = sandboxv1alpha1.BatchSandboxPhaseResuming
+			bs.Status.PauseObservedGeneration = bs.Generation
+			require.NoError(t, apiClient.Status().Update(testContext, bs))
+			snapshot := &sandboxv1alpha1.SandboxSnapshot{ObjectMeta: metav1.ObjectMeta{Name: name + "-pause", Namespace: "default"},
+				Spec: sandboxv1alpha1.SandboxSnapshotSpec{SandboxName: name},
+			}
+			require.NoError(t, apiClient.Create(testContext, snapshot))
+			snapshot.Status.Phase = sandboxv1alpha1.SandboxSnapshotPhaseSucceed
+			snapshot.Status.Containers = []sandboxv1alpha1.ContainerSnapshot{{ContainerName: "main", ImageURI: "snapshot:test"}}
+			require.NoError(t, apiClient.Status().Update(testContext, snapshot))
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name + "-0", Namespace: "default",
+				Finalizers:      []string{"test.opensandbox.io/hold"},
+				Labels:          map[string]string{LabelBatchSandboxNameKey: name, LabelBatchSandboxPodIndexKey: "0"},
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(bs, sandboxv1alpha1.GroupVersion.WithKind("BatchSandbox"))},
+			}, Spec: *bs.Spec.Template.Spec.DeepCopy()}
+			require.NoError(t, apiClient.Create(testContext, pod))
+			oldUID := pod.UID
+			r := &BatchSandboxReconciler{Client: manager.GetClient(), Scheme: testscheme,
+				Recorder: record.NewFakeRecorder(100), StatusRVExpectation: expectations.NewResourceVersionExpectation()}
+			key := client.ObjectKeyFromObject(bs)
+			syncObject := func(object client.Object) {
+				t.Helper()
+				require.Eventually(t, func() bool {
+					cached := object.DeepCopyObject().(client.Object)
+					return r.Get(testContext, client.ObjectKeyFromObject(object), cached) == nil && cached.GetResourceVersion() == object.GetResourceVersion()
+				}, 5*time.Second, 20*time.Millisecond)
+			}
+			markFailed := func() {
+				pod.Status.Phase = corev1.PodFailed
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{Name: "main", Image: "snapshot:test", ImageID: "snapshot:test",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"}},
+				}}
+				require.NoError(t, apiClient.Status().Update(testContext, pod))
+				syncObject(pod)
+			}
+			reconcile := func() {
+				t.Helper()
+				syncObject(bs)
+				_, err := r.Reconcile(testContext, ctrl.Request{NamespacedName: key})
+				require.NoError(t, err)
+				require.NoError(t, apiClient.Get(testContext, key, bs))
+			}
+			syncObject(snapshot)
+			if failureBeforeDeletion {
+				markFailed()
+				reconcile()
+				require.Equal(t, sandboxv1alpha1.BatchSandboxPhaseFailed, bs.Status.Phase)
+			}
+			require.NoError(t, apiClient.Delete(testContext, pod, client.GracePeriodSeconds(0)))
+			require.NoError(t, apiClient.Get(testContext, client.ObjectKeyFromObject(pod), pod))
+			require.NotNil(t, pod.DeletionTimestamp)
+			if !failureBeforeDeletion {
+				markFailed()
+			} else {
+				syncObject(pod)
+			}
+			reconcile()
+			if failureBeforeDeletion {
+				require.Equal(t, sandboxv1alpha1.BatchSandboxPhaseFailed, bs.Status.Phase)
+				require.True(t, hasTrueBatchSandboxCondition(bs.Status.Conditions, sandboxv1alpha1.BatchSandboxConditionResumeFailed))
+				return
+			}
+			require.Equal(t, sandboxv1alpha1.BatchSandboxPhaseResuming, bs.Status.Phase)
+			require.False(t, hasTrueBatchSandboxCondition(bs.Status.Conditions, sandboxv1alpha1.BatchSandboxConditionResumeFailed))
+			require.False(t, hasTrueBatchSandboxCondition(bs.Status.Conditions, sandboxv1alpha1.BatchSandboxConditionPodFailed))
+			pod.Finalizers = nil
+			require.NoError(t, apiClient.Update(testContext, pod))
+			require.Eventually(t, func() bool {
+				return apierrors.IsNotFound(r.Get(testContext, client.ObjectKeyFromObject(pod), &corev1.Pod{}))
+			}, 5*time.Second, 20*time.Millisecond)
+			reconcile()
+			replacement := &corev1.Pod{}
+			require.NoError(t, apiClient.Get(testContext, client.ObjectKeyFromObject(pod), replacement))
+			require.NotEmpty(t, replacement.UID)
+			require.NotEqual(t, oldUID, replacement.UID)
+			replacement.Status.Phase = corev1.PodRunning
+			replacement.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+			require.NoError(t, apiClient.Status().Update(testContext, replacement))
+			syncObject(replacement)
+			reconcile()
+			require.Equal(t, sandboxv1alpha1.BatchSandboxPhaseSucceed, bs.Status.Phase)
+		})
+	}
+}

--- a/kubernetes/internal/utils/fieldindex/register.go
+++ b/kubernetes/internal/utils/fieldindex/register.go
@@ -31,7 +31,12 @@ const (
 )
 
 var (
-	registerOnce sync.Once
+	registerMu sync.Mutex
+	// registeredCaches deduplicates registration per cache instance: a process may
+	// run several managers (production one plus envtest-based tests), and each
+	// cache needs its own informer indexes. A process-wide sync.Once would leave
+	// every later cache without indexes.
+	registeredCaches = map[cache.Cache]struct{}{}
 )
 
 var OwnerIndexFunc = func(obj client.Object) []string {
@@ -51,15 +56,18 @@ var PoolRefIndexFunc = func(obj client.Object) []string {
 }
 
 func RegisterFieldIndexes(c cache.Cache) error {
-	var err error
-	registerOnce.Do(func() {
-		// pod ownerReference
-		if err = c.IndexField(context.TODO(), &v1.Pod{}, IndexNameForOwnerRefUID, OwnerIndexFunc); err != nil {
-			return
-		}
-		if err = c.IndexField(context.TODO(), &sandboxv1alpha1.BatchSandbox{}, IndexNameForPoolRef, PoolRefIndexFunc); err != nil {
-			return
-		}
-	})
-	return err
+	registerMu.Lock()
+	defer registerMu.Unlock()
+	if _, ok := registeredCaches[c]; ok {
+		return nil
+	}
+	// pod ownerReference
+	if err := c.IndexField(context.TODO(), &v1.Pod{}, IndexNameForOwnerRefUID, OwnerIndexFunc); err != nil {
+		return err
+	}
+	if err := c.IndexField(context.TODO(), &sandboxv1alpha1.BatchSandbox{}, IndexNameForPoolRef, PoolRefIndexFunc); err != nil {
+		return err
+	}
+	registeredCaches[c] = struct{}{}
+	return nil
 }

--- a/kubernetes/test/e2e/pause_resume_test.go
+++ b/kubernetes/test/e2e/pause_resume_test.go
@@ -163,7 +163,7 @@ var _ = Describe("PauseResume", Ordered, Label("PauseResume"), func() {
 	})
 
 	Context("Pause and Resume", func() {
-		It("should complete the full pause-resume flow via spec.pause trigger", func() {
+		DescribeTable("should complete the full pause-resume flow via spec.pause trigger", func(waitForDeletion bool) {
 			const sandboxName = "test-pause-resume"
 
 			// --- Step 1: Create BatchSandbox ---
@@ -227,6 +227,11 @@ var _ = Describe("PauseResume", Ordered, Label("PauseResume"), func() {
 				}
 			}
 			Expect(podName).NotTo(BeEmpty(), "Should find a pod owned by BatchSandbox")
+			cmd = exec.Command("kubectl", "get", "pod", podName, "-n", pauseResumeNamespace,
+				"-o", "jsonpath={.metadata.uid}")
+			oldUID, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(oldUID).NotTo(BeEmpty())
 
 			markerValue := fmt.Sprintf("pause-test-%d", time.Now().UnixNano())
 			By("writing marker file into container for rootfs verification")
@@ -243,7 +248,7 @@ var _ = Describe("PauseResume", Ordered, Label("PauseResume"), func() {
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("waiting for BatchSandbox phase to be Paused (snapshot ready, pods deleted)")
+			By("waiting for BatchSandbox phase to be Paused (snapshot ready, pod deletion requested)")
 			Eventually(func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "batchsandbox", sandboxName,
 					"-n", pauseResumeNamespace, "-o", "jsonpath={.status.phase}")
@@ -252,18 +257,21 @@ var _ = Describe("PauseResume", Ordered, Label("PauseResume"), func() {
 				g.Expect(output).To(Equal("Paused"))
 			}, 3*time.Minute).Should(Succeed())
 
-			// Verify pods are deleted
-			By("verifying pods are deleted after pause")
-			cmd = exec.Command("kubectl", "get", "pods", "-n", pauseResumeNamespace,
-				"-l", "batchsandbox-name="+sandboxName, "-o", "name")
-			output, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(BeEmpty(), "Pods should be deleted after pause")
+			if waitForDeletion {
+				By("waiting for pods to be deleted after pause")
+				Eventually(func(g Gomega) {
+					cmd := exec.Command("kubectl", "get", "pods", "-n", pauseResumeNamespace,
+						"-l", "batch-sandbox.sandbox.opensandbox.io/name="+sandboxName, "-o", "name")
+					output, err := utils.Run(cmd)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(output).To(BeEmpty(), "Pods should eventually be deleted after pause")
+				}, time.Minute).Should(Succeed())
+			}
 
 			By("verifying the reserved internal SandboxSnapshot exists after pause")
 			cmd = exec.Command("kubectl", "get", "sandboxsnapshot", sandboxName+"-pause",
 				"-n", pauseResumeNamespace, "-o", "jsonpath={.status.phase}")
-			output, err = utils.Run(cmd)
+			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(Equal("Succeed"), "Internal pause snapshot should be ready after pause")
 
@@ -274,6 +282,17 @@ var _ = Describe("PauseResume", Ordered, Label("PauseResume"), func() {
 				"-p", `{"spec":{"pause":false}}`)
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
+
+			if !waitForDeletion {
+				By("proving resume was submitted while the old pod was still terminating")
+				cmd = exec.Command("kubectl", "get", "pod", podName, "-n", pauseResumeNamespace,
+					"-o", "jsonpath={.metadata.uid} {.metadata.deletionTimestamp}")
+				output, err = utils.Run(cmd)
+				Expect(err).NotTo(HaveOccurred(), "Race coverage missing: old pod disappeared before confirmation")
+				fields := strings.Fields(output)
+				Expect(fields).To(HaveLen(2), "Race coverage missing: old pod must be terminating")
+				Expect(fields[0]).To(Equal(oldUID), "Race coverage missing: pod was already replaced")
+			}
 
 			By("waiting for resumed BatchSandbox to return to Succeed")
 			Eventually(func(g Gomega) {
@@ -323,6 +342,12 @@ var _ = Describe("PauseResume", Ordered, Label("PauseResume"), func() {
 				}
 			}
 			Expect(resumedPodName).NotTo(BeEmpty(), "Should find a pod owned by resumed BatchSandbox")
+			cmd = exec.Command("kubectl", "get", "pod", resumedPodName, "-n", pauseResumeNamespace,
+				"-o", "jsonpath={.metadata.uid}")
+			newUID, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newUID).NotTo(BeEmpty())
+			Expect(newUID).NotTo(Equal(oldUID), "Resume must create a replacement pod")
 
 			By("reading marker file from resumed container to verify rootfs persistence")
 			cmd = exec.Command("kubectl", "exec", resumedPodName, "-n", pauseResumeNamespace,
@@ -335,7 +360,10 @@ var _ = Describe("PauseResume", Ordered, Label("PauseResume"), func() {
 			By("cleaning up")
 			cmd = exec.Command("kubectl", "delete", "batchsandbox", sandboxName, "-n", pauseResumeNamespace, "--ignore-not-found=true")
 			utils.Run(cmd)
-		})
+		},
+			Entry("after pod deletion completes", true),
+			Entry("immediately while the old pod is terminating", false),
+		)
 
 		It("should complete pool-based pause-resume via spec.pause trigger", func() {
 			const poolName = "test-pool-pause"


### PR DESCRIPTION
Fixes #1824

## Root cause

On Kubernetes >= 1.27 (kubernetes/kubernetes#115331, KEP-3329), when a pod's grace period expires during deletion, kubelet writes `phase: Failed` on the still-Terminating pod (SIGKILL, exit 137).

During pause -> resume, the controller deletes the old frozen pod (whose process cannot handle SIGTERM while frozen, so it always hits the full 30s grace) and then recreates a same-name replacement. The controller's failure attribution has no deletionTimestamp filter, so the dying OLD pod's exit-137 status is misattributed as a resume failure: the BatchSandbox goes terminal `Failed` and the replacement pod is never created. On v1.22.4 kubelet does not publish that terminal status on deleting pods, which is why CI passes there and consistently fails on v1.28.6 / v1.34.2.

## Fix

Skip failure attribution for pods that carry a `deletionTimestamp` (both failure detectors, including waiting states). Semantics:

- pods being deleted no longer contribute NEW failure conditions;
- failures already recorded on the sandbox remain terminal (no undo);
- failures of replacement pods are still reported normally.

## Tests

- **Table-driven unit tests**: terminal/waiting failure detection across Pending/Resuming/Succeed phases, active vs deleting pods.
- **Controller-level envtest regression** (deterministic, drives the real `Reconcile`): both observation orders — (1) deletion mark precedes first observation (the issue's sequence) → no `ResumeFailed`, replacement pod created with a different UID once the old object is gone → `Succeed`; (2) real failure observed before deletion → `Failed` written and preserved. **Differential property verified**: removing the guard turns case 1 red with the exact issue signature (`expected "Resuming", actual "Failed"`); restoring it is green.
- **e2e pause/resume now runs two scenarios**: resume after the old pod is fully gone, and resume immediately while the old pod is still Terminating. The latter asserts — after the resume patch returns — that the old pod still has its old UID and a non-empty `deletionTimestamp` (proving the race window was genuinely hit), then expects `Succeed`. Also fixes a stale `batchsandbox-name=` label selector (real label: `batch-sandbox.sandbox.opensandbox.io/name`) and asserts the replacement pod's UID differs.

## Verification

Locally on kind (arm64, all 7 PauseResume-labelled specs each):

| K8s | role | result |
|---|---|---|
| v1.28.6 | failing CI version in #1824 | 7 Passed / 0 Failed |
| v1.30.4 | same kubelet behavior family (>= 1.27) | 7 Passed / 0 Failed |
| v1.22.4 | passing CI version (pre-1.27) | 7 Passed / 0 Failed |

The immediate-resume scenario hit the race window (old UID + deletionTimestamp confirmed post-patch) on all three. v1.34.2 is covered by the CI matrix.

## Drive-by fix (required for CI)

`fieldindex.RegisterFieldIndexes` used a package-level `sync.Once`, so with a second envtest-backed manager in the same test binary the ginkgo suite's cache silently got no informer indexes and 23/36 specs timed out under the unfiltered `make test` run. Registration is now deduplicated per cache instance (separate commit; no behavior change for single-manager production processes).

## Follow-ups (out of scope for this PR)

- With this fix, resume is correct but not instant: the frozen old pod still waits out its full termination grace (~30s — SIGTERM cannot be handled while frozen) before the same-name replacement can be created. Shortening the grace for pods deleted at pause completion was considered as a follow-up; it needs its own impact review (preStop/lifecycle hooks, node failures, multi-container pods) and is intentionally not bundled here.
- What the `Paused` phase should promise (e.g., how quickly resume must return) is a contract question — happy to open a separate discussion if useful.
